### PR TITLE
WT-18348 Track truncates in the unpublished durable minimum of a layered table

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1520,9 +1520,17 @@ __clayered_stable_replay_remove_int(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, 
     F_SET(upd, WT_UPDATE_RESTORED_FROM_INGEST);
 
     ret = __wt_row_modify(cbt, &cbt->iface.key, NULL, &upd, WT_UPDATE_INVALID, false, false);
-    if (ret != 0)
+    if (ret != 0) {
         __wt_free(session, upd);
-    return (ret);
+        return (ret);
+    }
+
+    /*
+     * Replayed truncates bypass the commit path that tracks the unpublished minimum, so do it here.
+     */
+    if (F_ISSET_ATOMIC_32(CUR2BT(cbt), WT_BTREE_AWAITS_PUBLISH))
+        __wt_btree_update_unpublished_min(CUR2BT(cbt), session->replay_trunc_ctx.durable_ts);
+    return (0);
 }
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -843,6 +843,13 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
         ref->page_del->pg_del_start_ts = session->replay_trunc_ctx.commit_ts;
         ref->page_del->pg_del_durable_ts = session->replay_trunc_ctx.durable_ts;
         ref->page_del->committed = true;
+
+        /*
+         * Fast truncate only takes pages with a disk address, which a tree awaiting publication
+         * never has, so there is no unpublished minimum to maintain here.
+         */
+        WT_ASSERT_ALWAYS(session, !F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_AWAITS_PUBLISH),
+          "fast truncate of a table awaiting publication");
         return (0);
     }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1840,6 +1840,13 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
             break;
         case WT_TXN_OP_REF_DELETE:
             WT_ERR(__wt_txn_op_set_timestamp(session, op, true));
+
+            /*
+             * Fast truncate only takes pages with a disk address, which a tree awaiting publication
+             * never has, so there is no unpublished minimum to maintain here.
+             */
+            WT_ASSERT_ALWAYS(session, !F_ISSET_ATOMIC_32(op->btree, WT_BTREE_AWAITS_PUBLISH),
+              "fast truncate of a table awaiting publication");
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -93,6 +93,24 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
         self.assertTrue('unpublished data' in msg)
 
+    def truncate_all_rows(self, commit_ts):
+        """Truncate the whole key range at commit_ts."""
+        c_start = self.session.open_cursor(self.uri)
+        c_start.set_key(1)
+        c_stop = self.session.open_cursor(self.uri)
+        c_stop.set_key(self.nrows)
+        self.session.begin_transaction()
+        self.session.truncate(None, c_start, c_stop, None)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        c_start.close()
+        c_stop.close()
+
+    def assert_no_rows(self, session):
+        """Assert that the table reads back empty through the given session."""
+        cursor = session.open_cursor(self.uri)
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
     def assert_drop_succeeds(self):
         """Drop the table and confirm it is gone from local metadata."""
         self.session.drop(self.uri)
@@ -227,4 +245,39 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.write_rows(commit_ts=3)
         self.set_stable_epoch(10)
         self.leader_checkpoint(3)
+        self.assert_drop_succeeds()
+
+    def test_drop_with_replayed_truncate_is_refused(self):
+        # A follower-era truncate reaches the stable constituent through the step-up drain rather
+        # than the commit path. The deletion it carries lives only in the awaiting-publication
+        # table until a checkpoint publishes it, so the drop must be refused meanwhile and the
+        # truncate must survive the publish.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+        self.step_down()
+
+        # A follower-era create, insert and truncate: everything lives in the ingest constituent
+        # and the truncate is held in the follower truncate list.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+        self.write_rows(commit_ts=3)
+        self.truncate_all_rows(commit_ts=5)
+
+        # Step up: the missing stable constituent is created awaiting publication and the drain
+        # moves the truncated rows into it, interleaved with the recorded truncate.
+        self.step_up()
+        self.assert_drop_refused()
+
+        # The refused drop left no partial state, so the truncate is still in effect.
+        self.assert_no_rows(self.session)
+
+        # A checkpoint publishes and persists the table: a follower sees the truncated table
+        # rather than the pre-truncate rows, and the published table then drops normally.
+        self.set_stable_epoch(10)
+        self.leader_checkpoint(6)
+        conn_follower, session_follower = self.open_follower()
+        self.assert_no_rows(session_follower)
+        session_follower.close()
+        conn_follower.close()
         self.assert_drop_succeeds()


### PR DESCRIPTION
### Context

`btree->min_unpublished_durable_ts` tells us an unpublished layered table holds committed data, so the drop path can refuse and the checkpoint path can flag an API violation. Only ordinary commits maintained it. Truncates did not.

### Changes

The step-up drain replays follower truncates outside any transaction, so track the durable timestamp where it writes tombstones.

Fast truncate needs no tracking: it only takes pages with a disk address, which an unpublished table never has. Assert that instead. `WT_TXN_OP_TRUNCATE_ROW/COL` need nothing, they only record a log range.

### Testing

New `test_layered_schema21` case: follower truncate replayed into an unpublished table, drop refused,
truncate survives the publish. Also ran the layered schema suite and `test_layered_fast_truncate16/17/stress01`.