### PR TITLE
WT-18355 Report statistics for a layered table created during step-down

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1151,6 +1151,9 @@ __clayered_ignore_missing_stable(WT_SESSION_IMPL *session, WTI_CLAYERED_ROLE rol
      * The resolved role is stale if the step-down timestamp is set or the role already changed.
      * Step-down changes both values while holding the schema lock, and the failed open that led
      * here acquired that lock, so relaxed loads see current values.
+     *
+     * FIXME-WT-18359: Investigate whether this guard is reachable now that WT_LAYERED_TABLE_STEP_DOWN_CREATED
+     * skips opening the stable constituent for tables created during the step-down window.
      */
     return (__wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_timestamp) != WT_TS_NONE ||
       !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1152,8 +1152,9 @@ __clayered_ignore_missing_stable(WT_SESSION_IMPL *session, WTI_CLAYERED_ROLE rol
      * Step-down changes both values while holding the schema lock, and the failed open that led
      * here acquired that lock, so relaxed loads see current values.
      *
-     * FIXME-WT-18359: Investigate whether this guard is reachable now that WT_LAYERED_TABLE_STEP_DOWN_CREATED
-     * skips opening the stable constituent for tables created during the step-down window.
+     * FIXME-WT-18359: Investigate whether this guard is reachable now that
+     * WT_LAYERED_TABLE_STEP_DOWN_CREATED skips opening the stable constituent for tables created
+     * during the step-down window.
      */
     return (__wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_timestamp) != WT_TS_NONE ||
       !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader));

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -433,7 +433,7 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
 retry:
     stable_uri = layered->stable_uri;
     /*
-     * Now do the stable table. A table created inside the step-down window has no stable
+     * Now do the stable table. A table created while the step-down timestamp was set has no stable
      * constituent until a later step-up creates one, so it reports the same way a follower does.
      */
     if (!__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader) ||
@@ -441,8 +441,8 @@ retry:
         /*
          * Neither case has the stable's pages resident in the local cache, so its non-walk stats
          * are ~0 - except the block size, which we read from the checkpoint metadata directly since
-         * this path never opens the stable table to obtain it. A table created inside the window
-         * has no metadata entry at all, which reads back as a size of zero.
+         * this path never opens the stable table to obtain it. A table with no stable constituent
+         * has no metadata entry either, which reads back as a size of zero.
          */
         if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK)) {
             uint64_t ckpt_size = 0;
@@ -480,6 +480,15 @@ retry:
         __wt_free(session, checkpoint_name);
         __wt_scr_free(session, &stable_uri_buf);
         goto retry;
+    }
+
+    /*
+     * A reader races the role change across a step-up or step-down, so a leader can still find the
+     * stable constituent missing here.
+     */
+    if (ret == ENOENT) {
+        ret = 0;
+        goto done;
     }
 
     WT_ERR(ret);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -485,6 +485,9 @@ retry:
     /*
      * A reader races the role change across a step-up or step-down, so a leader can still find the
      * stable constituent missing here.
+     *
+     * FIXME-WT-18359: Investigate whether this guard is reachable now that WT_LAYERED_TABLE_STEP_DOWN_CREATED
+     * routes tables without a stable constituent through the follower path above.
      */
     if (ret == ENOENT) {
         ret = 0;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -486,8 +486,9 @@ retry:
      * A reader races the role change across a step-up or step-down, so a leader can still find the
      * stable constituent missing here.
      *
-     * FIXME-WT-18359: Investigate whether this guard is reachable now that WT_LAYERED_TABLE_STEP_DOWN_CREATED
-     * routes tables without a stable constituent through the follower path above.
+     * FIXME-WT-18359: Investigate whether this guard is reachable now that
+     * WT_LAYERED_TABLE_STEP_DOWN_CREATED routes tables without a stable constituent through the
+     * follower path above.
      */
     if (ret == ENOENT) {
         ret = 0;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -432,12 +432,17 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
 
 retry:
     stable_uri = layered->stable_uri;
-    /* Now do the stable table. */
-    if (!__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader)) {
+    /*
+     * Now do the stable table. A table created inside the step-down window has no stable
+     * constituent until a later step-up creates one, so it reports the same way a follower does.
+     */
+    if (!__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader) ||
+      F_ISSET(layered, WT_LAYERED_TABLE_STEP_DOWN_CREATED)) {
         /*
-         * On a follower the stable's pages are not resident in the local cache, so its non-walk
-         * stats are ~0 - except the block size, which we read from the checkpoint metadata directly
-         * since this path never opens the stable table to obtain it.
+         * Neither case has the stable's pages resident in the local cache, so its non-walk stats
+         * are ~0 - except the block size, which we read from the checkpoint metadata directly since
+         * this path never opens the stable table to obtain it. A table created inside the window
+         * has no metadata entry at all, which reads back as a size of zero.
          */
         if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK)) {
             uint64_t ckpt_size = 0;

--- a/test/suite/test_layered_cursor26.py
+++ b/test/suite/test_layered_cursor26.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# A table created inside the step-down window has no stable constituent until a later step-up
+# creates one. A statistics cursor on such a table must report the ingest constituent alone rather
+# than trying to open the missing one, whichever URI names the table and whichever statistics it
+# is asked for.
+
+from helper_disagg import DisaggSchemaEpochMixin, DisaggSizeTestMixin, disagg_test_class
+from helper_layered_stepdown import LayeredStepdownMixin
+from wiredtiger import stat
+import wttest
+
+
+@disagg_test_class
+class test_layered_cursor26(
+  DisaggSizeTestMixin, LayeredStepdownMixin, wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    conn_config = ('statistics=(all),precise_checkpoint=true,'
+                   'disaggregated=(role="leader",lose_all_my_data=true)')
+
+    table_config = 'key_format=S,value_format=S,type=layered'
+
+    # The step-down timestamp every test opens its window on.
+    cutoff = 5
+
+    table_uri = f'table:{__qualname__}'
+    layered_uri = f'layered:{__qualname__}'
+
+    def open_window_and_create(self):
+        """Open the step-down window, then create and populate a table inside it."""
+        self.set_global_ts(1, 1)
+        self.set_step_down_ts(self.cutoff)
+
+        self.session.create(self.table_uri, self.table_config)
+        # Rows written inside the window commit above the cutoff and belong to the follower era.
+        self.write_at(self.table_uri, {'k1': 'v1', 'k2': 'v2'}, self.cutoff + 1)
+
+        # Assert the premise of every test below, so a create that started behaving differently
+        # cannot pass as a correct statistics result.
+        self.assertFalse(self.stable_constituent_exists(self.conn, self.layered_uri))
+
+    def block_size(self, uri, config='statistics=(size)'):
+        """Return the block size reported by a statistics cursor on uri."""
+        with wttest.open_cursor(self.session, f'statistics:{uri}', config=config) as cursor:
+            return cursor[stat.dsrc.block_size][2]
+
+    def assert_size_is_ingest_only(self, uri, config):
+        """The table has no stable constituent, so its size is the ingest constituent's alone."""
+        ingest = self.block_size(self.ingest_uri(self.layered_uri), config)
+        # A zero on both sides would satisfy the comparison without proving anything.
+        self.assertGreater(ingest, 0)
+        self.assertEqual(self.block_size(uri, config), ingest)
+
+    def test_size_stats_on_table_uri(self):
+        """The table URI declines the size fast path and falls back to the slow path."""
+        self.open_window_and_create()
+        self.assert_size_is_ingest_only(self.table_uri, 'statistics=(size)')
+
+    def test_size_stats_on_layered_uri(self):
+        """The layered URI has no size fast path, so it reaches the slow path directly."""
+        self.open_window_and_create()
+        self.assert_size_is_ingest_only(self.layered_uri, 'statistics=(size)')
+
+    def test_all_stats_on_table_uri(self):
+        """Full statistics walk the tree, which looks the checkpoint up a different way."""
+        self.open_window_and_create()
+        self.assert_size_is_ingest_only(self.table_uri, 'statistics=(all)')
+
+    def test_all_stats_on_layered_uri(self):
+        """Full statistics on the layered URI take the tree-walk branch without the fast path."""
+        self.open_window_and_create()
+        self.assert_size_is_ingest_only(self.layered_uri, 'statistics=(all)')
+
+    def test_size_reported_once_step_up_creates_the_constituent(self):
+        """A table that passed through the window reports its real size once it has a constituent."""
+        self.open_window_and_create()
+
+        self.complete_step_down(self.cutoff)
+        self.step_up()
+        self.leader_checkpoint(self.cutoff + 2)
+
+        self.assertTrue(self.stable_constituent_exists(self.conn, self.layered_uri))
+        expected = self.get_checkpoint_size(self.stable_uri(self.layered_uri))
+        self.assertGreater(expected, 0)
+        self.assertEqual(self.block_size(self.table_uri, 'statistics=(size)'), expected)
+
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_layered_cursor26.py
+++ b/test/suite/test_layered_cursor26.py
@@ -26,10 +26,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# A table created inside the step-down window has no stable constituent until a later step-up
-# creates one. A statistics cursor on such a table must report the ingest constituent alone rather
-# than trying to open the missing one, whichever URI names the table and whichever statistics it
-# is asked for.
+# A table created while the step-down timestamp is set has no stable constituent until a later
+# step-up creates one. A statistics cursor on such a table must report the ingest constituent alone
+# rather than trying to open the missing one, whichever URI names the table and whichever
+# statistics it is asked for.
 
 from helper_disagg import DisaggSchemaEpochMixin, DisaggSizeTestMixin, disagg_test_class
 from helper_layered_stepdown import LayeredStepdownMixin
@@ -45,19 +45,20 @@ class test_layered_cursor26(
 
     table_config = 'key_format=S,value_format=S,type=layered'
 
-    # The step-down timestamp every test opens its window on.
+    # The step-down timestamp every test creates its table under.
     cutoff = 5
 
     table_uri = f'table:{__qualname__}'
     layered_uri = f'layered:{__qualname__}'
 
-    def open_window_and_create(self):
-        """Open the step-down window, then create and populate a table inside it."""
+    def create_with_step_down_ts_set(self):
+        """Set the step-down timestamp, then create and populate a table under it."""
         self.set_global_ts(1, 1)
         self.set_step_down_ts(self.cutoff)
 
         self.session.create(self.table_uri, self.table_config)
-        # Rows written inside the window commit above the cutoff and belong to the follower era.
+        # Rows written once the timestamp is set commit above the cutoff and belong to the follower
+        # era.
         self.write_at(self.table_uri, {'k1': 'v1', 'k2': 'v2'}, self.cutoff + 1)
 
         # Assert the premise of every test below, so a create that started behaving differently
@@ -78,27 +79,27 @@ class test_layered_cursor26(
 
     def test_size_stats_on_table_uri(self):
         """The table URI declines the size fast path and falls back to the slow path."""
-        self.open_window_and_create()
+        self.create_with_step_down_ts_set()
         self.assert_size_is_ingest_only(self.table_uri, 'statistics=(size)')
 
     def test_size_stats_on_layered_uri(self):
         """The layered URI has no size fast path, so it reaches the slow path directly."""
-        self.open_window_and_create()
+        self.create_with_step_down_ts_set()
         self.assert_size_is_ingest_only(self.layered_uri, 'statistics=(size)')
 
     def test_all_stats_on_table_uri(self):
         """Full statistics walk the tree, which looks the checkpoint up a different way."""
-        self.open_window_and_create()
+        self.create_with_step_down_ts_set()
         self.assert_size_is_ingest_only(self.table_uri, 'statistics=(all)')
 
     def test_all_stats_on_layered_uri(self):
         """Full statistics on the layered URI take the tree-walk branch without the fast path."""
-        self.open_window_and_create()
+        self.create_with_step_down_ts_set()
         self.assert_size_is_ingest_only(self.layered_uri, 'statistics=(all)')
 
     def test_size_reported_once_step_up_creates_the_constituent(self):
-        """A table that passed through the window reports its real size once it has a constituent."""
-        self.open_window_and_create()
+        """A table created under the timestamp reports its real size once it has a constituent."""
+        self.create_with_step_down_ts_set()
 
         self.complete_step_down(self.cutoff)
         self.step_up()


### PR DESCRIPTION
A leader with the step-down timestamp set skips creating the stable constituent, so a table created inside that window has no stable metadata row until a later step-up creates one. The statistics cursor forked on the leader flag alone and fell through to opening the constituent, which surfaced the metadata miss as ENOENT.

Route such a table through the follower branch, which reads the size from the checkpoint metadata and already tolerates a missing entry. This reuses the WT_LAYERED_TABLE_STEP_DOWN_CREATED flag the layered cursor code uses for the same purpose.
