### PR TITLE
WT-17950 Use a consistent rec_ prefix for WT_PAGE_MODIFY eviction state

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1467,9 +1467,9 @@ __split_multi_inmem_mod_stats_update(WT_PAGE_MODIFY *mod, WT_PAGE_MODIFY *orig_m
      * Restore the previous page's modify state to avoid repeatedly attempting eviction on the same
      * page.
      */
-    mod->last_evict_pass_gen = orig_modify->last_evict_pass_gen;
-    mod->last_eviction_id = orig_modify->last_eviction_id;
-    mod->last_eviction_timestamp = orig_modify->last_eviction_timestamp;
+    mod->rec_evict_attempt_pass_gen = orig_modify->rec_evict_attempt_pass_gen;
+    mod->rec_evict_attempt_oldest_id = orig_modify->rec_evict_attempt_oldest_id;
+    mod->rec_evict_attempt_pinned_ts = orig_modify->rec_evict_attempt_pinned_ts;
     mod->rec_max_txn = orig_modify->rec_max_txn;
     mod->rec_max_timestamp = orig_modify->rec_max_timestamp;
     /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -373,21 +373,21 @@ struct __wt_page_modify {
     /* The first unwritten transaction ID (approximate). */
     wt_shared uint64_t first_dirty_txn;
 
-    /* The transaction state last time eviction was attempted. */
-    uint64_t last_evict_pass_gen;
-    uint64_t last_eviction_id;
-    wt_timestamp_t last_eviction_timestamp;
+    /* The transaction state as of the last eviction attempt, successful or not. */
+    uint64_t rec_evict_attempt_pass_gen;
+    uint64_t rec_evict_attempt_oldest_id;
+    wt_timestamp_t rec_evict_attempt_pinned_ts;
 
 #ifdef HAVE_DIAGNOSTIC
     /* Check that transaction time moves forward. */
-    uint64_t last_oldest_id;
+    uint64_t rec_last_oldest_id;
 #endif
 
     /* Avoid checking for obsolete updates during checkpoints. */
     uint64_t obsolete_check_txn;
     wt_timestamp_t obsolete_check_timestamp;
 
-    /* The largest transaction and timestamp seen on the page by reconciliation. */
+    /* The largest transaction and timestamp seen on the page by a successful reconciliation. */
     uint64_t rec_max_txn;
     wt_timestamp_t rec_max_timestamp;
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2293,23 +2293,23 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
      * a reasonable amount of time is currently pretty arbitrary.
      */
     if (__wt_evict_aggressive(session) ||
-      mod->last_evict_pass_gen + 5 <
+      mod->rec_evict_attempt_pass_gen + 5 <
         __wt_atomic_load_uint64_relaxed(&S2C(session)->evict->evict_pass_gen))
         return (true);
 
     /* Retry if the global transaction state has moved forward. */
     if (__wt_atomic_load_uint64_v_relaxed(&txn_global->current) ==
         __wt_atomic_load_uint64_v_relaxed(&txn_global->oldest_id) ||
-      mod->last_eviction_id != __wt_txn_oldest_id(session))
+      mod->rec_evict_attempt_oldest_id != __wt_txn_oldest_id(session))
         return (true);
 
     /*
      * It is possible that we have not started using the timestamps just yet. So, check for the last
      * time we evicted only if there is a timestamp set.
      */
-    if (mod->last_eviction_timestamp != WT_TS_NONE) {
+    if (mod->rec_evict_attempt_pinned_ts != WT_TS_NONE) {
         __wt_txn_pinned_timestamp(session, &pinned_ts);
-        if (pinned_ts > mod->last_eviction_timestamp)
+        if (pinned_ts > mod->rec_evict_attempt_pinned_ts)
             return (true);
     }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -225,9 +225,9 @@ __reconcile_save_evict_state(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
      * this state changes.
      */
     if (LF_ISSET(WT_REC_EVICT)) {
-        mod->last_eviction_id = oldest_id;
-        __wt_txn_pinned_timestamp(session, &mod->last_eviction_timestamp);
-        mod->last_evict_pass_gen =
+        mod->rec_evict_attempt_oldest_id = oldest_id;
+        __wt_txn_pinned_timestamp(session, &mod->rec_evict_attempt_pinned_ts);
+        mod->rec_evict_attempt_pass_gen =
           __wt_atomic_load_uint64_relaxed(&S2C(session)->evict->evict_pass_gen);
     }
 
@@ -236,8 +236,8 @@ __reconcile_save_evict_state(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
      * Check that transaction time always moves forward for a given page. If this check fails,
      * reconciliation can free something that a future reconciliation will need.
      */
-    WT_ASSERT(session, mod->last_oldest_id <= oldest_id);
-    mod->last_oldest_id = oldest_id;
+    WT_ASSERT(session, mod->rec_last_oldest_id <= oldest_id);
+    mod->rec_last_oldest_id = oldest_id;
 #endif
 }
 


### PR DESCRIPTION
`WT_PAGE_MODIFY` mixed a `last_` and a `rec_` prefix for fields that all track per-page eviction/reconciliation history. `__split_multi_inmem_mod_stats_update()` copies both groups field-by-field, where the inconsistency is most visible.

Everything stays under `rec_` — all of these fields are written by reconciliation. The attempt-vs-success distinction the ticket asks to preserve is carried by a sub-prefix instead of a comment:

| before | after |
|---|---|
| `last_evict_pass_gen` | `rec_evict_attempt_pass_gen` |
| `last_eviction_id` | `rec_evict_attempt_oldest_id` |
| `last_eviction_timestamp` | `rec_evict_attempt_pinned_ts` |
| `last_oldest_id` (diagnostic) | `rec_last_oldest_id` |

`rec_evict_attempt_*` is sampled at the start of every eviction-driven reconciliation and read only by `__wt_page_evict_retry()` to decide whether a *failed* eviction is worth retrying; `rec_max_*` and friends hold values from a reconciliation that *completed*.

Two of these also named neither what they store nor when they are stored, so the rename fixes that: the id is the oldest id, and the timestamp is the pinned timestamp.

The diagnostic `last_oldest_id` is included because leaving it would reintroduce the same inconsistency in the same struct. It keeps a plain `rec_last_` prefix rather than `rec_evict_attempt_`: it sits outside the `WT_REC_EVICT` block and is updated on every reconciliation, not just eviction.

Mechanical rename, no behavior change.
