### PR TITLE
WT-12717 Declare destructor for timestamp simulator's timestamp_manager

### DIFF
--- a/test/simulator/timestamp/src/include/timestamp_manager.h
+++ b/test/simulator/timestamp/src/include/timestamp_manager.h
@@ -60,6 +60,7 @@ private:
     /* No copies of the singleton allowed. */
 private:
     timestamp_manager();
+    ~timestamp_manager() = default;
 
 public:
     timestamp_manager(timestamp_manager const &) = delete;


### PR DESCRIPTION
Coverity CID 138963: timestamp_manager deletes its copy operations but never declares a destructor. Declaring it explicitly satisfies the rule of three, the class owns no resources, so this is hygiene, not a behaviour change.