### PR TITLE
WT-18178 Return WT_ERROR with WT_VERIFY_PAGE_ID_MISMATCH sub-error from disagg page-discard verify

### DIFF
--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -206,6 +206,11 @@ sub_errors = [
         than the eviction updates trigger or the eviction dirty trigger allows. Eviction
         cannot reclaim content pinned by an uncommitted transaction, so the transaction
         cannot succeed against the configured cache size and has been rolled back.'''),
+    Error('WT_VERIFY_PAGE_ID_MISMATCH', -32017,
+        "Verify found a mismatch between the btree and PALI page ID lists", '''
+        This sub-level error indicates that the disaggregated-storage verify pass found
+        one or more page IDs present in the btree walk but absent from the page log (or
+        vice versa), meaning a page was either leaked or discarded prematurely.'''),
 ]
 
 # Update the #defines in the wiredtiger.h.in file.

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1714,13 +1714,13 @@ __verify_compare_page_id_lists(WT_SESSION_IMPL *session, uint64_t *btree_ids, si
             __wt_verbose_error(session, WT_VERB_VERIFY,
               "Unreferenced page was not discarded: PALI[%" PRIu32 "] %" PRIu64, index_in_pali,
               id_in_pali);
-            WT_TRET(EINVAL);
+            WT_TRET(WT_ERROR);
             index_in_pali++;
         } else if (index_in_pali == num_pali || id_in_pali > id_in_btree) {
             __wt_verbose_error(session, WT_VERB_VERIFY,
               "Discarded page is still in use: BTREE[%" PRIu32 "] %" PRIu64, index_in_btree,
               id_in_btree);
-            WT_TRET(EINVAL);
+            WT_TRET(WT_ERROR);
             index_in_btree++;
         } else {
             index_in_pali++;
@@ -1843,7 +1843,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
           "Mismatch in the number of page IDs found from PALI and btree walk: PALI %" PRIu64
           " Btree walk %" WT_SIZET_FMT,
           (uint64_t)num_pages_found_in_pali, list.count);
-        WT_TRET(EINVAL);
+        WT_TRET(WT_ERROR);
     }
 
     /*
@@ -1852,10 +1852,11 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      */
     __wt_qsort(list.ids, list.count, sizeof(uint64_t), __verify_compare_page_id);
 
-    WT_ERR_MSG_CHK(session,
-      __verify_compare_page_id_lists(
-        session, list.ids, list.count, (const uint64_t *)item->data, num_pages_found_in_pali),
-      "Page discard verification found mismatches");
+    WT_TRET(__verify_compare_page_id_lists(
+      session, list.ids, list.count, (const uint64_t *)item->data, num_pages_found_in_pali));
+    if (ret != 0)
+        WT_ERR_SUB(session, WT_ERROR, WT_VERIFY_PAGE_ID_MISMATCH,
+          "Page discard verification found mismatches");
 
 err:
     __wt_free(session, list.ids);

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -84,6 +84,10 @@ __wt_wiredtiger_error(int error)
         return (
           "WT_TXN_TOO_LARGE_FOR_CACHE: Transaction dirty content alone exceeds the eviction "
           "updates or dirty trigger");
+    case WT_VERIFY_PAGE_ID_MISMATCH:
+        return (
+          "WT_VERIFY_PAGE_ID_MISMATCH: Verify found a mismatch between the btree and PALI page ID "
+          "lists");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -168,6 +168,11 @@ updates trigger or the eviction dirty trigger allows. Eviction cannot reclaim co
 uncommitted transaction, so the transaction cannot succeed against the configured cache size and has
 been rolled back.
 
+@par \c WT_VERIFY_PAGE_ID_MISMATCH
+This sub-level error indicates that the disaggregated-storage verify pass found one or more page IDs
+present in the btree walk but absent from the page log (or vice versa), meaning a page was either
+leaked or discarded prematurely.
+
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif
 

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -4552,6 +4552,14 @@ const char *wiredtiger_repair(WT_CONNECTION *connection, const char *config)
  * rolled back.
  */
 #define	WT_TXN_TOO_LARGE_FOR_CACHE	(-32016)
+/*!
+ * Verify found a mismatch between the btree and PALI page ID lists.
+ * This sub-level error indicates that the disaggregated-storage verify pass
+ * found one or more page IDs present in the btree walk but absent from the page
+ * log (or vice versa), meaning a page was either leaked or discarded
+ * prematurely.
+ */
+#define	WT_VERIFY_PAGE_ID_MISMATCH	(-32017)
 /*
  * Sub-level error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.

--- a/test/catch2/misc_tests/test_verify_compare_page_id_lists.cpp
+++ b/test/catch2/misc_tests/test_verify_compare_page_id_lists.cpp
@@ -9,7 +9,7 @@
 /*
  * Unit tests for __verify_compare_page_id_lists.
  *
- * The merge-compares two sorted arrays returning EINVAL on any mismatch.
+ * The merge-compares two sorted arrays returning WT_ERROR on any mismatch.
  */
 
 #include <catch2/catch.hpp>
@@ -40,36 +40,36 @@ TEST_CASE("verify_compare_page_id_lists merge loop", "[verify][disagg]")
 
     SECTION("PALI exhausted first")
     {
-        CHECK(run_compare(ms, {1, 2, 3}, {1, 2}) == EINVAL);
+        CHECK(run_compare(ms, {1, 2, 3}, {1, 2}) == WT_ERROR);
     }
 
     SECTION("btree exhausted first")
     {
-        CHECK(run_compare(ms, {1, 2}, {1, 2, 3}) == EINVAL);
+        CHECK(run_compare(ms, {1, 2}, {1, 2, 3}) == WT_ERROR);
     }
 
     SECTION("interleaved mismatches")
     {
-        CHECK(run_compare(ms, {1, 2, 3}, {1, 3, 4}) == EINVAL);
+        CHECK(run_compare(ms, {1, 2, 3}, {1, 3, 4}) == WT_ERROR);
     }
 
     SECTION("all entries mismatched")
     {
-        CHECK(run_compare(ms, {1, 4}, {2, 3}) == EINVAL);
+        CHECK(run_compare(ms, {1, 4}, {2, 3}) == WT_ERROR);
     }
 
     SECTION("empty PALI")
     {
-        CHECK(run_compare(ms, {1, 2, 3}, {}) == EINVAL);
+        CHECK(run_compare(ms, {1, 2, 3}, {}) == WT_ERROR);
     }
 
     SECTION("empty btree")
     {
-        CHECK(run_compare(ms, {}, {1, 2, 3}) == EINVAL);
+        CHECK(run_compare(ms, {}, {1, 2, 3}) == WT_ERROR);
     }
 
     SECTION("multiple trailing mismatches on each side")
     {
-        CHECK(run_compare(ms, {1, 2, 3, 4}, {1, 2, 5, 6}) == EINVAL);
+        CHECK(run_compare(ms, {1, 2, 3, 4}, {1, 2, 5, 6}) == WT_ERROR);
     }
 }


### PR DESCRIPTION
Change `__verify_compare_page_id_lists` and its caller in `__verify_page_discard` to return `WT_ERROR` with new sub-error `WT_VERIFY_PAGE_ID_MISMATCH` instead of `EINVAL`, so disaggregated-storage page-list mismatches no longer surface as the misleading "Invalid argument".