### PR TITLE
WT-17677 Don't dirty the btree when instantiating updates on page read

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -580,12 +580,6 @@ __instantiate_col_var(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_DELETED *pa
     /* We just read the page and it's still locked. The append list should be empty. */
     WT_ASSERT(session, WT_COL_APPEND(page) == NULL);
 
-    /*
-     * The modify code marks the page dirty. Mark it back to clean as instantiated deleted page
-     * should be clean.
-     */
-    __wt_page_modify_clear(session, page);
-
 err:
     __wt_free(session, upd);
 
@@ -702,17 +696,17 @@ __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     /*
      * Give the page a modify structure. We need it to remember that the page has been instantiated.
      * We do not need to mark the page dirty here. (It used to be necessary because evicting a clean
-     * instantiated page would lose the delete information; but that is no longer the case.) Note
-     * though that because VLCS instantiation goes through col_modify it will mark the page dirty
-     * regardless, except in read-only trees where attempts to mark things dirty are ignored.
-     * Therefore, we explicitly mark it as clean. (Row- store instantiation adds the tombstones by
-     * hand and so does not need to mark the page dirty.)
+     * instantiated page would lose the delete information; but that is no longer the case.) VLCS
+     * instantiation goes through col_modify, which would otherwise dirty the page and the tree, so
+     * flag the page to keep the modify path from doing so. (Row-store instantiation adds the
+     * tombstones by hand and so does not need to mark the page dirty.)
      *
      * Note that partially visible truncates that may need instantiation can appear in read-only
      * trees (whether a read-only open of the live database or via a checkpoint cursor) if they were
      * not yet globally visible when the tree was checkpointed.
      */
     WT_RET(__wt_page_modify_init(session, page));
+    F_SET(page->modify, WT_PAGE_MODIFY_INSTANTIATING);
 
     /*
      * If the truncate operation is not yet resolved and the btree is not read-only, count how many
@@ -737,7 +731,7 @@ __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
                 ++count;
             break;
         }
-        WT_RET(__wt_calloc_def(session, count + 1, &update_list));
+        WT_ERR(__wt_calloc_def(session, count + 1, &update_list));
     }
 
     /*
@@ -758,9 +752,7 @@ __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
     page->modify->instantiated = true;
     page->modify->inst_updates = update_list;
-
-    /* The instantiated deleted page should be clean. */
-    WT_ASSERT(session, !__wt_page_is_modified(page));
+    update_list = NULL;
 
     /*
      * We will leave the WT_PAGE_DELETED structure in the ref; all of its information has been
@@ -768,9 +760,12 @@ __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
      * page reconciliation until the instantiated page is itself successfully reconciled.
      */
 
-    return (0);
-
 err:
+    F_CLR(page->modify, WT_PAGE_MODIFY_INSTANTIATING);
+
+    /* The instantiated deleted page should be clean. */
+    WT_ASSERT(session, !__wt_page_is_modified(page));
+
     __wt_free(session, update_list);
     return (ret);
 }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -955,6 +955,14 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
     /* We don't handle in-memory prepare resolution here. */
     WT_ASSERT(session, !__wt_btree_stays_in_memory(btree));
 
+    /*
+     * The prepared updates are already on disk, so the page must not end up dirty. The modify path
+     * would otherwise dirty the page and the tree; flag the page so it stays clean. The page isn't
+     * yet reachable by other threads, so the flag needs no synchronization.
+     */
+    WT_RET(__wt_page_modify_init(session, page));
+    F_SET(page->modify, WT_PAGE_MODIFY_INSTANTIATING);
+
     __wt_btcur_init(session, &cbt);
     __wt_btcur_open(&cbt);
 
@@ -1016,16 +1024,15 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
-    /*
-     * The data is written to the disk so we can mark the page clean after re-instantiating prepared
-     * updates to avoid reconciling the page every time.
-     */
-    __wt_page_modify_clear(session, page);
-
     if (0) {
 err:
         __wt_free_update_list(session, &upd);
     }
+    F_CLR(page->modify, WT_PAGE_MODIFY_INSTANTIATING);
+
+    /* The page with re-instantiated prepared updates should be clean. */
+    WT_ASSERT(session, !__wt_page_is_modified(page));
+
     WT_TRET(__wt_btcur_close(&cbt, true));
     __wt_scr_free(session, &value);
     return (ret);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -556,10 +556,14 @@ struct __wt_page_modify {
 #define WT_PAGE_RS_RESTORED 0x1
     uint8_t restore_state; /* Created by restoring updates */
 
-/* Additional diagnostics fields to catch invalid updates to page_state, even in release builds. */
+/*
+ * Flags set while the page is held exclusive; the exclusive and reconciling flags catch invalid
+ * updates to page_state, even in release builds.
+ */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_PAGE_MODIFY_EXCLUSIVE 0x1u
-#define WT_PAGE_MODIFY_RECONCILING 0x2u
+#define WT_PAGE_MODIFY_INSTANTIATING 0x2u
+#define WT_PAGE_MODIFY_RECONCILING 0x4u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 };

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -991,6 +991,10 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return;
 
+    /* A page being instantiated ends up clean, don't dirty it. */
+    if (F_ISSET(page->modify, WT_PAGE_MODIFY_INSTANTIATING))
+        return;
+
     WT_ASSERT(session,
       !F_ISSET(btree, WT_BTREE_DISAGGREGATED) ||
         __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1206,6 +1206,14 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return;
 
+    /*
+     * Instantiating updates onto a page that has just been read is internal bookkeeping: the page
+     * is left clean, so dirtying the tree here would cost a checkpoint of a tree with no
+     * user-visible change.
+     */
+    if (F_ISSET(page->modify, WT_PAGE_MODIFY_INSTANTIATING))
+        return;
+
     WT_ASSERT(session,
       !F_ISSET(btree, WT_BTREE_DISAGGREGATED) ||
         __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));

--- a/test/suite/test_instantiate01.py
+++ b/test/suite/test_instantiate01.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_instantiate01.py
+#
+# Instantiating updates while reading a page from disk is internal bookkeeping: the page ends up
+# clean, so it must not mark the btree dirty. If it did, the next checkpoint would rewrite a tree
+# with no user-visible changes. Cover the two instantiation paths: fast-truncated pages and pages
+# with prepared updates on disk.
+@wttest.skip_for_hook("disagg", "checkpoint skip behavior differs on disagg followers")
+@wttest.skip_for_hook("tiered", "flush_tier calls interfere with checkpoint skip accounting")
+class test_instantiate01(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all)'
+
+    format_values = [
+        ('column', dict(key_format='r')),
+        ('row', dict(key_format='i')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def checkpoint_handles_applied(self):
+        self.session.checkpoint()
+        return self.get_stat(stat.conn.checkpoint_handle_applied)
+
+    def checkpoint_until_quiescent(self):
+        # A tree is only skipped by checkpoints once it is clean and its file has no reclaimable
+        # space, which can take a few checkpoints after real work. Checkpoint until nothing is
+        # applied so the assertions below observe only the effect of the instantiating read.
+        for _ in range(10):
+            if self.checkpoint_handles_applied() == 0:
+                return
+        self.fail('checkpoints never reached a quiescent state')
+
+    def test_instantiate_deleted_page(self):
+        nrows = 20000
+        uri = 'table:instantiate01'
+        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format='S',
+            config='log=(enabled=false)')
+        ds.populate()
+
+        # Make the values distinct: identical column-store values are RLE-compressed into a
+        # single cell, which would collapse the tree to a page or two and leave nothing for
+        # fast-truncate to delete.
+        def value(i):
+            return 'a' * 100 + str(i)
+
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        # Write data at time 10 and persist it.
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value(i)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        cursor.close()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        # Reopen the connection so nothing is in memory and the truncate can be fast.
+        self.reopen_conn()
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        # Fast-truncate the middle of the table at time 20.
+        self.session.begin_transaction()
+        lo_cursor = self.session.open_cursor(uri)
+        hi_cursor = self.session.open_cursor(uri)
+        lo_cursor.set_key(ds.key(nrows // 4 + 1))
+        hi_cursor.set_key(ds.key(nrows // 4 + nrows // 2))
+        self.assertEqual(self.session.truncate(None, lo_cursor, hi_cursor, None), 0)
+        lo_cursor.close()
+        hi_cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+        self.assertGreater(self.get_stat(stat.conn.rec_page_delete_fast), 0)
+
+        # Persist the truncate and checkpoint until the tree is skipped as clean.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        self.checkpoint_until_quiescent()
+
+        # Read everything at time 10. The truncate isn't visible at that timestamp and isn't
+        # globally visible (oldest is pinned at 1), so this read must instantiate tombstones
+        # onto the truncated pages.
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, value(count + 1))
+            count += 1
+        self.assertEqual(count, nrows)
+        self.session.rollback_transaction()
+        cursor.close()
+        self.assertGreater(self.get_stat(stat.conn.cache_read_deleted), 0)
+
+        # Instantiation is not a user-visible change: the tree must still be clean and the next
+        # checkpoint must skip it entirely.
+        self.assertEqual(self.checkpoint_handles_applied(), 0)
+
+    def test_instantiate_prepared_updates(self):
+        uri = 'table:instantiate01'
+        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format='S',
+            config='log=(enabled=false)')
+        ds.populate()
+
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        # Commit one key, then prepare an update to a neighboring key on the same page.
+        session2 = self.conn.open_session()
+        cursor2 = session2.open_cursor(uri)
+        session2.begin_transaction()
+        cursor2[ds.key(2)] = 'committed'
+        session2.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        session3 = self.conn.open_session()
+        cursor3 = session3.open_cursor(uri)
+        session3.begin_transaction()
+        cursor3[ds.key(1)] = 'prepared'
+        session3.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+        cursor2.close()
+
+        # Evict the page: reconciliation writes the prepared update to disk and the page is
+        # rebuilt in cache from that disk image, instantiating the prepared update onto the
+        # update chain. (The page can't leave the cache entirely while the prepared transaction
+        # is active, so the instantiate-on-disk-read variant of this path is not reachable here;
+        # it is exercised by the disagg tests.)
+        evict_cursor = self.session.open_cursor(uri, None, 'debug=(release_evict)')
+        evict_cursor.set_key(ds.key(2))
+        self.assertEqual(evict_cursor.search(), 0)
+        self.assertEqual(evict_cursor.reset(), 0)
+        evict_cursor.close()
+
+        # Checkpoint until the tree is skipped as clean.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.checkpoint_until_quiescent()
+
+        # Read the committed key (avoiding a prepare conflict) and checkpoint again: the tree
+        # holding only the instantiated prepared update must stay clean and be skipped.
+        cursor = self.session.open_cursor(uri)
+        cursor.set_key(ds.key(2))
+        self.assertEqual(cursor.search(), 0)
+        cursor.close()
+        self.assertEqual(self.checkpoint_handles_applied(), 0)
+
+        session3.rollback_transaction()
+        session3.close()
+        session2.close()


### PR DESCRIPTION
Instantiating updates on page read (fast-truncate tombstones, or prepared updates in the disk image) went through the normal modify path, which marked the leaf and the btree dirty; the leaf was marked clean again but the btree stayed modified, so checkpoints reprocessed a tree with no real changes.

Set a new WT_PAGE_MODIFY_INSTANTIATING flag during instantiation and have __wt_page_modify_set do nothing while it's set, so the page and tree are never dirtied. The page is private to the reading thread, so the flag needs no synchronization.

The new test test_instantiate01.py asserts checkpoints still skip the tree after an instantiating read; it fails without this change.