### PR TITLE
WT-18134 Roll back parallel-checkpoint worker transactions on failure

### DIFF
--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -534,3 +534,43 @@ __wti_checkpoint_parallel_commit(WT_SESSION_IMPL *session)
 
     return (0);
 }
+
+/*
+ * __checkpoint_parallel_thread_rollback --
+ *     Roll back the transaction associated with the thread.
+ */
+static int
+__checkpoint_parallel_thread_rollback(WT_SESSION_IMPL *session, WT_THREAD *thread)
+{
+    WT_UNUSED(thread);
+
+    if (F_ISSET(session->txn, WT_TXN_RUNNING)) {
+        __wt_verbose(session, WT_VERB_CHECKPOINT,
+          "Checkpoint page reconciliation thread %u rolling back the transaction", thread->id);
+        WT_RET(__wt_txn_rollback(session, NULL, false));
+    }
+
+    return (0);
+}
+
+/*
+ * __wti_checkpoint_parallel_rollback --
+ *     Roll back all transactions for the checkpoint page reconciliation workers.
+ */
+int
+__wti_checkpoint_parallel_rollback(WT_SESSION_IMPL *session)
+{
+    WT_CHECKPOINT_RECONCILE_THREADS *ckpt_threads;
+
+    if (!WT_PARALLEL_CHECKPOINTS_ENABLED(session))
+        return (0);
+
+    WT_ASSERT_ALWAYS(session, __checkpoint_parallel_work_queue_empty(session),
+      "Checkpoint page reconciliation workers still have work to do");
+
+    ckpt_threads = S2C(session)->ckpt_reconcile_threads;
+    WT_RET(__wt_thread_group_foreach(
+      session, &ckpt_threads->thread_group, __checkpoint_parallel_thread_rollback));
+
+    return (0);
+}

--- a/src/checkpoint/checkpoint_private.h
+++ b/src/checkpoint/checkpoint_private.h
@@ -102,6 +102,8 @@ extern int __wti_checkpoint_parallel_commit(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_checkpoint_parallel_release_snapshot(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_checkpoint_parallel_rollback(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 
 #ifdef HAVE_UNITTEST
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2129,6 +2129,14 @@ err:
         WT_STAT_CONN_INCR(session, checkpoints_total_failed);
     }
 
+    /*
+     * Roll back any parallel-checkpoint worker transactions the coordinator did not commit, before
+     * any early-return path below can skip the coordinator's own rollback and leave them running
+     * until connection teardown.
+     */
+    if (failed)
+        WT_TRET(__wti_checkpoint_parallel_rollback(session));
+
     session->isolation = txn->isolation = WT_ISO_READ_UNCOMMITTED;
     if (tracking) {
         if (__wt_meta_track_off(session, false, failed) != 0)

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2127,15 +2127,12 @@ err:
     if (failed) {
         conn->modified = true;
         WT_STAT_CONN_INCR(session, checkpoints_total_failed);
-    }
-
-    /*
-     * Roll back any parallel-checkpoint worker transactions the coordinator did not commit, before
-     * any early-return path below can skip the coordinator's own rollback and leave them running
-     * until connection teardown.
-     */
-    if (failed)
+        /*
+         * Roll back any parallel-checkpoint worker transactions before any early-return path below
+         * can skip the coordinator's own rollback and leave them running until connection teardown.
+         */
         WT_TRET(__wti_checkpoint_parallel_rollback(session));
+    }
 
     session->isolation = txn->isolation = WT_ISO_READ_UNCOMMITTED;
     if (tracking) {

--- a/test/suite/test_corrupt02.py
+++ b/test/suite/test_corrupt02.py
@@ -38,7 +38,6 @@ from metadata_helper import checkpoint_extent_list_blocks
 # as an ordinary WT_PANIC the application can handle, not a crash.
 @wttest.skip_for_hook("tiered", "corrupts local block files not used by tiered storage")
 @wttest.skip_for_hook("disagg", "corrupts blocks which are not relevant for disagg")
-@wttest.skip_for_hook("parallel_checkpoint", "FIXME-WT-18134: deliberately fails a checkpoint; parallel checkpoint tears down worker threads mid-transaction")
 class test_corrupt02(wttest.WiredTigerTestCase):
     conn_config = ('cache_size=50MB,statistics=(fast),debug_mode=(corruption_abort=false),'
                    'eviction_dirty_trigger=50,eviction_updates_trigger=50')


### PR DESCRIPTION
Add `__wti_checkpoint_parallel_rollback` (mirror of __wti_checkpoint_parallel_rollback_commit) and invoke it from the `err:` block of `__txn_checkpoint`, placed before `__wt_meta_track_off`'s early-return so worker transactions are cleaned up on every failure path, including the disaggregated `WT_RET_PANIC` branch. Re-enable `test_corrupt02` under `--hook parallel_checkpoint` as the regression test.