### PR TITLE
WT-18049 Don't read under a snapshot when evicting the shared metadata

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1365,19 +1365,12 @@ static int
 __evict_snapshot_app(
   WT_SESSION_IMPL *session, uint32_t *flagsp, WT_EVICT_SNAPSHOT_STATE *snap_statep)
 {
-    bool ckpt_writes_tree;
-
-    /* The only trees a checkpoint writes in its own transaction. */
-    ckpt_writes_tree = WT_SESSION_IS_CHECKPOINT(session) &&
-      (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle));
-
     /*
      * If we couldn't make progress with the existing snapshot, save it and refresh to acquire a new
-     * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds
-     * on the trees it writes: it must not write out and discard its own updates before its
-     * transaction commits.
+     * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds:
+     * a newer one would let content that is not part of the checkpoint into a tree it is writing.
      */
-    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !ckpt_writes_tree) {
+    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !WT_SESSION_IS_CHECKPOINT(session)) {
         WT_RET(__wt_txn_snapshot_save_and_refresh(session));
         WT_STAT_CONN_INCR(session, application_evict_snapshot_refreshed);
         *snap_statep = WT_EVICT_SNAP_RESTORE;
@@ -1444,9 +1437,13 @@ __evict_snapshot_setup(
     *snap_statep = WT_EVICT_SNAP_NONE;
     session->txn->ckpt_snap_gen = WT_CKPT_SNAP_GEN_NONE;
 
-    /* Only an application thread evicting its own data brings a snapshot worth reading under. */
+    /*
+     * Only an application thread evicting its own data brings a snapshot worth reading under. The
+     * metadata trees are excluded: a checkpoint writing them is not done with its updates, and
+     * recognizing that relies on the pinned ID rather than on a snapshot.
+     */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
-      !WT_IS_METADATA(session->dhandle);
+      !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);
 
     if (F_ISSET(session, WT_SESSION_EVICTION))
         *snap_statep = __evict_snapshot_evict_thread(session, flagsp);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1439,7 +1439,8 @@ __evict_snapshot_setup(
     /*
      * Only an application thread evicting its own data brings a snapshot worth reading under. A
      * checkpoint writes only the metadata trees, and it hides its transaction ID from the global
-     * table, so a snapshot shows its uncommitted updates there as committed. Exclude them.
+     * table, so a snapshot shows its uncommitted updates there as committed. Do not read under a
+     * snapshot when evicting those trees.
      */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
       !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1438,8 +1438,8 @@ __evict_snapshot_setup(
 
     /*
      * Only an application thread evicting its own data brings a snapshot worth reading under. A
-     * checkpoint writes only the metadata trees, and a snapshot shows its uncommitted updates there
-     * as committed, so exclude them.
+     * checkpoint writes only the metadata trees, and it hides its transaction ID from the global
+     * table, so a snapshot shows its uncommitted updates there as committed. Exclude them.
      */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
       !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1438,9 +1438,9 @@ __evict_snapshot_setup(
 
     /*
      * Only an application thread evicting its own data brings a snapshot worth reading under. The
-     * metadata trees are excluded: a running checkpoint has uncommitted updates there, and they are
-     * only held back by reconciling without a snapshot, which lowers the visibility bound to the
-     * checkpoint's transaction.
+     * metadata trees are excluded: a running checkpoint hides its ID from the global table, so no
+     * snapshot sees its updates there as uncommitted. Reconciling without one bounds visibility by
+     * the checkpoint's transaction instead.
      */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
       !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1438,8 +1438,9 @@ __evict_snapshot_setup(
 
     /*
      * Only an application thread evicting its own data brings a snapshot worth reading under. The
-     * metadata trees are excluded: a running checkpoint has uncommitted updates there, and what
-     * keeps eviction from writing them out is the pinned ID, which a snapshot bypasses.
+     * metadata trees are excluded: a running checkpoint has uncommitted updates there, and they are
+     * only held back by reconciling without a snapshot, which lowers the visibility bound to the
+     * checkpoint's transaction.
      */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
       !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1437,10 +1437,9 @@ __evict_snapshot_setup(
     session->txn->ckpt_snap_gen = WT_CKPT_SNAP_GEN_NONE;
 
     /*
-     * Only an application thread evicting its own data brings a snapshot worth reading under. The
-     * metadata trees are excluded: a running checkpoint hides its ID from the global table, so no
-     * snapshot sees its updates there as uncommitted. Reconciling without one bounds visibility by
-     * the checkpoint's transaction instead.
+     * Only an application thread evicting its own data brings a snapshot worth reading under. A
+     * checkpoint writes only the metadata trees, and a snapshot shows its uncommitted updates there
+     * as committed, so exclude them.
      */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
       !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1365,12 +1365,19 @@ static int
 __evict_snapshot_app(
   WT_SESSION_IMPL *session, uint32_t *flagsp, WT_EVICT_SNAPSHOT_STATE *snap_statep)
 {
+    bool ckpt_writes_tree;
+
+    /* The only trees a checkpoint writes in its own transaction. */
+    ckpt_writes_tree = WT_SESSION_IS_CHECKPOINT(session) &&
+      (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle));
+
     /*
      * If we couldn't make progress with the existing snapshot, save it and refresh to acquire a new
-     * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds:
-     * it must not write out and discard its own updates before its transaction commits.
+     * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds
+     * on the trees it writes: it must not write out and discard its own updates before its
+     * transaction commits.
      */
-    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !WT_SESSION_IS_CHECKPOINT(session)) {
+    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !ckpt_writes_tree) {
         WT_RET(__wt_txn_snapshot_save_and_refresh(session));
         WT_STAT_CONN_INCR(session, application_evict_snapshot_refreshed);
         *snap_statep = WT_EVICT_SNAP_RESTORE;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1367,10 +1367,9 @@ __evict_snapshot_app(
 {
     /*
      * If we couldn't make progress with the existing snapshot, save it and refresh to acquire a new
-     * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds:
-     * a newer one would let content that is not part of the checkpoint into a tree it is writing.
+     * one, restoring the original once eviction is done.
      */
-    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !WT_SESSION_IS_CHECKPOINT(session)) {
+    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT)) {
         WT_RET(__wt_txn_snapshot_save_and_refresh(session));
         WT_STAT_CONN_INCR(session, application_evict_snapshot_refreshed);
         *snap_statep = WT_EVICT_SNAP_RESTORE;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1367,9 +1367,10 @@ __evict_snapshot_app(
 {
     /*
      * If we couldn't make progress with the existing snapshot, save it and refresh to acquire a new
-     * one, restoring the original once eviction is done.
+     * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds:
+     * a newer one would let content that is not part of the checkpoint into a tree it is writing.
      */
-    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT)) {
+    if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !WT_SESSION_IS_CHECKPOINT(session)) {
         WT_RET(__wt_txn_snapshot_save_and_refresh(session));
         WT_STAT_CONN_INCR(session, application_evict_snapshot_refreshed);
         *snap_statep = WT_EVICT_SNAP_RESTORE;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1438,8 +1438,8 @@ __evict_snapshot_setup(
 
     /*
      * Only an application thread evicting its own data brings a snapshot worth reading under. The
-     * metadata trees are excluded: a checkpoint writing them is not done with its updates, and
-     * recognizing that relies on the pinned ID rather than on a snapshot.
+     * metadata trees are excluded: a running checkpoint has uncommitted updates there, and what
+     * keeps eviction from writing them out is the pinned ID, which a snapshot bypasses.
      */
     app_thread = !F_ISSET(session, WT_SESSION_EVICTION | WT_SESSION_INTERNAL) &&
       !WT_IS_METADATA(session->dhandle) && !WT_IS_DISAGG_META(session->dhandle);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1368,7 +1368,7 @@ __evict_snapshot_app(
     /*
      * If we couldn't make progress with the existing snapshot, save it and refresh to acquire a new
      * one, restoring the original once eviction is done. A checkpoint keeps the snapshot it holds:
-     * a newer one would let content that is not part of the checkpoint into a tree it is writing.
+     * it must not write out and discard its own updates before its transaction commits.
      */
     if (F_ISSET(session->txn, WT_TXN_REFRESH_SNAPSHOT) && !WT_SESSION_IS_CHECKPOINT(session)) {
         WT_RET(__wt_txn_snapshot_save_and_refresh(session));

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -747,15 +747,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
     max_ts = WT_TS_NONE;
     max_txn = WT_TXN_NONE;
     is_hs_page = F_ISSET(session->dhandle, WT_DHANDLE_HS);
-    /*
-     * A running checkpoint hides its ID from the global table, so take its ID from the transaction
-     * itself: evicting a page under the checkpoint discards its own uncommitted updates, which it
-     * still needs at commit. The checkpoint's own writes of the tree must not be blocked this way,
-     * so this only applies to eviction.
-     */
-    session_txnid = WT_SESSION_IS_CHECKPOINT(session) && F_ISSET(r, WT_REC_EVICT) ?
-      session->txn->time_point.id :
-      __wt_atomic_load_uint64_v_relaxed(&WT_SESSION_TXN_SHARED(session)->id);
+    session_txnid = __wt_atomic_load_uint64_v_relaxed(&WT_SESSION_TXN_SHARED(session)->id);
     *write_prepare = false;
 
     for (upd = first_upd; upd != NULL; upd = upd->next) {

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -747,7 +747,15 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
     max_ts = WT_TS_NONE;
     max_txn = WT_TXN_NONE;
     is_hs_page = F_ISSET(session->dhandle, WT_DHANDLE_HS);
-    session_txnid = __wt_atomic_load_uint64_v_relaxed(&WT_SESSION_TXN_SHARED(session)->id);
+    /*
+     * A running checkpoint hides its ID from the global table, so take its ID from the transaction
+     * itself: evicting a page under the checkpoint discards its own uncommitted updates, which it
+     * still needs at commit. The checkpoint's own writes of the tree must not be blocked this way,
+     * so this only applies to eviction.
+     */
+    session_txnid = WT_SESSION_IS_CHECKPOINT(session) && F_ISSET(r, WT_REC_EVICT) ?
+      session->txn->time_point.id :
+      __wt_atomic_load_uint64_v_relaxed(&WT_SESSION_TXN_SHARED(session)->id);
     *write_prepare = false;
 
     for (upd = first_upd; upd != NULL; upd = upd->next) {

--- a/test/suite/test_disagg_checkpoint_shared_metadata_evict.py
+++ b/test/suite/test_disagg_checkpoint_shared_metadata_evict.py
@@ -29,6 +29,7 @@
 import wttest
 from helpers.helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
+from wiredtiger import stat
 
 # test_disagg_checkpoint_shared_metadata_evict.py
 #   A checkpoint writes the shared metadata of every table it checkpointed, in its own transaction.
@@ -41,15 +42,21 @@ class test_disagg_checkpoint_shared_metadata_evict(wttest.WiredTigerTestCase):
 
     # A small cache lowers the in-memory page size at which a page is forcibly evicted when the
     # thread writing it releases it, so a modest number of tables is enough.
-    conn_base_config = 'cache_size=4MB,'
+    conn_base_config = 'cache_size=4MB,statistics=(all),'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     # A table contributes two shared metadata entries, and a checkpoint writes each of them twice:
-    # once for the table's creation and once to record the checkpoint it just wrote.
-    ntables = 40
+    # once for the table's creation and once to record the checkpoint it just wrote. Enough tables
+    # to take the page well past the size at which it is forcibly evicted, which the test checks.
+    ntables = 100
+
+    def forced_evictions(self):
+        with wttest.open_cursor(self.session, 'statistics:') as stat_cursor:
+            return stat_cursor[stat.conn.eviction_force][2] + \
+                stat_cursor[stat.conn.eviction_force_fail][2]
 
     def test_shared_metadata_forced_evict(self):
         uris = [f'layered:{self.test_name}_{i}' for i in range(self.ntables)]
@@ -60,7 +67,13 @@ class test_disagg_checkpoint_shared_metadata_evict(wttest.WiredTigerTestCase):
             cursor['key'] = 'value'
             cursor.close()
 
+        before = self.forced_evictions()
         self.session.checkpoint()
+
+        # Without a forced eviction while the checkpoint was writing shared metadata, this test
+        # proves nothing, so fail rather than pass silently.
+        self.assertGreater(self.forced_evictions(), before,
+            'no page was forcibly evicted, the configuration no longer exercises the checkpoint')
 
         # The connection must remain usable, and a second checkpoint must be able to write more
         # shared metadata on top of what the first one wrote.

--- a/test/suite/test_disagg_checkpoint_shared_metadata_evict.py
+++ b/test/suite/test_disagg_checkpoint_shared_metadata_evict.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helpers.helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_disagg_checkpoint_shared_metadata_evict.py
+#   A checkpoint writes the shared metadata of every table it checkpointed, in its own transaction.
+#   Writing enough of it forces eviction of the page being written, which must not discard the
+#   updates the checkpoint has yet to commit.
+@disagg_test_class
+class test_disagg_checkpoint_shared_metadata_evict(wttest.WiredTigerTestCase):
+
+    test_name = __qualname__
+
+    # A small cache lowers the in-memory page size at which a page is forcibly evicted when the
+    # thread writing it releases it, so a modest number of tables is enough.
+    conn_base_config = 'cache_size=4MB,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    # A table contributes two shared metadata entries, and a checkpoint writes each of them twice:
+    # once for the table's creation and once to record the checkpoint it just wrote.
+    ntables = 40
+
+    def test_shared_metadata_forced_evict(self):
+        uris = [f'layered:{self.test_name}_{i}' for i in range(self.ntables)]
+
+        for uri in uris:
+            self.session.create(uri, 'key_format=S,value_format=S')
+            cursor = self.session.open_cursor(uri)
+            cursor['key'] = 'value'
+            cursor.close()
+
+        self.session.checkpoint()
+
+        # The connection must remain usable, and a second checkpoint must be able to write more
+        # shared metadata on top of what the first one wrote.
+        for uri in uris:
+            cursor = self.session.open_cursor(uri)
+            self.assertEqual(cursor['key'], 'value')
+            cursor['key2'] = 'value2'
+            cursor.close()
+
+        self.session.checkpoint()

--- a/test/suite/test_disagg_checkpoint_shared_metadata_evict.py
+++ b/test/suite/test_disagg_checkpoint_shared_metadata_evict.py
@@ -53,6 +53,10 @@ class test_disagg_checkpoint_shared_metadata_evict(wttest.WiredTigerTestCase):
     # to take the page well past the size at which it is forcibly evicted, which the test checks.
     ntables = 100
 
+    # Padding carried into each shared metadata entry, so the page reaches that size on a much
+    # wider range of cache sizes than the entries alone would.
+    padding = 'x' * 4096
+
     def forced_evictions(self):
         with wttest.open_cursor(self.session, 'statistics:') as stat_cursor:
             return stat_cursor[stat.conn.eviction_force][2] + \
@@ -62,7 +66,8 @@ class test_disagg_checkpoint_shared_metadata_evict(wttest.WiredTigerTestCase):
         uris = [f'layered:{self.test_name}_{i}' for i in range(self.ntables)]
 
         for uri in uris:
-            self.session.create(uri, 'key_format=S,value_format=S')
+            self.session.create(uri,
+                f'key_format=S,value_format=S,app_metadata="{self.padding}"')
             cursor = self.session.open_cursor(uri)
             cursor['key'] = 'value'
             cursor.close()


### PR DESCRIPTION
A checkpoint writes shared metadata in its own transaction, twice per table in one drain. That takes the page past the forced-eviction size, so the inserting thread evicts the page it is writing and the discard frees updates the transaction has not committed. Commit then dereferences freed memory, which surfaces as a timestamp usage check failure.

A snapshot cannot tell those updates are uncommitted: the checkpoint hides its transaction ID from the global table, so its ID reads as long-since-committed. Reconciling without a snapshot instead bounds visibility by the checkpoint's transaction, which holds the updates back. `app_thread` in `__evict_snapshot_setup` excludes the metadata file from the snapshot path but not the shared metadata; this excludes both.

`test_disagg_checkpoint_shared_metadata_evict` reproduces the failure deterministically in under two seconds, and fails if the configuration stops producing a forced eviction.
