### PR TITLE
WT-18363 Honor the -G conn_logging, timing_stress and checkpoint_crash overrides in model_test

### DIFF
--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -108,12 +108,6 @@ kv_workload_generator_spec::kv_workload_generator_spec()
 }
 
 /*
- * kv_workload_generator::_default_spec --
- *     The default workload specification.
- */
-const kv_workload_generator_spec kv_workload_generator::_default_spec;
-
-/*
  * kv_workload_generator::kv_workload_generator --
  *     Create a new workload generator.
  */

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -466,7 +466,7 @@ public:
      *     Generate the workload.
      */
     static inline std::shared_ptr<kv_workload>
-    generate(const kv_workload_generator_spec &spec = _default_spec, uint64_t seed = 0)
+    generate(const kv_workload_generator_spec &spec, uint64_t seed = 0)
     {
         kv_workload_generator generator(spec, seed);
         generator.run();
@@ -570,8 +570,6 @@ protected:
     data_value random_data_value(const std::string &format);
 
 private:
-    static const kv_workload_generator_spec _default_spec;
-
     std::shared_ptr<kv_workload> _workload_ptr;
     kv_workload &_workload;
 

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -474,9 +474,9 @@ public:
     }
 
     static std::string
-    generate_stress_configurations(uint64_t seed = 0)
+    generate_stress_configurations(const kv_workload_generator_spec &spec, uint64_t seed = 0)
     {
-        kv_workload_generator generator(_default_spec, seed);
+        kv_workload_generator generator(spec, seed);
         return generator.generate_connection_stress_config();
     }
 

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -481,9 +481,9 @@ public:
     }
 
     static std::string
-    generate_log_configurations(uint64_t seed = 0)
+    generate_log_configurations(const kv_workload_generator_spec &spec, uint64_t seed = 0)
     {
-        kv_workload_generator generator(_default_spec, seed);
+        kv_workload_generator generator(spec, seed);
         return generator.generate_connection_log_config();
     }
 

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -908,7 +908,7 @@ main(int argc, char *argv[])
             /* Generate random timing stress configurations and add it to the WiredTiger config. */
             if (generate_timing_stress_configurations) {
                 std::string rand_stress_config =
-                  model::kv_workload_generator::generate_stress_configurations(seed);
+                  model::kv_workload_generator::generate_stress_configurations(spec, seed);
                 wt_conn_config = model::join(wt_conn_config, rand_stress_config);
             }
 

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -301,6 +301,7 @@ update_spec(model::kv_workload_generator_spec &spec, std::string &conn_config,
         UPDATE_SPEC(truncate, float);
 
         UPDATE_SPEC(checkpoint, float);
+        UPDATE_SPEC(checkpoint_crash, float);
         UPDATE_SPEC(crash, float);
         UPDATE_SPEC(evict, float);
         UPDATE_SPEC(restart, float);
@@ -887,8 +888,8 @@ main(int argc, char *argv[])
         for (uint64_t iteration = 1;; iteration++) {
             uint64_t seed = next_seed;
             std::string wt_conn_config = conn_config;
-            wt_conn_config = model::join(
-              wt_conn_config, model::kv_workload_generator::generate_log_configurations(seed));
+            wt_conn_config = model::join(wt_conn_config,
+              model::kv_workload_generator::generate_log_configurations(spec, seed));
 
             next_seed = model::random::next_seed(next_seed);
 


### PR DESCRIPTION
Three of `model_test`'s `-G` generator overrides had no effect.

**`conn_logging`** — `kv_workload_generator::generate_log_configurations()` built a throwaway generator from the static `_default_spec` rather than the spec the caller passed, so `-G conn_logging=<p>` was discarded and connection logging stayed at its 0.5 default.

**`timing_stress.*`** — `generate_stress_configurations()` had the identical bug, so all eleven `-G timing_stress.<mode>=<w>` weights were discarded and every mode stayed at its equal 0.1 default.

**`checkpoint_crash`** — no `UPDATE_SPEC` entry in `update_spec()`, so the probability could not be tuned at all (`checkpoint`, `crash`, `evict` and `restart` are all there).

Between them this made it impossible to ask for a run with logging deliberately on or off at a chosen checkpoint-crash rate, which is exactly what is needed to test crash/recovery behaviour that depends on logging.

### Verification

From `cmake_build/test/model/tools`, `-n` generates and prints the workload without running it, so these need no database.

Logging, which is ignored in both directions before the fix:

```
./model_test -n -l 5-6 -S 1  -G conn_logging=0.0 | grep -c 'log=(enabled=true)'   # 0, was 1
./model_test -n -l 5-6 -S 11 -G conn_logging=1.0 | grep -c 'log=(enabled=true)'   # 1, was 0
```

Timing stress, asking for one mode at weight 1.0 with the other ten zeroed:

```
./model_test -n -g -l 5-6 -S <seed> -G timing_stress.ckpt_slow=1.0,<other ten =0.0>
```

Now prints `timing_stress_for_test=[checkpoint_slow]` for every seed; before the fix it printed `[checkpoint_evict_page]`, the default-weighted draw. Same check passes pinning `rec_before_wrapup`.

### Cleanup

The third commit drops the `_default_spec` default argument on `generate()`. Both callers already pass a spec explicitly, so it was never exercised — but it is what the two config helpers reached for instead of the caller's spec, so removing it means a helper written that way no longer compiles. `_default_spec` has no remaining users and is deleted.

### Testing note

Verification above used `-n`, which generates and prints the workload without opening a database, so it does not exercise the paths broken by WT-15324 (test/model fails on macOS). The run path is left to Evergreen.
