### PR TITLE
WT-18167 Pin cache in test_cc02 to keep eviction scenario in-memory

### DIFF
--- a/test/suite/test_cc02.py
+++ b/test/suite/test_cc02.py
@@ -39,6 +39,9 @@ from wtscenario import make_scenarios
 class test_cc02(test_cc_base):
     # Useful for debugging:
     # conn_config = "verbose=[checkpoint_cleanup:4]"
+    # Use an oversized cache so background eviction cannot flip a clean page to on-disk between
+    # the populate/checkpoint and the cleanup walk; keeps each scenario purely in-memory or on-disk.
+    conn_config = "cache_size=1GB"
     cleanup_flows = [
         # Keep everything in memory, obsolete cleanup should mark obsolete data dirty so it is evicted.
         ('eviction', dict(in_memory=True)),


### PR DESCRIPTION
test_cc02 splits into two mirrored scenarios: `eviction` (all pages stay in memory, cleanup should only take the in-memory arm) and `disk` (all pages force-evicted first, cleanup should only take the on-disk arm). The `disk` scenario enforces its precondition with a force-evict pass (`debug=(release_evict_page=true)`); the `eviction` scenario did not, so background eviction could rarely flip one clean HS/DS leaf to disk between the initial checkpoint and the cleanup walk. That made the disk arm fire once and the strict `assertEqual(obsolete_on_disk, 0)` fail with `1 != 0`.

Pin the cache large enough that background eviction stays idle for this test's ~1 MB payload, restoring the residency invariant. Mirrors the pattern already used in test_cc07.