### PR TITLE
WT-18265 Corrupted address cookie guard

### DIFF
--- a/dist/s_clang_scan.diff
+++ b/dist/s_clang_scan.diff
@@ -4,7 +4,6 @@ wiredtiger/src/block_cache/block_io.c Called function pointer is null (null dere
 wiredtiger/src/btree/bt_delete.c The left operand of '!=' is a garbage value [core.UndefinedBinaryOperatorResult]
 wiredtiger/src/btree/bt_sync_obsolete.c The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
 wiredtiger/src/btree/bt_sync_obsolete.c The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
-wiredtiger/src/btree/bt_sync_obsolete.c The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
 wiredtiger/src/include/intpack_inline.h Assigned value is garbage or undefined [core.uninitialized.Assign]
 wiredtiger/src/os_posix/os_fs.c The 1st argument to 'fdatasync' is -1 but should be >= 0 [unix.StdCLibraryFunctions]
 wiredtiger/src/reconcile/rec_row.c Branch condition evaluates to a garbage value [core.uninitialized.Branch]

--- a/src/block_disagg/block_disagg_addr.c
+++ b/src/block_disagg/block_disagg_addr.c
@@ -167,14 +167,13 @@ __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, siz
     WT_RET(__block_disagg_addr_unpack_version(buf, 0, &version, &version_min));
 
     /*
-     * No writer emits either field beyond one past the format version, the extra one coming from
-     * the debug upgrade setting, so a cookie claiming otherwise is corruption rather than a format
-     * we might meet. Check ahead of the return below, which is itself a case worth a core, and is
-     * handled far enough above that nothing there names the cookie.
+     * Diagnostic builds only: a version this far ahead of the format version is corruption rather
+     * than one we might meet, and a core localizes it where the error reported below cannot. The
+     * bound is loose to leave room for upgrade and downgrade testing.
      */
     WT_ASSERT(session,
-      version <= WT_BLOCK_DISAGG_ADDR_VERSION + 1 &&
-        version_min <= WT_BLOCK_DISAGG_ADDR_VERSION + 1);
+      version <= WT_BLOCK_DISAGG_ADDR_VERSION + 4 &&
+        version_min <= WT_BLOCK_DISAGG_ADDR_VERSION + 4);
 
     if (version_min > current_version)
         WT_RET_MSG(session, ENOTSUP,

--- a/src/block_disagg/block_disagg_addr.c
+++ b/src/block_disagg/block_disagg_addr.c
@@ -24,12 +24,6 @@
 #define WT_BLOCK_DISAGG_ADDR_VERSION_MIN 0 /* The oldest version that can read this format. */
 
 /*
- * The highest version a writer can produce: the format version above, or one higher when the debug
- * upgrade setting is on to test reading a newer format.
- */
-#define WT_BLOCK_DISAGG_ADDR_VERSION_MAX (WT_BLOCK_DISAGG_ADDR_VERSION + 1)
-
-/*
  * __block_disagg_addr_debug_upgrade --
  *     Check if we are in the debug mode for testing disaggregated address cookie upgrade/downgrade.
  */
@@ -173,13 +167,14 @@ __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, siz
     WT_RET(__block_disagg_addr_unpack_version(buf, 0, &version, &version_min));
 
     /*
-     * No writer emits either field beyond this, so a cookie claiming otherwise is corruption rather
-     * than a format we might meet. Check ahead of the return below, which is itself a case worth a
-     * core, and is handled far enough above that nothing there names the cookie.
+     * No writer emits either field beyond one past the format version, the extra one coming from
+     * the debug upgrade setting, so a cookie claiming otherwise is corruption rather than a format
+     * we might meet. Check ahead of the return below, which is itself a case worth a core, and is
+     * handled far enough above that nothing there names the cookie.
      */
     WT_ASSERT(session,
-      version <= WT_BLOCK_DISAGG_ADDR_VERSION_MAX &&
-        version_min <= WT_BLOCK_DISAGG_ADDR_VERSION_MAX);
+      version <= WT_BLOCK_DISAGG_ADDR_VERSION + 1 &&
+        version_min <= WT_BLOCK_DISAGG_ADDR_VERSION + 1);
 
     if (version_min > current_version)
         WT_RET_MSG(session, ENOTSUP,

--- a/src/block_disagg/block_disagg_addr.c
+++ b/src/block_disagg/block_disagg_addr.c
@@ -24,6 +24,12 @@
 #define WT_BLOCK_DISAGG_ADDR_VERSION_MIN 0 /* The oldest version that can read this format. */
 
 /*
+ * The highest version a writer can produce: the format version above, or one higher when the debug
+ * upgrade setting is on to test reading a newer format.
+ */
+#define WT_BLOCK_DISAGG_ADDR_VERSION_MAX (WT_BLOCK_DISAGG_ADDR_VERSION + 1)
+
+/*
  * __block_disagg_addr_debug_upgrade --
  *     Check if we are in the debug mode for testing disaggregated address cookie upgrade/downgrade.
  */
@@ -165,6 +171,16 @@ __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, siz
 
     /* Unpack the address version. */
     WT_RET(__block_disagg_addr_unpack_version(buf, 0, &version, &version_min));
+
+    /*
+     * No writer emits either field beyond this, so a cookie claiming otherwise is corruption rather
+     * than a format we might meet. Check ahead of the return below, which is itself a case worth a
+     * core, and is handled far enough above that nothing there names the cookie.
+     */
+    WT_ASSERT(session,
+      version <= WT_BLOCK_DISAGG_ADDR_VERSION_MAX &&
+        version_min <= WT_BLOCK_DISAGG_ADDR_VERSION_MAX);
+
     if (version_min > current_version)
         WT_RET_MSG(session, ENOTSUP,
           "Unsupported disaggregated address cookie version %" PRIu8 ", min %" PRIu8, version,

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1967,6 +1967,15 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
 
     /* If off-page, the pointer references a WT_ADDR structure. */
     if (__wt_off_page(page, addr)) {
+        /*
+         * A zero-length address copies nothing, so the caller would proceed on whatever its buffer
+         * already held. Abort while the reference and the parent's image are still intact; the
+         * block manager only catches this several frames later, with nothing naming the reference.
+         */
+        WT_ASSERT_ALWAYS(session, addr->block_cookie_size != 0,
+          "%s: off-page ref address has zero length: ref %p, state %d",
+          session->dhandle == NULL ? "[no dhandle]" : session->dhandle->name, (void *)ref,
+          (int)WT_REF_GET_STATE(ref));
         WT_TIME_AGGREGATE_COPY(&copy->ta, &addr->ta);
         copy->type = addr->type;
         memcpy(copy->addr, addr->block_cookie, copy->size = addr->block_cookie_size);
@@ -1975,6 +1984,18 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
 
     /* If on-page, the pointer references a cell. */
     __wt_cell_unpack_addr(session, page->dsk, (WT_CELL *)addr, unpack);
+
+    /*
+     * As above, plus an upper bound: the copy narrows the length to a uint8_t, so an oversized
+     * cookie would truncate into a plausible short one. Empty cookies exist only in delta cells,
+     * which the merge drops before the image is materialized.
+     */
+    WT_ASSERT_ALWAYS(session, unpack->size != 0 && unpack->size <= WT_ADDR_MAX_COOKIE,
+      "%s: on-page ref address cell has unusable length %" PRIu32
+      ": ref %p, state %d, cell type %" PRIu8,
+      session->dhandle == NULL ? "[no dhandle]" : session->dhandle->name, unpack->size, (void *)ref,
+      (int)WT_REF_GET_STATE(ref), unpack->raw);
+
     WT_TIME_AGGREGATE_COPY(&copy->ta, &unpack->ta);
 
     switch (unpack->raw) {

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1986,9 +1986,9 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
     __wt_cell_unpack_addr(session, page->dsk, (WT_CELL *)addr, unpack);
 
     /*
-     * As above, plus an upper bound: the copy narrows the length to a uint8_t, so an oversized
-     * cookie would truncate into a plausible short one. Empty cookies exist only in delta cells,
-     * which the merge drops before the image is materialized.
+     * As above. The address copy holds the length in a single byte, so an oversized length is
+     * silently truncated rather than rejected. Zero-length address cells exist only as
+     * WT_CELL_ADDR_DEL_VISIBLE_ALL, which the delta merge drops before the image is materialized.
      */
     WT_ASSERT_ALWAYS(session, unpack->size != 0 && unpack->size <= WT_ADDR_MAX_COOKIE,
       "%s: on-page ref address cell has unusable length %" PRIu32


### PR DESCRIPTION
Adds a `WT_ASSERT_ALWAYS` on both branches of `__wt_ref_addr_copy` so we abort where an unusable address length is read, naming the dhandle, ref and ref state.