### PR TITLE
WT-18293 Disagg database_size drop accounting is wrong when a dropped URI is recreated

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -42,6 +42,7 @@ func_ok()
         -e '/int __curlog_reset$/d' \
         -e '/int __cursor_fix_implicit$/d' \
         -e '/int __delete_redo_window_cleanup_skip$/d' \
+        -e '/int __disagg_file_size_sum$/d' \
         -e '/int __gen_active_callback$/d' \
         -e '/int __gen_oldest_callback$/d' \
         -e '/int __handle_close_default$/d' \

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -277,67 +277,6 @@ err:
 }
 
 /*
- * __disagg_database_size_walk --
- *     Sum the most recent checkpoint size of every stable file the metadata holds.
- */
-static int
-__disagg_database_size_walk(WT_SESSION_IMPL *session, uint64_t *sizep)
-{
-    WT_CURSOR *cursor;
-    WT_DECL_RET;
-    uint64_t ckpt_size, total_size;
-    const char *uri, *value;
-
-    cursor = NULL;
-    total_size = 0;
-
-    WT_RET(__wt_metadata_cursor(session, &cursor));
-
-    while ((ret = cursor->next(cursor)) == 0) {
-        WT_ERR(cursor->get_key(cursor, &uri));
-
-        /* Only consider file URIs as only they contribute to database_size. */
-        if (!WT_PREFIX_MATCH(uri, "file:") || !WT_SUFFIX_MATCH(uri, ".wt_stable"))
-            continue;
-
-        /* Look up the metadata string and extract the most recent checkpoint size. */
-        WT_ERR(cursor->get_value(cursor, &value));
-        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, value, &ckpt_size), true);
-        if (ret == WT_NOTFOUND)
-            continue;
-
-        total_size += ckpt_size;
-    }
-    /*
-     * A not found error is okay. cursor->next() returns it once it goes through all the metadata
-     * entries.
-     */
-    WT_ERR_NOTFOUND_OK(ret, false);
-
-    *sizep = total_size;
-
-err:
-    WT_TRET(__wt_metadata_cursor_release(session, &cursor));
-    return (ret);
-}
-
-/*
- * __wt_disagg_get_database_size --
- *     Recompute the disaggregated database size from the metadata, excluding the fixed overhead for
- *     the KEK table and shared turtle page. Reads uncommitted, as all metadata reads do.
- */
-int
-__wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
-{
-    WT_DECL_RET;
-
-    WT_WITH_TXN_ISOLATION(
-      session, WT_ISO_READ_UNCOMMITTED, ret = __disagg_database_size_walk(session, sizep));
-
-    return (ret);
-}
-
-/*
  * __wt_verify_disagg_database_size --
  *     Verify the database size for disaggregated storage. Walk the metadata and sum the most recent
  *     checkpoint size for every file, then compare the total against the stored database size.
@@ -359,7 +298,7 @@ __wt_verify_disagg_database_size(WT_SESSION_IMPL *session)
     conn = S2C(session);
     database_size = conn->disaggregated_storage.database_size;
 
-    WT_RET(__wt_disagg_get_database_size(session, &total_size));
+    WT_RET(__wt_disagg_file_sizes_from_metadata(session, &total_size));
 
     /*
      * Three cases to consider after the metadata walk:

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -307,9 +307,6 @@ __disagg_database_size_walk(WT_SESSION_IMPL *session, uint64_t *sizep)
             continue;
 
         total_size += ckpt_size;
-
-        __wt_verbose_debug3(session, WT_VERB_VERIFY,
-          "disagg database size: %s checkpoint size %" PRIu64, uri, ckpt_size);
     }
     /*
      * A not found error is okay. cursor->next() returns it once it goes through all the metadata
@@ -384,6 +381,10 @@ __wt_verify_disagg_database_size(WT_SESSION_IMPL *session)
          * any btree's checkpoint size but are always included in database_size.
          */
         total_size += WT_DISAGG_CHECKPOINT_SIZE_BUFFER;
+
+        __wt_verbose_debug1(session, WT_VERB_VERIFY,
+          "disagg database size verify: stored %" PRIu64 ", computed %" PRIu64, database_size,
+          total_size);
 
         if (total_size != database_size)
             WT_RET_MSG(session, WT_ERROR,

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -277,13 +277,11 @@ err:
 }
 
 /*
- * __wt_disagg_get_database_size --
- *     Recompute the disaggregated database size from scratch: walk the metadata and sum the most
- *     recent checkpoint size for every file. The fixed overhead for the KEK table and shared turtle
- *     page is not included; callers add it when comparing against or storing a database_size.
+ * __disagg_database_size_walk --
+ *     Sum the most recent checkpoint size of every stable file the metadata holds.
  */
-int
-__wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
+static int
+__disagg_database_size_walk(WT_SESSION_IMPL *session, uint64_t *sizep)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
@@ -323,6 +321,22 @@ __wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
 
 err:
     WT_TRET(__wt_metadata_cursor_release(session, &cursor));
+    return (ret);
+}
+
+/*
+ * __wt_disagg_get_database_size --
+ *     Recompute the disaggregated database size from the metadata, excluding the fixed overhead for
+ *     the KEK table and shared turtle page. Reads uncommitted, as all metadata reads do.
+ */
+int
+__wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
+{
+    WT_DECL_RET;
+
+    WT_WITH_TXN_ISOLATION(
+      session, WT_ISO_READ_UNCOMMITTED, ret = __disagg_database_size_walk(session, sizep));
+
     return (ret);
 }
 

--- a/src/checkpoint/checkpoint.h
+++ b/src/checkpoint/checkpoint.h
@@ -41,12 +41,6 @@ struct __wt_ckpt_session {
 
     /* Checkpoint time of current checkpoint, during a checkpoint */
     uint64_t current_sec;
-
-    /*
-     * Accumulated change in database size during this checkpoint. Applied to the connection-level
-     * database_size only after the checkpoint succeeds.
-     */
-    int64_t ckpt_size_delta;
 };
 
 /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -989,7 +989,7 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session, bool database
 
         /* A mismatch means a stable file's metadata changed outside
          * __wt_metadata_insert/update/remove. */
-        WT_RET(__wt_disagg_get_database_size(session, &walked_size));
+        WT_RET(__wt_disagg_file_sizes_from_metadata(session, &walked_size));
         walked_size += WT_DISAGG_CHECKPOINT_SIZE_BUFFER;
         WT_ASSERT_ALWAYS(session, walked_size == database_size,
           "disagg database size: recorded per-file total %" PRIu64

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -960,79 +960,50 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session, const char *msg)
  *     On completion of the checkpoint, update the database size in disaggregated storage.
  */
 static int
-__checkpoint_update_disagg_database_size(
-  WT_SESSION_IMPL *session, uint64_t drop_size, bool database_size_fix)
+__checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session, bool database_size_fix)
 {
-    WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
-    uint64_t recomputed_size;
-    bool recomputed;
-
-    conn = S2C(session);
+    uint64_t database_size;
 
     if (!__wt_conn_is_disagg(session))
         return (0);
 
-    /*
-     * If this is a newly created database, add a 1MB buffer onto the database's size. This is done
-     * to account for the KEK table and shared turtle page size. Correctness here is provided by the
-     * fact that we pickup a new checkpoint on startup. Thus subsequent starts of the database will
-     * already have a checkpoint size set.
-     */
-    if (conn->disaggregated_storage.database_size == 0)
-        conn->disaggregated_storage.database_size = WT_DISAGG_CHECKPOINT_SIZE_BUFFER;
+    /* The repair database flow asks us to rebuild the per-file sizes from the metadata. */
+    if (database_size_fix)
+        __wt_disagg_file_sizes_clear(session);
 
     /*
-     * The repair database flow asks us to recompute the database size from the metadata from
-     * scratch, superseding the incremental delta below, since the metadata already reflects this
-     * checkpoint's own sizes. A recompute error fails the checkpoint instead of falling back, since
-     * the caller explicitly asked for this recompute and needs to know.
+     * The database size is the total checkpoint size of every stable file, plus a 1MB buffer for
+     * the KEK table and shared turtle page, which no file's checkpoint accounts for.
      */
-    recomputed = false;
-    if (database_size_fix) {
-        if ((ret = __wt_disagg_get_database_size(session, &recomputed_size)) != 0) {
-            __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
-              "disagg database size fix: failed to recompute database size: %s",
-              __wt_strerror(session, ret, NULL, 0));
-            return (ret);
-        }
+    WT_RET(__wt_disagg_file_sizes_sum(session, &database_size));
+    database_size += WT_DISAGG_CHECKPOINT_SIZE_BUFFER;
+    __wt_disagg_set_database_size(session, database_size);
 
-        recomputed_size += WT_DISAGG_CHECKPOINT_SIZE_BUFFER;
-        __wt_disagg_set_database_size(session, recomputed_size);
+    if (database_size_fix)
         __wt_verbose(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "disagg database size fix: recomputed database size -> %" PRIu64, recomputed_size);
-        recomputed = true;
+          "disagg database size fix: recomputed database size -> %" PRIu64, database_size);
+
+#ifdef HAVE_DIAGNOSTIC
+    {
+        uint64_t walked_size;
+
+        /* A mismatch means a stable file's metadata changed outside
+         * __wt_metadata_insert/update/remove. */
+        WT_RET(__wt_disagg_get_database_size(session, &walked_size));
+        walked_size += WT_DISAGG_CHECKPOINT_SIZE_BUFFER;
+        WT_ASSERT_ALWAYS(session, walked_size == database_size,
+          "disagg database size: recorded per-file total %" PRIu64
+          " does not match the metadata walk %" PRIu64,
+          database_size, walked_size);
     }
-
-    /*
-     * Apply the accumulated size delta to the in-memory database_size now that the checkpoint has
-     * succeeded, unless the recompute above already replaced it. Positive deltas occur when data is
-     * added during the checkpoint. Negative deltas occur when data is removed reducing the total
-     * storage footprint. Guard against overflow/underflow in both cases.
-     */
-    if (!recomputed && session->ckpt.ckpt_size_delta != 0) {
-        uint64_t db;
-        int64_t delta;
-
-        db = conn->disaggregated_storage.database_size;
-        /* Subtract the size of the dropped tables from our delta, we need to account for those. */
-        delta = session->ckpt.ckpt_size_delta - (int64_t)drop_size;
-
-        if (delta > 0) {
-            WT_ASSERT(session, UINT64_MAX - db >= (uint64_t)delta);
-            __wt_disagg_set_database_size(session, db + (uint64_t)delta);
-        } else {
-            WT_ASSERT(session, db >= (uint64_t)(-delta));
-            __wt_disagg_set_database_size(session, db - (uint64_t)(-delta));
-        }
-    }
+#endif
 
     /*
      * The database size must never drop below the checkpoint buffer because the checkpoint metadata
      * itself occupies space that must always be accounted for.
      */
-    WT_ASSERT(
-      session, conn->disaggregated_storage.database_size >= WT_DISAGG_CHECKPOINT_SIZE_BUFFER);
+    WT_ASSERT(session,
+      S2C(session)->disaggregated_storage.database_size >= WT_DISAGG_CHECKPOINT_SIZE_BUFFER);
     return (0);
 }
 
@@ -1782,7 +1753,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_ISOLATION saved_isolation;
     wt_off_t hs_size;
     wt_timestamp_t ckpt_tmp_ts, ckpt_disagg_schema_epoch;
-    uint64_t drop_size, generation;
+    uint64_t generation;
     char schema_epoch_string[WT_TS_INT_STRING_SIZE], ts_string[WT_TS_INT_STRING_SIZE];
     bool failed, tracking;
 
@@ -1791,7 +1762,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     ckpt_disagg_schema_epoch = WT_TS_NONE;
     ckpt_tmp_ts = WT_TS_NONE;
-    drop_size = 0;
     hs_size = 0;
     hs_dhandle = hs_dhandle_shared = NULL;
     txn = session->txn;
@@ -1958,15 +1928,11 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_ERR(__checkpoint_hs(session, cfg, hs_dhandle, hs_dhandle_shared));
 
-    /*
-     * Copy any updated metadata to the shared metadata table. Compute the drop size first so we can
-     * adjust the overall database size after the checkpoint completes.
-     */
+    /* Copy any updated metadata to the shared metadata table. */
     if (__wt_conn_is_disagg(session) &&
       __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         WT_WITH_SCHEMA_LOCK(session,
-          ret = __wt_disagg_shared_metadata_queue_process(
-            session, ckpt_disagg_schema_epoch, &drop_size));
+          ret = __wt_disagg_shared_metadata_queue_process(session, ckpt_disagg_schema_epoch));
         WT_ERR_MSG_CHK(session, ret,
           "Disaggregated storage checkpoint failed while processing shared metadata queue");
     }
@@ -2100,8 +2066,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     }
 
     /* Disaggregated storage database size accounting. */
-    WT_ERR(
-      __checkpoint_update_disagg_database_size(session, drop_size, ckpt_cfg.database_size_fix));
+    WT_ERR(__checkpoint_update_disagg_database_size(session, ckpt_cfg.database_size_fix));
 
     WT_STAT_CONN_INCR(session, checkpoints_total_succeed);
 
@@ -3129,9 +3094,6 @@ __checkpoint_teardown(WT_SESSION_IMPL *session, bool failed, WT_TXN_ISOLATION sa
     __wt_free(session, session->ckpt.handle);
     WT_ASSERT(session, session->ckpt.crash_trigger_point == 0 && session->ckpt.crash_point == 0);
     session->ckpt.handle_allocated = session->ckpt.handle_next = 0;
-
-    /* Reset accumulated change in database size. Failed checkpoints do not affect database size. */
-    session->ckpt.ckpt_size_delta = 0;
 
     session->isolation = txn->isolation = saved_isolation;
     WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_INACTIVE);

--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -67,7 +67,7 @@ __repair_fetch_database_size(WT_SESSION_IMPL *session, WT_ITEM *report, bool is_
         WT_RET(__wt_buf_catfmt(session, report, "fetch_database_size(local): %" PRIu64,
           S2C(session)->disaggregated_storage.database_size));
     else {
-        WT_RET(__wt_disagg_get_database_size(session, &database_size));
+        WT_RET(__wt_disagg_file_sizes_from_metadata(session, &database_size));
         WT_RET(__wt_buf_catfmt(session, report, "fetch_database_size(recompute): %" PRIu64,
           database_size + WT_DISAGG_CHECKPOINT_SIZE_BUFFER));
     }

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -59,6 +59,8 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
       session, &conn->disaggregated_storage.shared_metadata_queue_lock, "update shared metadata"));
     WT_RET(__wt_spin_init(
       session, &conn->disaggregated_storage.pending_crypt_key_lock, "pending crypt key"));
+    WT_RET(
+      __wt_spin_init(session, &conn->disaggregated_storage.file_sizes_lock, "disagg file sizes"));
     WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
     WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
     WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
@@ -122,6 +124,8 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_spin_destroy(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
     __wti_disagg_pending_crypt_key_clear(session);
     __wt_spin_destroy(session, &conn->disaggregated_storage.pending_crypt_key_lock);
+    __wt_disagg_file_sizes_clear(session);
+    __wt_spin_destroy(session, &conn->disaggregated_storage.file_sizes_lock);
     __wt_rwlock_destroy(session, &conn->log_mgr.debug_log_retention_lock);
     __wt_rwlock_destroy(session, &conn->dhandle_lock);
     __wt_spin_destroy(session, &conn->fh_lock);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -295,12 +295,14 @@ __disagg_file_size_tracked(WT_SESSION_IMPL *session, const char *uri)
 }
 
 /*
- * __disagg_file_size_set --
- *     Record a stable file's checkpoint size, replacing any size recorded for it.
+ * __disagg_file_size_set_locked --
+ *     Record a stable file's checkpoint size, replacing any size recorded for it. The caller holds
+ *     the file sizes lock.
  */
 static int
-__disagg_file_size_set(WT_SESSION_IMPL *session, const char *uri, uint64_t size)
+__disagg_file_size_set_locked(WT_SESSION_IMPL *session, const char *uri, uint64_t size)
 {
+    WT_DECL_RET;
     WT_DISAGGREGATED_STORAGE *disagg;
     WT_DISAGG_FILE_SIZE *entry;
     uint64_t bucket;
@@ -317,12 +319,112 @@ __disagg_file_size_set(WT_SESSION_IMPL *session, const char *uri, uint64_t size)
             return (0);
         }
 
-    WT_RET(__wt_calloc_one(session, &entry));
-    WT_RET(__wt_strdup(session, uri, &entry->uri));
+    WT_ERR(__wt_calloc_one(session, &entry));
+    WT_ERR(__wt_strdup(session, uri, &entry->uri));
     entry->size = size;
     TAILQ_INSERT_HEAD(&disagg->file_sizes[bucket], entry, hashq);
 
+    if (0) {
+err:
+        __wt_free(session, entry);
+    }
+    return (ret);
+}
+
+/*
+ * __disagg_file_size_set --
+ *     Record a stable file's checkpoint size, replacing any size recorded for it. Shaped as a walk
+ *     action so the fill can record what it walks.
+ */
+static int
+__disagg_file_size_set(WT_SESSION_IMPL *session, const char *uri, uint64_t size, void *cookie)
+{
+    WT_DECL_RET;
+    WT_DISAGGREGATED_STORAGE *disagg;
+
+    WT_UNUSED(cookie);
+
+    disagg = &S2C(session)->disaggregated_storage;
+
+    __wt_spin_lock(session, &disagg->file_sizes_lock);
+    /* Before the sizes are filled there is nothing to record into; the fill will see this write. */
+    if (disagg->file_sizes != NULL)
+        ret = __disagg_file_size_set_locked(session, uri, size);
+    __wt_spin_unlock(session, &disagg->file_sizes_lock);
+
+    return (ret);
+}
+
+/*
+ * __disagg_file_size_sum --
+ *     Walk action: add a stable file's checkpoint size to a running total.
+ */
+static int
+__disagg_file_size_sum(WT_SESSION_IMPL *session, const char *uri, uint64_t size, void *cookie)
+{
+    WT_UNUSED(session);
+    WT_UNUSED(uri);
+
+    *(uint64_t *)cookie += size;
+
     return (0);
+}
+
+/*
+ * __disagg_stable_files_walk --
+ *     Apply a function to every stable file the metadata holds, passing the size recorded by the
+ *     file's most recent checkpoint, or zero when it has none.
+ */
+static int
+__disagg_stable_files_walk(WT_SESSION_IMPL *session,
+  int (*file_func)(WT_SESSION_IMPL *, const char *, uint64_t, void *), void *cookie)
+{
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    uint64_t size;
+    const char *uri, *value;
+
+    cursor = NULL;
+
+    WT_RET(__wt_metadata_cursor(session, &cursor));
+    while ((ret = cursor->next(cursor)) == 0) {
+        WT_ERR(cursor->get_key(cursor, &uri));
+        if (!__disagg_file_size_tracked(session, uri))
+            continue;
+        WT_ERR(cursor->get_value(cursor, &value));
+
+        /* A file that has not been checkpointed yet holds no size, and so contributes none. */
+        size = 0;
+        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, value, &size), false);
+
+        WT_ERR(file_func(session, uri, size, cookie));
+    }
+    /*
+     * A not found error is okay. cursor->next() returns it once it goes through all the metadata
+     * entries.
+     */
+    WT_ERR_NOTFOUND_OK(ret, false);
+
+err:
+    WT_TRET(__wt_metadata_cursor_release(session, &cursor));
+    return (ret);
+}
+
+/*
+ * __disagg_stable_files_apply --
+ *     Walk the stable files in the metadata. Reads uncommitted, as all metadata reads do, so the
+ *     walk sees the same state the recording hook saw.
+ */
+static int
+__disagg_stable_files_apply(WT_SESSION_IMPL *session,
+  int (*file_func)(WT_SESSION_IMPL *, const char *, uint64_t, void *), void *cookie)
+{
+    WT_DECL_RET;
+
+    WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED,
+      ret = __disagg_stable_files_walk(session, file_func, cookie));
+
+    return (ret);
 }
 
 /*
@@ -332,24 +434,15 @@ __disagg_file_size_set(WT_SESSION_IMPL *session, const char *uri, uint64_t size)
 int
 __wt_disagg_file_size_update(WT_SESSION_IMPL *session, const char *uri, const char *value)
 {
-    WT_DECL_RET;
     uint64_t size;
 
     if (!__disagg_file_size_tracked(session, uri))
         return (0);
 
-    /* Before the sizes are filled there is nothing to record into; the fill will see this write. */
-    if (S2C(session)->disaggregated_storage.file_sizes == NULL)
-        return (0);
-
     size = 0;
     WT_RET_NOTFOUND_OK(__wt_ckpt_last_size(session, value, &size));
 
-    __wt_spin_lock(session, &S2C(session)->disaggregated_storage.file_sizes_lock);
-    ret = __disagg_file_size_set(session, uri, size);
-    __wt_spin_unlock(session, &S2C(session)->disaggregated_storage.file_sizes_lock);
-
-    return (ret);
+    return (__disagg_file_size_set(session, uri, size, NULL));
 }
 
 /*
@@ -409,39 +502,9 @@ __wt_disagg_file_sizes_clear(WT_SESSION_IMPL *session)
 }
 
 /*
- * __disagg_file_sizes_walk --
- *     Record every stable file the metadata holds.
- */
-static int
-__disagg_file_sizes_walk(WT_SESSION_IMPL *session)
-{
-    WT_CURSOR *cursor;
-    WT_DECL_RET;
-    const char *uri, *value;
-
-    cursor = NULL;
-
-    WT_RET(__wt_metadata_cursor(session, &cursor));
-    while ((ret = cursor->next(cursor)) == 0) {
-        WT_ERR(cursor->get_key(cursor, &uri));
-        if (!__disagg_file_size_tracked(session, uri))
-            continue;
-        WT_ERR(cursor->get_value(cursor, &value));
-        WT_ERR(__wt_disagg_file_size_update(session, uri, value));
-    }
-    WT_ERR_NOTFOUND_OK(ret, false);
-
-err:
-    WT_TRET(__wt_metadata_cursor_release(session, &cursor));
-    return (ret);
-}
-
-/*
  * __disagg_file_sizes_fill --
  *     Fill the sizes from the metadata. Needed once per connection: a database that is opened
- *     rather than created gets its entries from recovery, not through a metadata write. The walk
- *     reads uncommitted, as all metadata reads do, so it sees the same state the recording hook
- *     saw.
+ *     rather than created gets its entries from recovery, not through a metadata write.
  */
 static int
 __disagg_file_sizes_fill(WT_SESSION_IMPL *session)
@@ -457,10 +520,7 @@ __disagg_file_sizes_fill(WT_SESSION_IMPL *session)
     __wt_spin_unlock(session, &disagg->file_sizes_lock);
     WT_RET(ret);
 
-    WT_WITH_TXN_ISOLATION(
-      session, WT_ISO_READ_UNCOMMITTED, ret = __disagg_file_sizes_walk(session));
-
-    return (ret);
+    return (__disagg_stable_files_apply(session, __disagg_file_size_set, NULL));
 }
 
 /*
@@ -491,6 +551,23 @@ __wt_disagg_file_sizes_sum(WT_SESSION_IMPL *session, uint64_t *sizep)
     __wt_spin_unlock(session, &disagg->file_sizes_lock);
 
     *sizep = total;
+    return (0);
+}
+
+/*
+ * __wt_disagg_file_sizes_from_metadata --
+ *     Recompute the disaggregated database size from the metadata, excluding the fixed overhead for
+ *     the KEK table and shared turtle page.
+ */
+int
+__wt_disagg_file_sizes_from_metadata(WT_SESSION_IMPL *session, uint64_t *sizep)
+{
+    uint64_t total;
+
+    total = 0;
+    WT_RET(__disagg_stable_files_apply(session, __disagg_file_size_sum, &total));
+    *sizep = total;
+
     return (0);
 }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -8,8 +8,6 @@
 
 #include "wt_internal.h"
 
-static int __disagg_accumulate_drop_size(
-  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_size);
 static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
 
 /*
@@ -247,6 +245,253 @@ __wt_disagg_set_database_size(WT_SESSION_IMPL *session, uint64_t database_size)
 {
     S2C(session)->disaggregated_storage.database_size = database_size;
     WT_STAT_CONN_SET(session, disagg_database_size, database_size);
+}
+
+/*
+ * __disagg_file_size_bucket --
+ *     Return the hash bucket a stable file's URI belongs to.
+ */
+static WT_INLINE uint64_t
+__disagg_file_size_bucket(WT_SESSION_IMPL *session, const char *uri)
+{
+    return (__wt_hash_city64(uri, strlen(uri)) & (uint64_t)(S2C(session)->hash_size - 1));
+}
+
+/*
+ * __disagg_file_sizes_alloc --
+ *     Allocate the hash buckets if they are not there yet.
+ */
+static int
+__disagg_file_sizes_alloc(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGGREGATED_STORAGE *disagg;
+    uint32_t i;
+
+    conn = S2C(session);
+    disagg = &conn->disaggregated_storage;
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &disagg->file_sizes_lock);
+
+    if (disagg->file_sizes != NULL)
+        return (0);
+
+    WT_RET(__wt_calloc_def(session, conn->hash_size, &disagg->file_sizes));
+    for (i = 0; i < conn->hash_size; ++i)
+        TAILQ_INIT(&disagg->file_sizes[i]);
+
+    return (0);
+}
+
+/*
+ * __disagg_file_size_tracked --
+ *     Return whether a metadata key names a file whose size counts towards the database size.
+ */
+static bool
+__disagg_file_size_tracked(WT_SESSION_IMPL *session, const char *uri)
+{
+    return (__wt_conn_is_disagg(session) && WT_PREFIX_MATCH(uri, "file:") &&
+      WT_SUFFIX_MATCH(uri, ".wt_stable"));
+}
+
+/*
+ * __disagg_file_size_set --
+ *     Record a stable file's checkpoint size, replacing any size recorded for it.
+ */
+static int
+__disagg_file_size_set(WT_SESSION_IMPL *session, const char *uri, uint64_t size)
+{
+    WT_DISAGGREGATED_STORAGE *disagg;
+    WT_DISAGG_FILE_SIZE *entry;
+    uint64_t bucket;
+
+    disagg = &S2C(session)->disaggregated_storage;
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &disagg->file_sizes_lock);
+    WT_ASSERT(session, disagg->file_sizes != NULL);
+
+    bucket = __disagg_file_size_bucket(session, uri);
+    TAILQ_FOREACH (entry, &disagg->file_sizes[bucket], hashq)
+        if (strcmp(entry->uri, uri) == 0) {
+            entry->size = size;
+            return (0);
+        }
+
+    WT_RET(__wt_calloc_one(session, &entry));
+    WT_RET(__wt_strdup(session, uri, &entry->uri));
+    entry->size = size;
+    TAILQ_INSERT_HEAD(&disagg->file_sizes[bucket], entry, hashq);
+
+    return (0);
+}
+
+/*
+ * __wt_disagg_file_size_update --
+ *     Record the checkpoint size a metadata value carries for a stable file.
+ */
+int
+__wt_disagg_file_size_update(WT_SESSION_IMPL *session, const char *uri, const char *value)
+{
+    WT_DECL_RET;
+    uint64_t size;
+
+    if (!__disagg_file_size_tracked(session, uri))
+        return (0);
+
+    /* Before the sizes are filled there is nothing to record into; the fill will see this write. */
+    if (S2C(session)->disaggregated_storage.file_sizes == NULL)
+        return (0);
+
+    size = 0;
+    WT_RET_NOTFOUND_OK(__wt_ckpt_last_size(session, value, &size));
+
+    __wt_spin_lock(session, &S2C(session)->disaggregated_storage.file_sizes_lock);
+    ret = __disagg_file_size_set(session, uri, size);
+    __wt_spin_unlock(session, &S2C(session)->disaggregated_storage.file_sizes_lock);
+
+    return (ret);
+}
+
+/*
+ * __wt_disagg_file_size_remove --
+ *     Forget a stable file, so its size leaves the database size.
+ */
+void
+__wt_disagg_file_size_remove(WT_SESSION_IMPL *session, const char *uri)
+{
+    WT_DISAGGREGATED_STORAGE *disagg;
+    WT_DISAGG_FILE_SIZE *entry;
+    uint64_t bucket;
+
+    if (!__disagg_file_size_tracked(session, uri))
+        return;
+
+    disagg = &S2C(session)->disaggregated_storage;
+
+    __wt_spin_lock(session, &disagg->file_sizes_lock);
+    if (disagg->file_sizes != NULL) {
+        bucket = __disagg_file_size_bucket(session, uri);
+        TAILQ_FOREACH (entry, &disagg->file_sizes[bucket], hashq)
+            if (strcmp(entry->uri, uri) == 0) {
+                TAILQ_REMOVE(&disagg->file_sizes[bucket], entry, hashq);
+                __wt_free(session, entry->uri);
+                __wt_free(session, entry);
+                break;
+            }
+    }
+    __wt_spin_unlock(session, &disagg->file_sizes_lock);
+}
+
+/*
+ * __wt_disagg_file_sizes_clear --
+ *     Discard the recorded sizes. Freeing the buckets is what asks the next sum to rebuild them.
+ */
+void
+__wt_disagg_file_sizes_clear(WT_SESSION_IMPL *session)
+{
+    WT_DISAGGREGATED_STORAGE *disagg;
+    WT_DISAGG_FILE_SIZE *entry;
+    uint32_t i;
+
+    disagg = &S2C(session)->disaggregated_storage;
+
+    __wt_spin_lock(session, &disagg->file_sizes_lock);
+    if (disagg->file_sizes != NULL) {
+        for (i = 0; i < S2C(session)->hash_size; ++i)
+            while ((entry = TAILQ_FIRST(&disagg->file_sizes[i])) != NULL) {
+                TAILQ_REMOVE(&disagg->file_sizes[i], entry, hashq);
+                __wt_free(session, entry->uri);
+                __wt_free(session, entry);
+            }
+        __wt_free(session, disagg->file_sizes);
+    }
+    __wt_spin_unlock(session, &disagg->file_sizes_lock);
+}
+
+/*
+ * __disagg_file_sizes_walk --
+ *     Record every stable file the metadata holds.
+ */
+static int
+__disagg_file_sizes_walk(WT_SESSION_IMPL *session)
+{
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    const char *uri, *value;
+
+    cursor = NULL;
+
+    WT_RET(__wt_metadata_cursor(session, &cursor));
+    while ((ret = cursor->next(cursor)) == 0) {
+        WT_ERR(cursor->get_key(cursor, &uri));
+        if (!__disagg_file_size_tracked(session, uri))
+            continue;
+        WT_ERR(cursor->get_value(cursor, &value));
+        WT_ERR(__wt_disagg_file_size_update(session, uri, value));
+    }
+    WT_ERR_NOTFOUND_OK(ret, false);
+
+err:
+    WT_TRET(__wt_metadata_cursor_release(session, &cursor));
+    return (ret);
+}
+
+/*
+ * __disagg_file_sizes_fill --
+ *     Fill the sizes from the metadata. Needed once per connection: a database that is opened
+ *     rather than created gets its entries from recovery, not through a metadata write. The walk
+ *     reads uncommitted, as all metadata reads do, so it sees the same state the recording hook
+ *     saw.
+ */
+static int
+__disagg_file_sizes_fill(WT_SESSION_IMPL *session)
+{
+    WT_DECL_RET;
+    WT_DISAGGREGATED_STORAGE *disagg;
+
+    disagg = &S2C(session)->disaggregated_storage;
+
+    /* Allocate before the walk, so a write that lands during it records itself. */
+    __wt_spin_lock(session, &disagg->file_sizes_lock);
+    ret = __disagg_file_sizes_alloc(session);
+    __wt_spin_unlock(session, &disagg->file_sizes_lock);
+    WT_RET(ret);
+
+    WT_WITH_TXN_ISOLATION(
+      session, WT_ISO_READ_UNCOMMITTED, ret = __disagg_file_sizes_walk(session));
+
+    return (ret);
+}
+
+/*
+ * __wt_disagg_file_sizes_sum --
+ *     Return the total checkpoint size of every stable file, excluding the fixed overhead.
+ */
+int
+__wt_disagg_file_sizes_sum(WT_SESSION_IMPL *session, uint64_t *sizep)
+{
+    WT_DISAGGREGATED_STORAGE *disagg;
+    WT_DISAGG_FILE_SIZE *entry;
+    uint64_t total;
+    uint32_t i;
+
+    disagg = &S2C(session)->disaggregated_storage;
+    *sizep = 0;
+
+    /* Only the fill allocates the buckets, so an allocated array is a filled one. */
+    if (disagg->file_sizes == NULL)
+        WT_RET(__disagg_file_sizes_fill(session));
+
+    total = 0;
+    __wt_spin_lock(session, &disagg->file_sizes_lock);
+    if (disagg->file_sizes != NULL)
+        for (i = 0; i < S2C(session)->hash_size; ++i)
+            TAILQ_FOREACH (entry, &disagg->file_sizes[i], hashq)
+                total += entry->size;
+    __wt_spin_unlock(session, &disagg->file_sizes_lock);
+
+    *sizep = total;
+    return (0);
 }
 
 /*
@@ -630,42 +875,6 @@ __disagg_handle_create_remove_pairing(WT_SESSION_IMPL *session, WT_CONNECTION_IM
 }
 
 /*
- * __disagg_accumulate_drop_size --
- *     Accumulate the drop size if the entry represents a table drop operation.
- */
-int
-__disagg_accumulate_drop_size(
-  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_sizep)
-{
-    WT_DECL_RET;
-    char *stable_config;
-
-    stable_config = NULL;
-
-    if (!(entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL))
-        return (0);
-
-    /* The stable entry is gone only after a real drop; a rolled-back drop leaves it. */
-    WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, entry->stable_uri, &stable_config), true);
-
-    if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-        uint64_t size = 0;
-        /* A table dropped before it was ever checkpointed has no checkpoint entry. */
-        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), true);
-        if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-            *drop_sizep += size;
-            __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-              "Accumulated drop size %" PRIu64 " for table \"%s\" (stable URI \"%s\")", size,
-              entry->table_name, entry->stable_uri);
-        }
-    }
-
-err:
-    __wt_free(session, stable_config);
-    return (ret);
-}
-
-/*
  * __disagg_requeue_skipped_creates --
  *     Return parked create entries to the head of the shared metadata queue, restoring their
  *     original order, so a later checkpoint revisits them.
@@ -690,19 +899,16 @@ __disagg_requeue_skipped_creates(
 
 /*
  * __wt_disagg_shared_metadata_queue_process --
- *     Process the update metadata list, returning the total checkpoint size of the tables actually
- *     dropped so the caller can reduce the database size accordingly.
+ *     Process the update metadata list.
  */
 int
-__wt_disagg_shared_metadata_queue_process(
-  WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch, uint64_t *drop_sizep)
+__wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch)
 {
     struct __wt_disagg_shared_metadata_qh skipped_creates;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
 
-    WT_ASSERT(session, drop_sizep != NULL);
     conn = S2C(session);
     TAILQ_INIT(&skipped_creates);
 
@@ -749,8 +955,6 @@ __wt_disagg_shared_metadata_queue_process(
 
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
         WT_ERR(__disagg_shared_metadata_op(session, entry));
-
-        WT_ERR(__disagg_accumulate_drop_size(session, entry, drop_sizep));
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -52,6 +52,18 @@ typedef enum __wt_background_compact_cleanup_stat_type {
 } WT_BACKGROUND_COMPACT_CLEANUP_STAT_TYPE;
 
 /*
+ * WT_DISAGG_FILE_SIZE --
+ *  The checkpoint size last accounted for one stable file.
+ */
+struct __wt_disagg_file_size {
+    char *uri;
+    uint64_t size; /* Its most recent checkpoint's size */
+
+    /* Hash of the stable files contributing to the disaggregated database size */
+    TAILQ_ENTRY(__wt_disagg_file_size) hashq;
+};
+
+/*
  * WT_BACKGROUND_COMPACT_STAT --
  *  List of tracking information for each file compact has worked on.
  */
@@ -374,6 +386,13 @@ struct __wt_disaggregated_storage {
     TAILQ_HEAD(__wt_disagg_pending_crypt_key_qh, __wt_disagg_pending_crypt_key)
     pending_crypt_key_qh;
     WT_SPINLOCK pending_crypt_key_lock;
+
+    /*
+     * The database size is the sum of its files, recorded where the metadata is written. Filled
+     * from the metadata on first use.
+     */
+    WT_SPINLOCK file_sizes_lock;
+    TAILQ_HEAD(__wt_disagg_file_size_hash, __wt_disagg_file_size) * file_sizes;
 
     uint64_t num_meta_put;               /* The number metadata puts since connection open. */
     uint64_t num_meta_put_at_ckpt_begin; /* The number metadata puts at checkpoint begin. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -598,6 +598,10 @@ extern int __wt_disagg_config_get_role(WT_SESSION_IMPL *session, const char **cf
 extern int __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *stable_uri,
   const char *table_name, WT_SHARED_METADATA_OP metadata_op, wt_timestamp_t schema_epoch,
   bool deferred, const char *stable_value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_disagg_file_size_update(WT_SESSION_IMPL *session, const char *uri,
+  const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_disagg_file_sizes_sum(WT_SESSION_IMPL *session, uint64_t *sizep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_parse_meta(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf,
@@ -607,9 +611,8 @@ extern int __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_shared_metadata_queue_process(
-  WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch, uint64_t *drop_sizep)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session,
+  wt_timestamp_t cur_schema_epoch) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_shared_metadata_queue_publish(
   WT_SESSION_IMPL *session, const char *table_name, wt_timestamp_t schema_epoch)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1830,6 +1833,8 @@ extern void __wt_debug_crash(WT_SESSION_IMPL *session)
 extern void __wt_dhandle_clear_add(
   WT_DHANDLE_CLEAR_LOG *log, const char *file, const char *func, int line);
 extern void __wt_disagg_deferred_pickup_signal(WT_SESSION_IMPL *session, uint64_t released_gen);
+extern void __wt_disagg_file_size_remove(WT_SESSION_IMPL *session, const char *uri);
+extern void __wt_disagg_file_sizes_clear(WT_SESSION_IMPL *session);
 extern void __wt_disagg_set_database_size(WT_SESSION_IMPL *session, uint64_t database_size);
 extern void __wt_encrypt_size(
   WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t incoming_size, size_t *sizep);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -600,9 +600,9 @@ extern int __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, cons
   bool deferred, const char *stable_value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_file_size_update(WT_SESSION_IMPL *session, const char *uri,
   const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_file_sizes_sum(WT_SESSION_IMPL *session, uint64_t *sizep)
+extern int __wt_disagg_file_sizes_from_metadata(WT_SESSION_IMPL *session, uint64_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
+extern int __wt_disagg_file_sizes_sum(WT_SESSION_IMPL *session, uint64_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_parse_meta(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf,
   WT_DISAGG_METADATA *metadata) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -237,6 +237,8 @@ struct __wt_dhandle_clear_log;
 typedef struct __wt_dhandle_clear_log WT_DHANDLE_CLEAR_LOG;
 struct __wt_disagg_deferred_ckpt;
 typedef struct __wt_disagg_deferred_ckpt WT_DISAGG_DEFERRED_CKPT;
+struct __wt_disagg_file_size;
+typedef struct __wt_disagg_file_size WT_DISAGG_FILE_SIZE;
 struct __wt_disagg_metadata_op;
 typedef struct __wt_disagg_metadata_op WT_DISAGG_METADATA_OP;
 struct __wt_disagg_pending_crypt_key;

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -483,15 +483,35 @@ err:
 int
 __wt_ckpt_last_size(WT_SESSION_IMPL *session, const char *config, uint64_t *sizep)
 {
-    WT_CKPT ckpt;
-    WT_CLEAR(ckpt);
+    WT_CONFIG ckptconf, entryconf;
+    WT_CONFIG_ITEM ek, ev, k, v;
+    uint64_t size;
+    int64_t found, order;
 
     *sizep = 0;
-    WT_RET(__ckpt_last(session, config, &ckpt));
-    *sizep = ckpt.size;
 
-    __wt_checkpoint_free(session, &ckpt);
-    return (0);
+    /* Read the order and size in one pass: loading the whole checkpoint copies and decodes more. */
+    WT_RET(__wt_config_getones(session, config, "checkpoint", &v));
+    __wt_config_subinit(session, &ckptconf, &v);
+    for (found = 0; __wt_config_next(&ckptconf, &k, &v) == 0;) {
+        order = 0;
+        size = 0;
+        __wt_config_subinit(session, &entryconf, &v);
+        while (__wt_config_next(&entryconf, &ek, &ev) == 0) {
+            if (WT_CONFIG_LIT_MATCH("order", ek))
+                order = ev.val;
+            else if (WT_CONFIG_LIT_MATCH("size", ek))
+                size = (uint64_t)ev.val;
+        }
+
+        /* Ignore checkpoints before the ones we've already seen. */
+        if (found != 0 && order < found)
+            continue;
+        found = order;
+        *sizep = size;
+    }
+
+    return (found ? 0 : WT_NOTFOUND);
 }
 
 /*
@@ -1392,36 +1412,24 @@ __wt_meta_ckptlist_set(
     WT_CKPT *ckpt;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
-    uint64_t prev_ckpt_size;
     const char *fname;
     bool has_lsn;
 
     btree = S2BT(session);
     fname = dhandle->name;
-    prev_ckpt_size = 0;
 
     WT_ERR(__wt_scr_alloc(session, 1024, &buf));
 
-    /*
-     * Add B-tree metadata to any added checkpoint. Track the previous checkpoint's size as we
-     * iterate so we can compute the delta for disaggregated storage.
-     */
+    /* Add B-tree metadata to any added checkpoint. */
     WT_CKPT_FOREACH (ckptbase, ckpt) {
         if (F_ISSET(ckpt, WT_CKPT_ADD)) {
             ckpt->next_page_id = btree->next_page_id;
             ckpt->leaf_entry_ewma = __wt_atomic_load_uint64_relaxed(&btree->leaf_entry_ewma);
             ckpt->approx_leaf_pages = __wt_atomic_load_uint64_relaxed(&btree->approx_leaf_pages);
-            /*
-             * For disaggregated storage, save the total bytes to the checkpoint size field. Track
-             * the delta between this checkpoint and the previous one, this delta will be applied to
-             * the database level size once the checkpoint succeeds.
-             */
-            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+
+            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
                 WT_ASSERT(session, ckpt->size == __wt_block_disagg_get_size(session));
-                session->ckpt.ckpt_size_delta += (int64_t)ckpt->size - (int64_t)prev_ckpt_size;
-            }
-        } else
-            prev_ckpt_size = ckpt->size;
+        }
     }
 
     WT_ERR(__wt_meta_ckptlist_to_meta(session, ckptbase, buf));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -498,14 +498,20 @@ __wt_ckpt_last_size(WT_SESSION_IMPL *session, const char *config, uint64_t *size
         size = 0;
         __wt_config_subinit(session, &entryconf, &v);
         while (__wt_config_next(&entryconf, &ek, &ev) == 0) {
-            if (WT_CONFIG_LIT_MATCH("order", ek))
+            if (WT_CONFIG_LIT_MATCH("order", ek)) {
+                if (ev.len == 0)
+                    WT_RET_MSG(session, WT_ERROR, "corrupted order value in checkpoint config");
                 order = ev.val;
-            else if (WT_CONFIG_LIT_MATCH("size", ek))
+            } else if (WT_CONFIG_LIT_MATCH("size", ek))
                 size = (uint64_t)ev.val;
         }
 
+        /* Order numbering starts at one, so anything below that is not a usable order. */
+        if (order < 1)
+            WT_RET_MSG(session, WT_ERROR, "missing or invalid order value in checkpoint config");
+
         /* Ignore checkpoints before the ones we've already seen. */
-        if (found != 0 && order < found)
+        if (order < found)
             continue;
         found = order;
         *sizep = size;

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -209,6 +209,9 @@ __wt_metadata_insert(WT_SESSION_IMPL *session, const char *key, const char *valu
     WT_ERR(cursor->insert(cursor));
     if (WT_META_TRACKING(session))
         WT_ERR(__wti_meta_track_insert(session, key));
+
+    /* Keep the disaggregated per-file size accounting in step with the metadata. */
+    WT_ERR(__wt_disagg_file_size_update(session, key, value));
 err:
     WT_TRET(__wt_metadata_cursor_release(session, &cursor));
     return (ret);
@@ -248,6 +251,9 @@ __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *valu
     cursor->set_key(cursor, key);
     cursor->set_value(cursor, value);
     WT_ERR(cursor->insert(cursor));
+
+    /* Keep the disaggregated per-file size accounting in step with the metadata. */
+    WT_ERR(__wt_disagg_file_size_update(session, key, value));
 err:
     WT_TRET(__wt_metadata_cursor_release(session, &cursor));
     return (ret);
@@ -286,7 +292,10 @@ __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key)
 
     WT_ERR(__wt_metadata_cursor(session, &cursor));
     cursor->set_key(cursor, key);
-    ret = cursor->remove(cursor);
+    WT_ERR(cursor->remove(cursor));
+
+    /* Keep the disaggregated per-file size accounting in step with the metadata. */
+    __wt_disagg_file_size_remove(session, key);
 
 err:
     WT_TRET(__wt_metadata_cursor_release(session, &cursor));

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -72,6 +72,16 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
             cursor[str(i)] = str(i) + 'x' * self.value_size
         cursor.close()
 
+    def get_checkpoint_size(self, uri):
+        """The size of a file's most recent checkpoint, as the database size counts it."""
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(uri)
+        self.assertEqual(meta_cursor.search(), 0)
+        sizes = re.findall(r',size=(\d+),', meta_cursor.get_value())
+        meta_cursor.close()
+        self.assertGreater(len(sizes), 0, f"no checkpoint size in the metadata for {uri}")
+        return int(sizes[-1])
+
     def database_size_check(self, context_message=""):
         self.session.checkpoint()
 
@@ -131,12 +141,15 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         busy_session.close()
         self.assertTrue(self.exists(self.victim_uri))
 
-        # We should see the drop size for a successful drop
-        with self.expectedStdoutPattern('.*Accumulated drop size.*', maxchars=1000000):
-            self.conn.reconfigure("verbose=[disaggregated_storage:2]")
-            self.session.drop(self.victim_uri, None)
-            self.session.checkpoint()
-            self.conn.reconfigure("verbose=[disaggregated_storage:0]")
+        # A successful drop takes the collection's whole size out of the database size.
+        victim_size = self.get_checkpoint_size("file:" + self.victim_base + ".wt_stable")
+        size_before_drop = self.get_database_size()
+        self.session.drop(self.victim_uri, None)
+        self.session.checkpoint()
+        size_after_drop = self.get_database_size()
+        self.assertGreaterEqual(size_before_drop - size_after_drop, victim_size,
+            f"a successful drop must remove the collection's size ({victim_size}) from the database "
+            f"size: {size_before_drop} -> {size_after_drop}")
 
         self.assertFalse(self.exists(self.victim_uri))
         self.database_size_check("after successful drop")

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -46,6 +46,12 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
     victim_uri = "layered:victim_table"
     victim_base = "victim_table"
 
+    # The shared metadata table. Its own checkpoint size moves with the drop.
+    shared_uri = "file:WiredTigerShared.wt_stable"
+
+    # The fixed overhead every database size carries for the KEK table and shared turtle page.
+    WT_DISAGG_CHECKPOINT_SIZE_BUFFER = 1024 * 1024
+
     value_size = 8000
     num_failed_ckpts = 4
 
@@ -82,24 +88,28 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         self.assertGreater(len(sizes), 0, f"no checkpoint size in the metadata for {uri}")
         return int(sizes[-1])
 
+    def accumulated_stable_size(self):
+        """The database size as the metadata defines it: every stable file's last checkpoint."""
+        total = 0
+        with WiredTigerCursor(self.session, 'metadata:') as cursor:
+            while cursor.next() == 0:
+                uri = cursor.get_key()
+                if not uri.startswith('file:') or not uri.endswith('.wt_stable'):
+                    continue
+                sizes = re.findall(r',size=(\d+),', cursor.get_value())
+                if sizes:
+                    total += int(sizes[-1])
+        return total
+
     def database_size_check(self, context_message=""):
         self.session.checkpoint()
 
-        # Calculate reference value from sum of all the collections
-        accumulated_database_size = 0
-        with WiredTigerCursor(self.session, 'metadata:') as cursor:
-            while cursor.next() == 0:
-                value = cursor.get_value()
-                checkpoints = re.findall(r',checkpoint=([^)]+),', value)
-                if checkpoints:
-                    sizes = re.findall(r',size=(\d+),', checkpoints[0])
-                    if sizes:
-                        accumulated_database_size += int(sizes[-1])
-
+        accumulated_database_size = \
+            self.accumulated_stable_size() + self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER
         database_size = self.get_database_size()
-        self.assertGreaterEqual(database_size, accumulated_database_size,
-            f"database size {database_size} should be greater or equal to "
-            f"accumulated {accumulated_database_size} : {context_message}")
+        self.assertEqual(database_size, accumulated_database_size,
+            f"database size {database_size} should equal the metadata's own total "
+            f"{accumulated_database_size} : {context_message}")
 
     def test_failed_drop_does_not_shrink_database_size(self):
         # Filler table for headroom.
@@ -141,15 +151,21 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         busy_session.close()
         self.assertTrue(self.exists(self.victim_uri))
 
-        # A successful drop takes the collection's whole size out of the database size.
+        # A successful drop takes the collection's whole size out of the database size. The same
+        # checkpoint applies the drop's removal to the shared metadata table, whose own checkpoint
+        # size moves as a result; that part of the change does not belong to the collection.
         victim_size = self.get_checkpoint_size("file:" + self.victim_base + ".wt_stable")
+        shared_before_drop = self.get_checkpoint_size(self.shared_uri)
         size_before_drop = self.get_database_size()
         self.session.drop(self.victim_uri, None)
         self.session.checkpoint()
+        shared_after_drop = self.get_checkpoint_size(self.shared_uri)
         size_after_drop = self.get_database_size()
-        self.assertGreaterEqual(size_before_drop - size_after_drop, victim_size,
+        self.assertEqual(size_before_drop - size_after_drop,
+            victim_size - (shared_after_drop - shared_before_drop),
             f"a successful drop must remove the collection's size ({victim_size}) from the database "
-            f"size: {size_before_drop} -> {size_after_drop}")
+            f"size: {size_before_drop} -> {size_after_drop}, shared metadata "
+            f"{shared_before_drop} -> {shared_after_drop}")
 
         self.assertFalse(self.exists(self.victim_uri))
         self.database_size_check("after successful drop")

--- a/test/suite/test_disagg_checkpoint_size23.py
+++ b/test/suite/test_disagg_checkpoint_size23.py
@@ -30,11 +30,13 @@
 #   Database size accounting across the events a URI's metadata entry goes through: created,
 #   checkpointed, dropped, and created again under the same name before the drop was processed.
 #
-#   Two things are checked at every step, because they fail independently:
+#   Three values are checked together at every step, because they fail independently:
 #     - the size published in the checkpoint metadata, which is what another node adopts;
-#     - the maintained size against the from-scratch recompute from the metadata, which is the
-#       definition the verify path uses. A one-sided check on the published value alone cannot see
-#       an over-subtraction, and equality alone cannot see a value that never reaches a checkpoint.
+#     - the maintained running size;
+#     - the from-scratch recompute from the metadata, which is the definition the verify path uses.
+#   A one-sided check on the published value alone cannot see an over-subtraction, and equality
+#   between the maintained and recomputed sizes alone cannot see a value that never reaches a
+#   checkpoint.
 
 import re, wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, disagg_test_class
@@ -46,7 +48,9 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
     conn_follow_config = conn_base_config + 'disaggregated=(role="follower")'
 
-    uri = "layered:reused_table"
+    table_name = "reused_table"
+    uri = "layered:" + table_name
+    stable_uri = "file:" + table_name + ".wt_stable"
     table_config = 'key_format=i,value_format=S'
 
     # The fixed overhead every database size carries for the KEK table and shared turtle page.
@@ -70,13 +74,25 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
         self.assertIsNotNone(recomputed)
         return int(local.group(1)), int(recomputed.group(1))
 
+    def stable_uri_present(self, stable_uri, conn=None):
+        """Whether a stable file has a metadata entry, in the view the size walk itself reads."""
+        if conn is None:
+            conn = self.conn
+        report = wiredtiger.wiredtiger_repair(
+            conn, f'fetch_metadata=(local=true,uri="{stable_uri}")')
+        return '<no matching metadata entry' not in report
+
     def check_consistent(self, label, conn=None):
-        """The running size must equal the metadata's own total, in both directions."""
+        """The published, running and recomputed sizes must all be the same number."""
         local, recomputed = self.maintained_and_recomputed(conn)
-        self.pr(f"{label}: local={local}, recomputed={recomputed}, drift={local - recomputed}")
+        published = self.published_size(conn)
+        self.pr(f"{label}: published={published}, local={local}, recomputed={recomputed}, "
+            f"drift={local - recomputed}")
         self.assertEqual(local, recomputed,
             f"{label}: maintained database size {local} != recomputed {recomputed} "
             f"(drift {local - recomputed})")
+        self.assertEqual(published, local,
+            f"{label}: published database size {published} != maintained {local}")
         return local
 
     def populate(self, session=None, rows=1000):
@@ -114,9 +130,18 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
 
         size_after = self.published_size()
         self.pr(f"empty={size_empty}, with_data={size_with_data}, after_all_dropped={size_after}")
-        self.assertLess(size_after, size_empty + (size_with_data - size_empty) * 0.1,
+
+        # Nothing of the table may be left in the metadata. With its entry gone the recompute
+        # cannot count it, so the equality check below is what proves the maintained size does not
+        # either. Note the size does not return to size_empty: the shared metadata table's own
+        # stable file is counted too, and the creates and drops above grew it.
+        self.assertFalse(self.stable_uri_present(self.stable_uri),
+            f"the dropped table's stable file must not remain: {self.stable_uri}")
+        # What is left above the fixed overhead is that shared file, not the data we inserted.
+        self.assertLess(size_after - self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER,
+            size_with_data - size_empty,
             f"the dropped data must not stay in the database size: empty={size_empty}, "
-            f"after_all_dropped={size_after}")
+            f"with_data={size_with_data}, after_all_dropped={size_after}")
         self.assertGreaterEqual(size_after, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER,
             f"the database size must not fall below its fixed overhead: {size_after}")
         self.check_consistent("after all dropped")
@@ -174,7 +199,7 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
 
             # The pickup must really have brought the table over, or the rest proves nothing.
             meta = session_follow.open_cursor('metadata:')
-            meta.set_key("file:reused_table.wt_stable")
+            meta.set_key(self.stable_uri)
             self.assertEqual(meta.search(), 0,
                 "the pickup did not bring the table's stable file into the local metadata")
             meta.close()
@@ -198,32 +223,3 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
             session_follow.close()
         finally:
             conn_follow.close()
-
-    # A stable file's metadata entry can arrive complete with a checkpoint, rather than being grown
-    # by checkpoints of our own: a checkpoint pickup inserts such entries. The size it carries has to
-    # be accounted for at the moment the entry appears, so write one directly and check the next
-    # checkpoint counts it.
-    def test_size_of_an_inserted_entry(self):
-        self.session.create(self.uri, self.table_config)
-        self.populate()
-        self.session.checkpoint()
-        size_before = self.check_consistent("before the inserted entry")
-
-        # Copy the table's own metadata entry, checkpoint and all, under a second stable file name.
-        meta = self.session.open_cursor('metadata:')
-        meta.set_key("file:reused_table.wt_stable")
-        self.assertEqual(meta.search(), 0)
-        value = meta.get_value()
-        meta.close()
-        inserted_size = int(re.findall(r',size=(\d+),', value)[-1])
-        self.assertGreater(inserted_size, 0)
-
-        meta = self.session.open_cursor('metadata:', None, 'readonly=false')
-        meta["file:inserted_table.wt_stable"] = value
-        meta.close()
-
-        self.session.checkpoint()
-        size_after = self.check_consistent("after the inserted entry")
-        self.assertEqual(size_after - size_before, inserted_size,
-            f"the inserted entry's checkpoint size must join the database size: "
-            f"{size_before} -> {size_after}, entry size {inserted_size}")

--- a/test/suite/test_disagg_checkpoint_size23.py
+++ b/test/suite/test_disagg_checkpoint_size23.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_disagg_checkpoint_size23.py
+#   Database size accounting across the events a URI's metadata entry goes through: created,
+#   checkpointed, dropped, and created again under the same name before the drop was processed.
+#
+#   Two things are checked at every step, because they fail independently:
+#     - the size published in the checkpoint metadata, which is what another node adopts;
+#     - the maintained size against the from-scratch recompute from the metadata, which is the
+#       definition the verify path uses. A one-sided check on the published value alone cannot see
+#       an over-subtraction, and equality alone cannot see a value that never reaches a checkpoint.
+
+import re, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+@disagg_test_class
+class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase):
+
+    conn_base_config = 'statistics=(all),disaggregated=(lose_all_my_data=true),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+    conn_follow_config = conn_base_config + 'disaggregated=(role="follower")'
+
+    uri = "layered:reused_table"
+    table_config = 'key_format=i,value_format=S'
+
+    # The fixed overhead every database size carries for the KEK table and shared turtle page.
+    size_buffer = 1024 * 1024
+
+    def published_size(self, conn=None):
+        """The database size in the newest complete checkpoint, as another node would read it."""
+        match = re.search(r'database_size=(\d+)', self.disagg_get_complete_checkpoint_meta(conn))
+        self.assertIsNotNone(match)
+        return int(match.group(1))
+
+    def maintained_and_recomputed(self, conn=None):
+        """The running database size, and the same value summed from the metadata."""
+        if conn is None:
+            conn = self.conn
+        local = wiredtiger.wiredtiger_repair(conn, 'fetch_database_size=(local=true)')
+        recomputed = wiredtiger.wiredtiger_repair(conn, 'fetch_database_size=(local=false)')
+        local = re.search(r'fetch_database_size\(local\): (\d+)', local)
+        recomputed = re.search(r'fetch_database_size\(recompute\): (\d+)', recomputed)
+        self.assertIsNotNone(local)
+        self.assertIsNotNone(recomputed)
+        return int(local.group(1)), int(recomputed.group(1))
+
+    def check_consistent(self, label, conn=None):
+        """The running size must equal the metadata's own total, in both directions."""
+        local, recomputed = self.maintained_and_recomputed(conn)
+        self.pr(f"{label}: local={local}, recomputed={recomputed}, drift={local - recomputed}")
+        self.assertEqual(local, recomputed,
+            f"{label}: maintained database size {local} != recomputed {recomputed} "
+            f"(drift {local - recomputed})")
+        return local
+
+    def populate(self, session=None, rows=1000):
+        if session is None:
+            session = self.session
+        cursor = session.open_cursor(self.uri)
+        for i in range(rows):
+            cursor[i] = 'a' * 500
+        cursor.close()
+
+    # A dropped table's size must leave the database size even when the name is taken again before
+    # the checkpoint processes the removal: the URI alone does not say which table a removal
+    # belonged to.
+    def test_recreate_between_drops_does_not_leak(self):
+        self.session.create(self.uri, self.table_config)
+        self.session.checkpoint()
+        size_empty = self.published_size()
+        self.check_consistent("after create")
+
+        self.populate()
+        self.session.checkpoint()
+        size_with_data = self.published_size()
+        self.assertGreater(size_with_data, size_empty)
+        self.check_consistent("after populate")
+
+        # Take the name again before the checkpoint processes the removal, so the removal is
+        # processed while the name belongs to a later table. Then drop that one too: nothing is left
+        # behind, so the data's size must leave the database size.
+        self.session.drop(self.uri)
+        self.session.create(self.uri, self.table_config)
+        self.session.checkpoint()
+        self.session.drop(self.uri)
+        self.session.checkpoint()
+        self.session.checkpoint()
+
+        size_after = self.published_size()
+        self.pr(f"empty={size_empty}, with_data={size_with_data}, after_all_dropped={size_after}")
+        self.assertLess(size_after, size_empty + (size_with_data - size_empty) * 0.1,
+            f"the dropped data must not stay in the database size: empty={size_empty}, "
+            f"after_all_dropped={size_after}")
+        self.assertGreaterEqual(size_after, self.size_buffer,
+            f"the database size must not fall below its fixed overhead: {size_after}")
+        self.check_consistent("after all dropped")
+
+    # The same name reused repeatedly, with each removal processed while the name belongs to a later
+    # table. An over-subtraction shows up as a drift, or as a size below the fixed overhead.
+    def test_reuse_churn(self):
+        for i in range(10):
+            self.session.create(self.uri, self.table_config)
+            self.populate(rows=100)
+            self.session.checkpoint()
+
+            self.session.drop(self.uri)
+            self.session.create(self.uri, self.table_config)
+            if i % 2 == 0:
+                self.populate(rows=50)
+            # A table must be checkpointed before it can be dropped.
+            self.session.checkpoint()
+            self.session.drop(self.uri)
+            self.session.checkpoint()
+
+            size = self.check_consistent(f"cycle {i}")
+            self.assertGreaterEqual(size, self.size_buffer)
+
+        self.session.checkpoint()
+        self.check_consistent("after churn")
+
+    # A node that learns of a table by adopting a checkpoint, rather than by creating it, must
+    # account for the size that arrives with it: the table's metadata entry appears complete with a
+    # checkpoint. Stepping the follower up makes it publish a size of its own.
+    def test_size_arriving_with_a_checkpoint(self):
+        self.session.create(self.uri, self.table_config)
+        self.populate()
+        self.session.checkpoint()
+        leader_size = self.published_size()
+        self.assertGreater(leader_size, self.size_buffer)
+
+        conn_follow = self.wiredtiger_open(
+            'follower', self.extensionsConfig() + ',create,' + self.conn_follow_config)
+        try:
+            session_follow = conn_follow.open_session('')
+
+            # Give the follower a table of its own and checkpoint it, so its size accounting is
+            # already established before the pickup brings a table it has never seen.
+            session_follow.create("table:follower_local", self.table_config)
+            local_cursor = session_follow.open_cursor("table:follower_local")
+            for i in range(100):
+                local_cursor[i] = 'b' * 500
+            local_cursor.close()
+            session_follow.checkpoint()
+
+            # The follower has never seen the table; the pickup brings its metadata entry, and its
+            # checkpoint size along with it.
+            self.disagg_advance_checkpoint(conn_follow)
+
+            # The pickup must really have brought the table over, or the rest proves nothing.
+            meta = session_follow.open_cursor('metadata:')
+            meta.set_key("file:reused_table.wt_stable")
+            self.assertEqual(meta.search(), 0,
+                "the pickup did not bring the table's stable file into the local metadata")
+            meta.close()
+            _, follower_recomputed = self.maintained_and_recomputed(conn_follow)
+            self.assertGreater(follower_recomputed, self.size_buffer,
+                "the follower's metadata must account for the adopted table's data")
+            self.check_consistent("follower after pickup", conn_follow)
+
+            # Give the step up a checkpoint the follower has not already adopted.
+            self.populate(rows=50)
+            self.session.checkpoint()
+            leader_size = self.published_size()
+
+            # As the new leader it publishes a size, which must still cover the adopted table.
+            self.disagg_switch_follower_and_leader(conn_follow)
+            session_follow.checkpoint()
+            follower_size = self.check_consistent("follower after step up", conn_follow)
+            self.assertGreaterEqual(follower_size, leader_size,
+                f"the size adopted with the checkpoint must survive a step up: leader published "
+                f"{leader_size}, new leader has {follower_size}")
+            session_follow.close()
+        finally:
+            conn_follow.close()
+
+    # A stable file's metadata entry can arrive complete with a checkpoint, rather than being grown
+    # by checkpoints of our own: a checkpoint pickup inserts such entries. The size it carries has to
+    # be accounted for at the moment the entry appears, so write one directly and check the next
+    # checkpoint counts it.
+    def test_size_of_an_inserted_entry(self):
+        self.session.create(self.uri, self.table_config)
+        self.populate()
+        self.session.checkpoint()
+        size_before = self.check_consistent("before the inserted entry")
+
+        # Copy the table's own metadata entry, checkpoint and all, under a second stable file name.
+        meta = self.session.open_cursor('metadata:')
+        meta.set_key("file:reused_table.wt_stable")
+        self.assertEqual(meta.search(), 0)
+        value = meta.get_value()
+        meta.close()
+        inserted_size = int(re.findall(r',size=(\d+),', value)[-1])
+        self.assertGreater(inserted_size, 0)
+
+        meta = self.session.open_cursor('metadata:', None, 'readonly=false')
+        meta["file:inserted_table.wt_stable"] = value
+        meta.close()
+
+        self.session.checkpoint()
+        size_after = self.check_consistent("after the inserted entry")
+        self.assertEqual(size_after - size_before, inserted_size,
+            f"the inserted entry's checkpoint size must join the database size: "
+            f"{size_before} -> {size_after}, entry size {inserted_size}")

--- a/test/suite/test_disagg_checkpoint_size23.py
+++ b/test/suite/test_disagg_checkpoint_size23.py
@@ -50,7 +50,7 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
     table_config = 'key_format=i,value_format=S'
 
     # The fixed overhead every database size carries for the KEK table and shared turtle page.
-    size_buffer = 1024 * 1024
+    WT_DISAGG_CHECKPOINT_SIZE_BUFFER = 1024 * 1024
 
     def published_size(self, conn=None):
         """The database size in the newest complete checkpoint, as another node would read it."""
@@ -117,7 +117,7 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
         self.assertLess(size_after, size_empty + (size_with_data - size_empty) * 0.1,
             f"the dropped data must not stay in the database size: empty={size_empty}, "
             f"after_all_dropped={size_after}")
-        self.assertGreaterEqual(size_after, self.size_buffer,
+        self.assertGreaterEqual(size_after, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER,
             f"the database size must not fall below its fixed overhead: {size_after}")
         self.check_consistent("after all dropped")
 
@@ -139,7 +139,7 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
             self.session.checkpoint()
 
             size = self.check_consistent(f"cycle {i}")
-            self.assertGreaterEqual(size, self.size_buffer)
+            self.assertGreaterEqual(size, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER)
 
         self.session.checkpoint()
         self.check_consistent("after churn")
@@ -152,7 +152,7 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
         self.populate()
         self.session.checkpoint()
         leader_size = self.published_size()
-        self.assertGreater(leader_size, self.size_buffer)
+        self.assertGreater(leader_size, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER)
 
         conn_follow = self.wiredtiger_open(
             'follower', self.extensionsConfig() + ',create,' + self.conn_follow_config)
@@ -179,7 +179,7 @@ class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase
                 "the pickup did not bring the table's stable file into the local metadata")
             meta.close()
             _, follower_recomputed = self.maintained_and_recomputed(conn_follow)
-            self.assertGreater(follower_recomputed, self.size_buffer,
+            self.assertGreater(follower_recomputed, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER,
                 "the follower's metadata must account for the adopted table's data")
             self.check_consistent("follower after pickup", conn_follow)
 

--- a/test/suite/test_layered_checkpoint12.py
+++ b/test/suite/test_layered_checkpoint12.py
@@ -66,14 +66,13 @@ class test_layered_checkpoint12(wttest.WiredTigerTestCase):
         self.conn.reconfigure('disaggregated=(role="follower")')
         self.close_conn()
         with self.customStdoutPattern(
-            lambda output: self.assertNotRegex(
-                output, r'disagg database size: .*checkpoint size')):
+            lambda output: self.assertNotRegex(output, r'disagg database size verify:')):
             self.open_conn(config=self._follower_config())
 
         # Reopen again with checkpoint metadata so startup picks up the latest
         # checkpoint and runs the database-size verification branch.
         with self.expectedStdoutPattern(
-            r'disagg database size: .*checkpoint size', maxchars=30000):
+            r'disagg database size verify: stored \d+, computed \d+', maxchars=30000):
             self.reopen_conn(config=self._follower_config(checkpoint_meta))
 
         # test_layered*.py modules run layered verify during teardown. Ignore the


### PR DESCRIPTION
The database size used to be assembled from per-checkpoint size deltas. Collection drops were accounted for separately by interpreting queued schema operations. This approach is error-prone and brittle.

The size is now recorded per stable file wherever that file's metadata is written, and the database size is simply the sum, so it cannot drift from the metadata it describes.

- Database size is tracked by following metadata writes instead of chasing checkpoint deltas.
- The delta machinery and the drop-size accounting built on top of it are gone.
- Diagnostic builds cross-check the tracked size against the metadata on every checkpoint.
- New test covers the reuse, churn, and checkpoint-adoption cases; an existing test no longer
  depends on a log message.