### PR TITLE
WT-14595 Scope the reconciliation and eviction timelines to the calls that own them

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -657,7 +657,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 
     /* Track next calls during HS wrapup */
     if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
-        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+        WT_STAT_CONN_INCR(session, rec_hs_wrapup_next_prev_calls);
 
     flags = WT_READ_NO_SPLIT | WT_READ_SKIP_INTL; /* tree walk flags */
     if (truncating)

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -575,7 +575,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 
     /* Track prev calls during HS wrapup */
     if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
-        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+        WT_STAT_CONN_INCR(session, rec_hs_wrapup_next_prev_calls);
 
     /* tree walk flags */
     flags = WT_READ_NO_SPLIT | WT_READ_PREV | WT_READ_SKIP_INTL;

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1266,7 +1266,7 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 
     /* Write the new version of the leaf page to disk. */
     WT_ERR(__slvg_modify_init(session, page));
-    WT_ERR(__wt_reconcile(session, ref, cookie, WT_REC_VISIBILITY_ERR));
+    WT_ERR(__wt_reconcile(session, ref, cookie, WT_REC_VISIBILITY_ERR, NULL));
 
     /* Reset the page. */
     page->pg_var = save_col_var;
@@ -1917,7 +1917,7 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref, WT_S
 
     /* Write the new version of the leaf page to disk. */
     WT_ERR(__slvg_modify_init(session, page));
-    WT_ERR(__wt_reconcile(session, ref, cookie, WT_REC_VISIBILITY_ERR));
+    WT_ERR(__wt_reconcile(session, ref, cookie, WT_REC_VISIBILITY_ERR, NULL));
 
     /* Reset the page. */
     page->entries += skip_stop;

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -368,7 +368,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 ++leaf_pages;
                 reconcile_start = __wt_clock(session);
                 WT_ERR(__wt_reconcile(session, walk, NULL,
-                  __sync_page_rec_flags(session, page, rec_flags, checkpoint_scrub)));
+                  __sync_page_rec_flags(session, page, rec_flags, checkpoint_scrub), NULL));
                 reconcile_time += __wt_clock(session) - reconcile_start;
             }
         }
@@ -552,7 +552,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             } else {
                 reconcile_start = __wt_clock(session);
                 WT_ERR(__wt_reconcile(session, walk, NULL,
-                  __sync_page_rec_flags(session, page, rec_flags, checkpoint_scrub)));
+                  __sync_page_rec_flags(session, page, rec_flags, checkpoint_scrub), NULL));
                 reconcile_time += __wt_clock(session) - reconcile_start;
             }
 

--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -233,7 +233,7 @@ __checkpoint_parallel_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
 
         time_rec_start = __wt_clock(session);
         WT_WITH_DHANDLE(session, entry->dhandle,
-          ret = __wt_reconcile(session, entry->ref, NULL, reconcile_flags));
+          ret = __wt_reconcile(session, entry->ref, NULL, reconcile_flags, NULL));
 
         /* Update the reconciliation time and the statistics. */
         entry->reconcile_time = __wt_clock(session) - time_rec_start;

--- a/src/evict/evict.h
+++ b/src/evict/evict.h
@@ -16,9 +16,9 @@
  */
 struct __wt_evict_timeline {
     uint64_t evict_start;
+    uint64_t evict_finish;
     uint64_t reentry_hs_evict_start;
     uint64_t reentry_hs_evict_finish;
-    uint64_t evict_finish;
     bool reentry_hs_eviction;
 
     /* Filled in by the reconciliation this eviction drove, if it ran one. */

--- a/src/evict/evict.h
+++ b/src/evict/evict.h
@@ -10,6 +10,21 @@
 
 #include "evict_private.h"
 
+/*
+ * The important timestamps of each stage in an eviction. If an eviction takes a long time and times
+ * out, we can trace the time usage of each stage from this information.
+ */
+struct __wt_evict_timeline {
+    uint64_t evict_start;
+    uint64_t reentry_hs_evict_start;
+    uint64_t reentry_hs_evict_finish;
+    uint64_t evict_finish;
+    bool reentry_hs_eviction;
+
+    /* Filled in by the reconciliation this eviction drove, if it ran one. */
+    WT_RECONCILE_TIMELINE reconcile;
+};
+
 struct __wt_evict {
     wt_shared volatile uint64_t eviction_progress; /* Eviction progress count */
     uint64_t last_eviction_progress;               /* Tracked eviction progress */

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -91,7 +91,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             if (!WT_IS_HS(btree->dhandle) && !WT_IS_METADATA(dhandle) &&
               !WT_IS_DISAGG_META(dhandle))
                 rec_flags |= WT_REC_HS;
-            WT_ERR(__wt_reconcile(session, ref, NULL, rec_flags));
+            WT_ERR(__wt_reconcile(session, ref, NULL, rec_flags, NULL));
         }
 
         /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -11,7 +11,7 @@
 static int __evict_page_clean_update(WT_SESSION_IMPL *, WT_REF *, uint32_t);
 static int __evict_page_dirty_update(WT_SESSION_IMPL *, WT_REF *, uint32_t);
 static bool __evict_page_victim_cache_eligible(WT_SESSION_IMPL *, WT_REF *);
-static int __evict_reconcile(WT_SESSION_IMPL *, WT_REF *, uint32_t);
+static int __evict_reconcile(WT_SESSION_IMPL *, WT_REF *, uint32_t, WT_RECONCILE_TIMELINE *);
 static int __evict_review(WT_SESSION_IMPL *, WT_REF *, uint32_t, bool *);
 
 /*
@@ -280,21 +280,20 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
  *
  */
 static void
-__evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
+__evict_stats_update(WT_SESSION_IMPL *session, WT_EVICT_TIMELINE *timeline, uint8_t flags)
 {
     WT_CONNECTION_IMPL *conn;
     uint64_t eviction_time, eviction_time_milliseconds;
     bool ingest = F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT);
     conn = S2C(session);
 
-    if (session->evict_timeline.reentry_hs_eviction) {
-        session->evict_timeline.reentry_hs_evict_finish = __wt_clock(session);
-        eviction_time = WT_CLOCKDIFF_US(session->evict_timeline.reentry_hs_evict_finish,
-          session->evict_timeline.reentry_hs_evict_start);
+    if (timeline->reentry_hs_eviction) {
+        timeline->reentry_hs_evict_finish = __wt_clock(session);
+        eviction_time =
+          WT_CLOCKDIFF_US(timeline->reentry_hs_evict_finish, timeline->reentry_hs_evict_start);
     } else {
-        session->evict_timeline.evict_finish = __wt_clock(session);
-        eviction_time = WT_CLOCKDIFF_US(
-          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
+        timeline->evict_finish = __wt_clock(session);
+        eviction_time = WT_CLOCKDIFF_US(timeline->evict_finish, timeline->evict_start);
     }
     if (LF_ISSET(WT_EVICT_STATS_SUCCESS)) {
         if (LF_ISSET(WT_EVICT_STATS_URGENT)) {
@@ -332,7 +331,7 @@ __evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
         if (ingest)
             WT_STAT_CONN_INCR(session, eviction_fail_ingest);
     }
-    if (!session->evict_timeline.reentry_hs_eviction) {
+    if (!timeline->reentry_hs_eviction) {
         eviction_time_milliseconds = eviction_time / WT_THOUSAND;
         __wt_atomic_stats_max_uint64(
           &conn->evict->evict_max_ms_per_checkpoint, eviction_time_milliseconds);
@@ -342,19 +341,17 @@ __evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
               "Eviction took more than 1 minute (%" PRIu64 "us). Building disk image took %" PRIu64
               "us. History store wrapup took %" PRIu64 "us.",
               eviction_time,
-              WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
-                session->reconcile_timeline.image_build_start),
-              WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
-                session->reconcile_timeline.hs_wrapup_start));
+              WT_CLOCKDIFF_US(
+                timeline->reconcile.image_build_finish, timeline->reconcile.image_build_start),
+              WT_CLOCKDIFF_US(
+                timeline->reconcile.hs_wrapup_finish, timeline->reconcile.hs_wrapup_start));
     } else {
         /*
          * We are in the reentrant history store eviction inside a data store reconciliation. Add to
          * the total time taken to do the reentrant history store eviction.
          */
         session->total_reentry_hs_eviction_time +=
-          WT_CLOCKDIFF_MS(session->evict_timeline.reentry_hs_evict_finish,
-            session->evict_timeline.reentry_hs_evict_start);
-        session->evict_timeline.reentry_hs_eviction = false;
+          WT_CLOCKDIFF_MS(timeline->reentry_hs_evict_finish, timeline->reentry_hs_evict_start);
     }
 }
 
@@ -381,6 +378,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
+    WT_EVICT_TIMELINE timeline;
     WT_PAGE *page;
     uint64_t page_size;
     uint8_t stats_flags;
@@ -399,13 +397,13 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     if (tree_dead)
         LF_SET(WT_EVICT_CALL_NO_SPLIT);
 
-    /* As re-entry into eviction is possible, only clear the statistics on the first entry. */
-    if (__wt_session_gen((session), (WT_GEN_EVICT)) == 0) {
-        WT_CLEAR(session->evict_timeline);
-        session->evict_timeline.evict_start = __wt_clock(session);
-    } else {
-        session->evict_timeline.reentry_hs_eviction = true;
-        session->evict_timeline.reentry_hs_evict_start = __wt_clock(session);
+    /* Re-entry into eviction is possible; a nested eviction times itself separately. */
+    WT_CLEAR(timeline);
+    if (__wt_session_gen((session), (WT_GEN_EVICT)) == 0)
+        timeline.evict_start = __wt_clock(session);
+    else {
+        timeline.reentry_hs_eviction = true;
+        timeline.reentry_hs_evict_start = __wt_clock(session);
     }
 
     /*
@@ -516,7 +514,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
         WT_ASSERT(session,
           ref->page->disagg_info == NULL ||
             __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader));
-        WT_ERR(__evict_reconcile(session, ref, flags));
+        WT_ERR(__evict_reconcile(session, ref, flags, &timeline.reconcile));
     }
 
     /* After this spot, the only recoverable failure is EBUSY. */
@@ -580,7 +578,7 @@ err:
 done:
     if (ret == 0)
         FLD_SET(stats_flags, WT_EVICT_STATS_SUCCESS);
-    __evict_stats_update(session, stats_flags);
+    __evict_stats_update(session, &timeline, stats_flags);
 
     /* Leave any local eviction generation. */
     WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
@@ -1475,7 +1473,8 @@ __evict_snapshot_setup(
  *     Reconcile the page for eviction.
  */
 static int
-__evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
+__evict_reconcile(
+  WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, WT_RECONCILE_TIMELINE *timeline)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
@@ -1568,10 +1567,10 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
 
     /* Force read-committed isolation if we set up a snapshot to reconcile under. */
     if (snap_state != WT_EVICT_SNAP_NONE)
-        WT_WITH_TXN_ISOLATION(
-          session, WT_ISO_READ_COMMITTED, ret = __wt_reconcile(session, ref, NULL, flags));
+        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_COMMITTED,
+          ret = __wt_reconcile(session, ref, NULL, flags, timeline));
     else
-        ret = __wt_reconcile(session, ref, NULL, flags);
+        ret = __wt_reconcile(session, ref, NULL, flags, timeline);
 
     if (ret != 0)
         WT_STAT_CONN_INCR(session, eviction_fail_in_reconciliation);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -351,7 +351,7 @@ __evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
          * We are in the reentrant history store eviction inside a data store reconciliation. Add to
          * the total time taken to do the reentrant history store eviction.
          */
-        session->reconcile_timeline.total_reentry_hs_eviction_time +=
+        session->total_reentry_hs_eviction_time +=
           WT_CLOCKDIFF_MS(session->evict_timeline.reentry_hs_evict_finish,
             session->evict_timeline.reentry_hs_evict_start);
         session->evict_timeline.reentry_hs_eviction = false;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1473,8 +1473,8 @@ __evict_snapshot_setup(
  *     Reconcile the page for eviction.
  */
 static int
-__evict_reconcile(
-  WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, WT_RECONCILE_TIMELINE *timeline)
+__evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags,
+  WT_RECONCILE_TIMELINE *reconcile_timelinep)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
@@ -1568,9 +1568,9 @@ __evict_reconcile(
     /* Force read-committed isolation if we set up a snapshot to reconcile under. */
     if (snap_state != WT_EVICT_SNAP_NONE)
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_COMMITTED,
-          ret = __wt_reconcile(session, ref, NULL, flags, timeline));
+          ret = __wt_reconcile(session, ref, NULL, flags, reconcile_timelinep));
     else
-        ret = __wt_reconcile(session, ref, NULL, flags, timeline);
+        ret = __wt_reconcile(session, ref, NULL, flags, reconcile_timelinep);
 
     if (ret != 0)
         WT_STAT_CONN_INCR(session, eviction_fail_in_reconciliation);

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -213,8 +213,9 @@ struct __wt_session_impl {
 #endif
 
     /*
-     * Time the nested evictions of history store pages have taken during the reconciliation
-     * currently in progress. Eviction accumulates into this, so it outlives any single call.
+     * Time the nested evictions of history store pages have taken, accumulated by eviction from
+     * frames a reconciliation cannot reach. It only grows: a reconciliation takes the difference
+     * across itself rather than resetting it, so nested reconciliations do not disturb each other.
      */
     uint64_t total_reentry_hs_eviction_time;
 

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -212,7 +212,11 @@ struct __wt_session_impl {
     } *scratch_track;
 #endif
 
-    /* Record the important timestamps of each stage in an reconciliation. */
+    /*
+     * The important timestamps of each stage in a reconciliation. Reconciliation owns a timeline
+     * per call and publishes it here once it completes, so this describes the last reconciliation
+     * to finish rather than one in progress.
+     */
     struct __wt_reconcile_timeline {
         uint64_t reconcile_start;
         uint64_t image_build_start;
@@ -220,8 +224,13 @@ struct __wt_session_impl {
         uint64_t hs_wrapup_start;
         uint64_t hs_wrapup_finish;
         uint64_t reconcile_finish;
-        uint64_t total_reentry_hs_eviction_time;
     } reconcile_timeline;
+
+    /*
+     * Time the nested evictions of history store pages have taken during the reconciliation
+     * currently in progress. Eviction accumulates into this, so it outlives any single call.
+     */
+    uint64_t total_reentry_hs_eviction_time;
 
     /* Record statistics in an reconciliation. */
     struct __wt_reconcile_stats {

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -219,11 +219,6 @@ struct __wt_session_impl {
      */
     uint64_t total_reentry_hs_eviction_time;
 
-    /* Record statistics in an reconciliation. */
-    struct __wt_reconcile_stats {
-        uint64_t hs_wrapup_next_prev_calls;
-    } reconcile_stats;
-
     WT_ITEM err; /* Error buffer */
     WT_ERROR_INFO err_info;
 

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -213,20 +213,6 @@ struct __wt_session_impl {
 #endif
 
     /*
-     * The important timestamps of each stage in a reconciliation. Reconciliation owns a timeline
-     * per call and publishes it here once it completes, so this describes the last reconciliation
-     * to finish rather than one in progress.
-     */
-    struct __wt_reconcile_timeline {
-        uint64_t reconcile_start;
-        uint64_t image_build_start;
-        uint64_t image_build_finish;
-        uint64_t hs_wrapup_start;
-        uint64_t hs_wrapup_finish;
-        uint64_t reconcile_finish;
-    } reconcile_timeline;
-
-    /*
      * Time the nested evictions of history store pages have taken during the reconciliation
      * currently in progress. Eviction accumulates into this, so it outlives any single call.
      */
@@ -236,18 +222,6 @@ struct __wt_session_impl {
     struct __wt_reconcile_stats {
         uint64_t hs_wrapup_next_prev_calls;
     } reconcile_stats;
-
-    /*
-     * Record the important timestamps of each stage in an eviction. If an eviction takes a long
-     * time and times out, we can trace the time usage of each stage from this information.
-     */
-    struct __wt_evict_timeline {
-        uint64_t evict_start;
-        uint64_t reentry_hs_evict_start;
-        uint64_t reentry_hs_evict_finish;
-        uint64_t evict_finish;
-        bool reentry_hs_eviction;
-    } evict_timeline;
 
     WT_ITEM err; /* Error buffer */
     WT_ERROR_INFO err_info;

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -631,6 +631,7 @@ typedef uint64_t wt_timestamp_t;
 #include "btmem.h"
 #include "btree.h"
 #include "cache.h"
+#include "../reconcile/reconcile.h"
 #include "../evict/evict.h"
 #include "capacity.h"
 #include "cell.h"
@@ -651,7 +652,6 @@ typedef uint64_t wt_timestamp_t;
 #include "meta.h" /* required by block.h */
 #include "optrack.h"
 #include "os.h"
-#include "../reconcile/reconcile.h"
 #include "rollback_to_stable.h"
 #include "schema.h"
 #include "tiered.h"

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -379,8 +379,6 @@ struct __wt_prefetch_queue_entry;
 typedef struct __wt_prefetch_queue_entry WT_PREFETCH_QUEUE_ENTRY;
 struct __wt_process;
 typedef struct __wt_process WT_PROCESS;
-struct __wt_reconcile_stats;
-typedef struct __wt_reconcile_stats WT_RECONCILE_STATS;
 struct __wt_reconcile_timeline;
 typedef struct __wt_reconcile_timeline WT_RECONCILE_TIMELINE;
 struct __wt_recovery_timeline;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3555,7 +3555,6 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
 
     /* Set a flag in the session to track that we're in HS wrapup */
     F_SET(session, WT_SESSION_HS_WRAPUP);
-    session->reconcile_stats.hs_wrapup_next_prev_calls = 0;
 
     /*
      * Sanity check: Can't insert updates into history store from the history store itself, the
@@ -3588,9 +3587,6 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
             }
         }
     }
-
-    WT_STAT_CONN_INCRV(
-      session, rec_hs_wrapup_next_prev_calls, session->reconcile_stats.hs_wrapup_next_prev_calls);
 
     __wt_verbose_debug1(session, WT_VERB_RECONCILE,
       "finished moving updates to the history store for %p", (void *)r->ref);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -190,7 +190,6 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     /*
      * Reconcile the page. The reconciliation code unlocks the page as soon as possible, and returns
      * that information.
-     *
      */
     ret = __reconcile(session, ref, salvage, flags, &page_locked);
 
@@ -312,6 +311,18 @@ __reconcile_post_wrapup(
 }
 
 /*
+ * __rec_timeline_publish --
+ *     Stamp a reconciliation as finished and publish its timeline. Eviction reports these timings
+ *     after reconciliation returns, and does so whether or not it succeeded.
+ */
+static WT_INLINE void
+__rec_timeline_publish(WT_SESSION_IMPL *session, WT_RECONCILE_TIMELINE *timeline)
+{
+    timeline->reconcile_finish = __wt_clock(session);
+    session->reconcile_timeline = *timeline;
+}
+
+/*
  * __reconcile --
  *     Reconcile an in-memory page into its on-disk format, and write it.
  */
@@ -325,7 +336,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_PAGE *page;
     WT_RECONCILE_TIMELINE timeline;
     WTI_RECONCILE *r;
-    uint64_t rec, rec_finish, rec_hs_wrapup, rec_img_build, rec_start;
+    uint64_t rec, rec_hs_wrapup, rec_img_build, rec_start;
     void *addr;
 
     btree = S2BT(session);
@@ -447,6 +458,10 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
           "Reconciliation trying to free the page that has been written to disk");
         WT_IGNORE_RET(__rec_write_err(session, r, page));
         WT_IGNORE_RET(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
+
+        /* Publish what was measured before the failure; stale timings are worse than partial. */
+        __rec_timeline_publish(session, &timeline);
+
         /*
          * This return statement covers non-panic error scenarios; any failure beyond this point is
          * a panic. Conversely, no return prior to this point should use the "err" label.
@@ -480,6 +495,9 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         WT_WITH_PAGE_INDEX(session, ret = __rec_root_write(session, page, flags));
         if (ret != 0)
             goto err;
+
+        /* Publish over the nested reconciliation: the caller asked about this page. */
+        __rec_timeline_publish(session, &timeline);
         return (0);
     }
 
@@ -494,12 +512,11 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      * Track the longest reconciliation and time spent in each reconciliation stage, ignoring races
      * (it's just a statistic).
      */
-    rec_finish = __wt_clock(session);
-    timeline.reconcile_finish = rec_finish;
+    __rec_timeline_publish(session, &timeline);
 
     rec_hs_wrapup = WT_CLOCKDIFF_MS(timeline.hs_wrapup_finish, timeline.hs_wrapup_start);
     rec_img_build = WT_CLOCKDIFF_MS(timeline.image_build_finish, timeline.image_build_start);
-    rec = WT_CLOCKDIFF_MS(rec_finish, rec_start);
+    rec = WT_CLOCKDIFF_MS(timeline.reconcile_finish, rec_start);
 
     /* Sanity check timings (WT_DAY is in seconds, and we have milliseconds). */
     WT_ASSERT(session, rec < WT_DAY * WT_THOUSAND);
@@ -513,9 +530,6 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         conn->rec_maximum_milliseconds = rec;
     if (session->total_reentry_hs_eviction_time > conn->evict->reentry_hs_eviction_ms)
         conn->evict->reentry_hs_eviction_ms = session->total_reentry_hs_eviction_time;
-
-    /* Publish the completed timeline for the eviction statistics, which run after this returns. */
-    session->reconcile_timeline = timeline;
 
 err:
     if (ret != 0) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -24,7 +24,8 @@ static int __rec_write_err(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_PAGE *);
 static int __rec_wrapup_decrease_disagg_size(
   WT_SESSION_IMPL *, WTI_RECONCILE *, const uint8_t *, size_t);
 static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_RECONCILE_TIMELINE *);
-static int __reconcile(WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_t, bool *);
+static int __reconcile(
+  WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_t, bool *, WT_RECONCILE_TIMELINE *);
 
 /*
  * __rec_save_disk_image --
@@ -90,7 +91,8 @@ __rec_track_saved_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
  *     Reconcile an in-memory page into its on-disk format, and write it.
  */
 int
-__wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, uint32_t flags)
+__wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, uint32_t flags,
+  WT_RECONCILE_TIMELINE *timeline)
 {
     WT_BTREE *btree;
     WT_DECL_RET;
@@ -191,7 +193,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
      * Reconcile the page. The reconciliation code unlocks the page as soon as possible, and returns
      * that information.
      */
-    ret = __reconcile(session, ref, salvage, flags, &page_locked);
+    ret = __reconcile(session, ref, salvage, flags, &page_locked, timeline);
 
     if (ret != 0)
         F_SET_ATOMIC_16(ref->page, WT_PAGE_REC_FAIL);
@@ -312,14 +314,16 @@ __reconcile_post_wrapup(
 
 /*
  * __rec_timeline_publish --
- *     Stamp a reconciliation as finished and publish its timeline. Eviction reports these timings
+ *     Stamp a reconciliation as finished and hand its timeline back. Eviction reports these timings
  *     after reconciliation returns, and does so whether or not it succeeded.
  */
 static WT_INLINE void
-__rec_timeline_publish(WT_SESSION_IMPL *session, WT_RECONCILE_TIMELINE *timeline)
+__rec_timeline_publish(
+  WT_SESSION_IMPL *session, WT_RECONCILE_TIMELINE *timeline, WT_RECONCILE_TIMELINE *published)
 {
     timeline->reconcile_finish = __wt_clock(session);
-    session->reconcile_timeline = *timeline;
+    if (published != NULL)
+        *published = *timeline;
 }
 
 /*
@@ -328,7 +332,7 @@ __rec_timeline_publish(WT_SESSION_IMPL *session, WT_RECONCILE_TIMELINE *timeline
  */
 static int
 __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, uint32_t flags,
-  bool *page_lockedp)
+  bool *page_lockedp, WT_RECONCILE_TIMELINE *published)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
@@ -460,7 +464,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         WT_IGNORE_RET(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
 
         /* Publish what was measured before the failure; stale timings are worse than partial. */
-        __rec_timeline_publish(session, &timeline);
+        __rec_timeline_publish(session, &timeline, published);
 
         /*
          * This return statement covers non-panic error scenarios; any failure beyond this point is
@@ -496,8 +500,8 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         if (ret != 0)
             goto err;
 
-        /* Publish over the nested reconciliation: the caller asked about this page. */
-        __rec_timeline_publish(session, &timeline);
+        /* The nested root write measured a different page; report this one. */
+        __rec_timeline_publish(session, &timeline, published);
         return (0);
     }
 
@@ -512,7 +516,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      * Track the longest reconciliation and time spent in each reconciliation stage, ignoring races
      * (it's just a statistic).
      */
-    __rec_timeline_publish(session, &timeline);
+    __rec_timeline_publish(session, &timeline, published);
 
     rec_hs_wrapup = WT_CLOCKDIFF_MS(timeline.hs_wrapup_finish, timeline.hs_wrapup_start);
     rec_img_build = WT_CLOCKDIFF_MS(timeline.image_build_finish, timeline.image_build_start);
@@ -739,7 +743,7 @@ __rec_root_write(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
      * Fake up a reference structure, and write the next root page.
      */
     __wt_root_ref_init(session, &fake_ref, next, page->type == WT_PAGE_COL_INT);
-    return (__wt_reconcile(session, &fake_ref, NULL, flags));
+    return (__wt_reconcile(session, &fake_ref, NULL, flags, NULL));
 
 err:
     __wt_page_out(session, &next);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -92,7 +92,7 @@ __rec_track_saved_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
  */
 int
 __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, uint32_t flags,
-  WT_RECONCILE_TIMELINE *timeline)
+  WT_RECONCILE_TIMELINE *reconcile_timelinep)
 {
     WT_BTREE *btree;
     WT_DECL_RET;
@@ -193,7 +193,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
      * Reconcile the page. The reconciliation code unlocks the page as soon as possible, and returns
      * that information.
      */
-    ret = __reconcile(session, ref, salvage, flags, &page_locked, timeline);
+    ret = __reconcile(session, ref, salvage, flags, &page_locked, reconcile_timelinep);
 
     if (ret != 0)
         F_SET_ATOMIC_16(ref->page, WT_PAGE_REC_FAIL);
@@ -314,16 +314,13 @@ __reconcile_post_wrapup(
 
 /*
  * __rec_timeline_publish --
- *     Stamp a reconciliation as finished and hand its timeline back. Eviction reports these timings
- *     after reconciliation returns, and does so whether or not it succeeded.
+ *     Stamp a reconciliation as finished. Eviction reports these timings after reconciliation
+ *     returns, and does so whether or not it succeeded.
  */
 static WT_INLINE void
-__rec_timeline_publish(
-  WT_SESSION_IMPL *session, WT_RECONCILE_TIMELINE *timeline, WT_RECONCILE_TIMELINE *published)
+__rec_timeline_publish(WT_SESSION_IMPL *session, WT_RECONCILE_TIMELINE *timeline)
 {
     timeline->reconcile_finish = __wt_clock(session);
-    if (published != NULL)
-        *published = *timeline;
 }
 
 /*
@@ -332,15 +329,15 @@ __rec_timeline_publish(
  */
 static int
 __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, uint32_t flags,
-  bool *page_lockedp, WT_RECONCILE_TIMELINE *published)
+  bool *page_lockedp, WT_RECONCILE_TIMELINE *reconcile_timelinep)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_PAGE *page;
-    WT_RECONCILE_TIMELINE timeline;
+    WT_RECONCILE_TIMELINE _timeline, *timeline;
     WTI_RECONCILE *r;
-    uint64_t rec, rec_hs_wrapup, rec_img_build, rec_start;
+    uint64_t rec, rec_hs_wrapup, rec_img_build, rec_reentry_hs, rec_start;
     void *addr;
 
     btree = S2BT(session);
@@ -360,16 +357,18 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_RET(__rec_init(session, ref, flags, salvage, &session->reconcile));
 
     /*
-     * The timeline is per-call state: reconciliation nests, and writing a root page reconciles the
-     * replacement root before this call has read its own timings.
+     * Fill in the caller's timeline where it wants one, otherwise a throwaway. The timeline is
+     * per-call state: reconciliation nests, and writing a root page reconciles the replacement root
+     * before this call has read its own timings.
      */
-    WT_CLEAR(timeline);
-    timeline.reconcile_start = rec_start;
-    session->total_reentry_hs_eviction_time = 0;
+    timeline = reconcile_timelinep != NULL ? reconcile_timelinep : &_timeline;
+    WT_CLEAR(*timeline);
+    timeline->reconcile_start = rec_start;
+    rec_reentry_hs = session->total_reentry_hs_eviction_time;
 
     r = session->reconcile;
 
-    timeline.image_build_start = __wt_clock(session);
+    timeline->image_build_start = __wt_clock(session);
 
     /* Reconcile the page. */
     switch (page->type) {
@@ -399,7 +398,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         break;
     }
 
-    timeline.image_build_finish = __wt_clock(session);
+    timeline->image_build_finish = __wt_clock(session);
 
     if (F_ISSET(r, WT_REC_CHECKPOINT))
         WT_STAT_CONN_SET(session, checkpoint_rec_blkcache_write, r->blkcache_write_time);
@@ -464,7 +463,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         WT_IGNORE_RET(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
 
         /* Publish what was measured before the failure; stale timings are worse than partial. */
-        __rec_timeline_publish(session, &timeline, published);
+        __rec_timeline_publish(session, timeline);
 
         /*
          * This return statement covers non-panic error scenarios; any failure beyond this point is
@@ -477,7 +476,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
       session, WT_VERB_RECONCILE, "finished building disk image for %p", (void *)ref);
 
     /* Wrap up the page reconciliation. Panic on failure. */
-    WT_ERR(__rec_write_wrapup(session, r, &timeline));
+    WT_ERR(__rec_write_wrapup(session, r, timeline));
     __rec_write_page_status(session, r);
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_COMPACTION_WRITE))
         WT_STAT_CONN_INCRV(
@@ -501,7 +500,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
             goto err;
 
         /* The nested root write measured a different page; report this one. */
-        __rec_timeline_publish(session, &timeline, published);
+        __rec_timeline_publish(session, timeline);
         return (0);
     }
 
@@ -516,11 +515,11 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      * Track the longest reconciliation and time spent in each reconciliation stage, ignoring races
      * (it's just a statistic).
      */
-    __rec_timeline_publish(session, &timeline, published);
+    __rec_timeline_publish(session, timeline);
 
-    rec_hs_wrapup = WT_CLOCKDIFF_MS(timeline.hs_wrapup_finish, timeline.hs_wrapup_start);
-    rec_img_build = WT_CLOCKDIFF_MS(timeline.image_build_finish, timeline.image_build_start);
-    rec = WT_CLOCKDIFF_MS(timeline.reconcile_finish, rec_start);
+    rec_hs_wrapup = WT_CLOCKDIFF_MS(timeline->hs_wrapup_finish, timeline->hs_wrapup_start);
+    rec_img_build = WT_CLOCKDIFF_MS(timeline->image_build_finish, timeline->image_build_start);
+    rec = WT_CLOCKDIFF_MS(timeline->reconcile_finish, rec_start);
 
     /* Sanity check timings (WT_DAY is in seconds, and we have milliseconds). */
     WT_ASSERT(session, rec < WT_DAY * WT_THOUSAND);
@@ -532,8 +531,10 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         conn->rec_maximum_image_build_milliseconds = rec_img_build;
     if (rec > conn->rec_maximum_milliseconds)
         conn->rec_maximum_milliseconds = rec;
-    if (session->total_reentry_hs_eviction_time > conn->evict->reentry_hs_eviction_ms)
-        conn->evict->reentry_hs_eviction_ms = session->total_reentry_hs_eviction_time;
+    /* The session counter only ever grows, so this reconciliation's share is the difference. */
+    rec_reentry_hs = session->total_reentry_hs_eviction_time - rec_reentry_hs;
+    if (rec_reentry_hs > conn->evict->reentry_hs_eviction_ms)
+        conn->evict->reentry_hs_eviction_ms = rec_reentry_hs;
 
 err:
     if (ret != 0) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -23,7 +23,7 @@ static void __rec_write_page_status(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __rec_write_err(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_PAGE *);
 static int __rec_wrapup_decrease_disagg_size(
   WT_SESSION_IMPL *, WTI_RECONCILE *, const uint8_t *, size_t);
-static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *);
+static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_RECONCILE_TIMELINE *);
 static int __reconcile(WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_t, bool *);
 
 /*
@@ -190,6 +190,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     /*
      * Reconcile the page. The reconciliation code unlocks the page as soon as possible, and returns
      * that information.
+     *
      */
     ret = __reconcile(session, ref, salvage, flags, &page_locked);
 
@@ -322,6 +323,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_PAGE *page;
+    WT_RECONCILE_TIMELINE timeline;
     WTI_RECONCILE *r;
     uint64_t rec, rec_finish, rec_hs_wrapup, rec_img_build, rec_start;
     void *addr;
@@ -341,14 +343,18 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
 
     /* Initialize the reconciliation structures for each new run. */
     WT_RET(__rec_init(session, ref, flags, salvage, &session->reconcile));
-    WT_CLEAR(session->reconcile_timeline);
-    session->reconcile_timeline.reconcile_start = rec_start;
+
+    /*
+     * The timeline is per-call state: reconciliation nests, and writing a root page reconciles the
+     * replacement root before this call has read its own timings.
+     */
+    WT_CLEAR(timeline);
+    timeline.reconcile_start = rec_start;
+    session->total_reentry_hs_eviction_time = 0;
 
     r = session->reconcile;
 
-    /* Only update if we are in the first entry into eviction. */
-    if (!session->evict_timeline.reentry_hs_eviction)
-        session->reconcile_timeline.image_build_start = __wt_clock(session);
+    timeline.image_build_start = __wt_clock(session);
 
     /* Reconcile the page. */
     switch (page->type) {
@@ -378,8 +384,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         break;
     }
 
-    if (!session->evict_timeline.reentry_hs_eviction)
-        session->reconcile_timeline.image_build_finish = __wt_clock(session);
+    timeline.image_build_finish = __wt_clock(session);
 
     if (F_ISSET(r, WT_REC_CHECKPOINT))
         WT_STAT_CONN_SET(session, checkpoint_rec_blkcache_write, r->blkcache_write_time);
@@ -453,7 +458,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
       session, WT_VERB_RECONCILE, "finished building disk image for %p", (void *)ref);
 
     /* Wrap up the page reconciliation. Panic on failure. */
-    WT_ERR(__rec_write_wrapup(session, r));
+    WT_ERR(__rec_write_wrapup(session, r, &timeline));
     __rec_write_page_status(session, r);
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_COMPACTION_WRITE))
         WT_STAT_CONN_INCRV(
@@ -490,19 +495,15 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      * (it's just a statistic).
      */
     rec_finish = __wt_clock(session);
-    session->reconcile_timeline.reconcile_finish = rec_finish;
+    timeline.reconcile_finish = rec_finish;
 
-    rec_hs_wrapup = WT_CLOCKDIFF_MS(
-      session->reconcile_timeline.hs_wrapup_finish, session->reconcile_timeline.hs_wrapup_start);
-    rec_img_build = WT_CLOCKDIFF_MS(session->reconcile_timeline.image_build_finish,
-      session->reconcile_timeline.image_build_start);
+    rec_hs_wrapup = WT_CLOCKDIFF_MS(timeline.hs_wrapup_finish, timeline.hs_wrapup_start);
+    rec_img_build = WT_CLOCKDIFF_MS(timeline.image_build_finish, timeline.image_build_start);
     rec = WT_CLOCKDIFF_MS(rec_finish, rec_start);
 
-    /*
-     * Sanity check timings (WT_DAY is in seconds, and we have milliseconds). FIXME-WT-12192
-     * rec_hs_wrapup and rec_img_build should also have an assertion here.
-     */
+    /* Sanity check timings (WT_DAY is in seconds, and we have milliseconds). */
     WT_ASSERT(session, rec < WT_DAY * WT_THOUSAND);
+    WT_ASSERT(session, rec_hs_wrapup <= rec && rec_img_build <= rec);
 
     if (rec_hs_wrapup > conn->rec_maximum_hs_wrapup_milliseconds)
         conn->rec_maximum_hs_wrapup_milliseconds = rec_hs_wrapup;
@@ -510,10 +511,11 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         conn->rec_maximum_image_build_milliseconds = rec_img_build;
     if (rec > conn->rec_maximum_milliseconds)
         conn->rec_maximum_milliseconds = rec;
-    if (session->reconcile_timeline.total_reentry_hs_eviction_time >
-      conn->evict->reentry_hs_eviction_ms)
-        conn->evict->reentry_hs_eviction_ms =
-          session->reconcile_timeline.total_reentry_hs_eviction_time;
+    if (session->total_reentry_hs_eviction_time > conn->evict->reentry_hs_eviction_ms)
+        conn->evict->reentry_hs_eviction_ms = session->total_reentry_hs_eviction_time;
+
+    /* Publish the completed timeline for the eviction statistics, which run after this returns. */
+    session->reconcile_timeline = timeline;
 
 err:
     if (ret != 0) {
@@ -2857,7 +2859,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     }
 
     WT_ERR(__wti_rec_split_finish(session, r));
-    WT_ERR(__rec_write_wrapup(session, r));
+    WT_ERR(__rec_write_wrapup(session, r, NULL));
     __rec_write_page_status(session, r);
 
     /* Mark the page's parent and the tree dirty. */
@@ -3057,7 +3059,7 @@ __rec_wrapup_decrease_disagg_size(
  *     Finish the reconciliation.
  */
 static int
-__rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
+__rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIMELINE *timeline)
 {
     WT_BM *bm;
     WT_BTREE *btree;
@@ -3088,9 +3090,11 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
      * fail, so try before clearing the page's previous reconciliation state.
      */
     if (F_ISSET(r, WT_REC_HS)) {
-        session->reconcile_timeline.hs_wrapup_start = __wt_clock(session);
+        /* Only reconciliation proper reaches the history store, and it always times the wrapup. */
+        WT_ASSERT(session, timeline != NULL);
+        timeline->hs_wrapup_start = __wt_clock(session);
         ret = __rec_hs_wrapup(session, r);
-        session->reconcile_timeline.hs_wrapup_finish = __wt_clock(session);
+        timeline->hs_wrapup_finish = __wt_clock(session);
         WT_RET(ret);
     }
 

--- a/src/reconcile/reconcile.h
+++ b/src/reconcile/reconcile.h
@@ -53,7 +53,8 @@ extern int __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
 extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage,
-  uint32_t flags, WT_RECONCILE_TIMELINE *timeline) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint32_t flags, WT_RECONCILE_TIMELINE *reconcile_timelinep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);

--- a/src/reconcile/reconcile.h
+++ b/src/reconcile/reconcile.h
@@ -32,11 +32,11 @@
 
 /* The important timestamps of each stage in a reconciliation, owned by the reconciliation. */
 struct __wt_reconcile_timeline {
-    uint64_t reconcile_start;
-    uint64_t image_build_start;
-    uint64_t image_build_finish;
     uint64_t hs_wrapup_start;
     uint64_t hs_wrapup_finish;
+    uint64_t image_build_start;
+    uint64_t image_build_finish;
+    uint64_t reconcile_start;
     uint64_t reconcile_finish;
 };
 

--- a/src/reconcile/reconcile.h
+++ b/src/reconcile/reconcile.h
@@ -30,6 +30,16 @@
 #define WT_REC_VISIBLE_NO_SNAPSHOT 0x2000u
 /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
 
+/* The important timestamps of each stage in a reconciliation, owned by the reconciliation. */
+struct __wt_reconcile_timeline {
+    uint64_t reconcile_start;
+    uint64_t image_build_start;
+    uint64_t image_build_finish;
+    uint64_t hs_wrapup_start;
+    uint64_t hs_wrapup_finish;
+    uint64_t reconcile_finish;
+};
+
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
 extern int __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
@@ -43,7 +53,7 @@ extern int __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
 extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage,
-  uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint32_t flags, WT_RECONCILE_TIMELINE *timeline) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);


### PR DESCRIPTION
The ticket asked whether the maximum image-build time was computed correctly, pointing at timestamps taken conditionally and then differenced unconditionally, and at a re-entry flag whose value is undefined outside eviction.

## What was wrong

The timeline recording each reconciliation stage lived on the session, but reconciliation nests. Reconciling a page that splits the root writes the replacement root, which reconciles again through `__rec_root_write`, and the nested call reset the timeline before the enclosing one had read it. A temporary `depth == 1` assertion aborts immediately in `test_hs14`, on the ordinary checkpoint path:

```
__wt_reconcile -> __reconcile -> __rec_root_write -> __wt_reconcile
```

The image-build timestamps were also guarded on `evict_timeline.reentry_hs_eviction`, which is only maintained during eviction, while the difference between them was taken and reported whether or not they had been set.

## What changed

Both timelines are per-call state and now say so. `WT_RECONCILE_TIMELINE` moves to `reconcile.h`, `WT_EVICT_TIMELINE` to `evict.h`, embedding the reconciliation it drove:

- `__wt_evict` owns the eviction timeline as a local and passes it to the statistics update.
- `__wt_reconcile` takes a `WT_RECONCILE_TIMELINE *` and writes each stage straight into it as the stage is measured, falling back to a throwaway local for the callers that pass `NULL` (salvage, sync, checkpoint, `evict_file`, and the recursive root write). It is stamped finished on every exit, including failures, because eviction reports its timings whether or not it succeeded and stale numbers are worse than partial ones.
- The image-build timestamps are taken unconditionally, which is what the unconditional reporting always assumed.
- The re-entry flag is gone. It was session state that only eviction maintained; as part of a per-call local there is no stale value left behind to read.

Two counters that eviction and cursor code write from frames a reconciliation cannot reach are handled separately:

- Nested history-store eviction time stays on the session, but reconciliation now takes the difference across itself instead of resetting it, so nested reconciliations leave each other alone.
- The history-store wrapup cursor-call counter is gone: the two sites that counted the calls increment the connection statistic directly. Same session, same total.

Also replaces the `FIXME-WT-12192` comment with the assertions it asked for, now that the stage timings are well defined.

`sizeof(WT_SESSION_IMPL)` drops from 2144 to 2048.
