### PR TITLE
WT-18365 Vary the seed across workload generation retries in test_model_workload

### DIFF
--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 #include "wiredtiger.h"
 extern "C" {
@@ -295,6 +296,8 @@ static void
 test_workload_generator(void)
 {
     int retries = 0;
+    uint64_t seed = 0;
+    std::string last_issue;
 
     while (true) {
         try {
@@ -303,19 +306,22 @@ test_workload_generator(void)
             spec.disaggregated = 0;
 
             std::shared_ptr<model::kv_workload> workload =
-              model::kv_workload_generator::generate(spec);
+              model::kv_workload_generator::generate(spec, seed);
 
             /* Run the workload in the model and in WiredTiger, then verify. */
             std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
             verify_workload(*workload, opts, test_home, ENV_CONFIG);
 
             break;
-        } catch (model::known_issue_exception &) {
-            /* Try again. */
+        } catch (model::known_issue_exception &e) {
+            /* Retry with a different workload; the same seed would hit the same issue. */
+            last_issue = e.issue();
+            seed = model::random::next_seed(seed);
         }
 
         if (retries++ > 10)
-            throw model::model_exception("Too many retries for workload generation");
+            throw model::model_exception(
+              "Too many retries for workload generation; last known issue: " + last_issue);
     }
 }
 


### PR DESCRIPTION
`test_workload_generator()` retried up to 11 times when workload verification threw
`known_issue_exception`, but every attempt called `generate(spec)` with the default seed 0,
so all attempts produced the byte-identical workload. A workload that trips a known issue
therefore trips it on all 11 attempts, and the test fails with the misleading
`Too many retries for workload generation` instead of naming what was hit.

This is latent today — the workload at seed 0 does not currently trip
[WT-13232](https://jira.mongodb.org/browse/WT-13232) — but becomes a confusingly-reported CI
failure the moment a change to the default spec or the generation algorithm makes seed 0
produce a triggering workload.

The fix follows the `model_test` pattern: hold a seed and advance it with
`model::random::next_seed()` before each retry, passing it to `generate(spec, seed)`. The
exhausted-retries message now also reports the last known issue hit.

### Reproducer

With the retry loop instrumented to print a fingerprint of each generated workload and to
force the known-issue path (throw `known_issue_exception("WT-13232")` right after
generation), before the fix:

```
REPRO attempt 0, 11665 ops, fingerprint 0xfef25bc935e79f0f
REPRO attempt 1, 11665 ops, fingerprint 0xfef25bc935e79f0f
...
REPRO attempt 11, 11665 ops, fingerprint 0xfef25bc935e79f0f
Test failed with exception: Too many retries for workload generation
```

After the fix:

```
REPRO attempt 0, 11665 ops, fingerprint 0xfef25bc935e79f0f
REPRO attempt 1, 7056 ops, fingerprint 0xf62ea5124fafc5e6
REPRO attempt 2, 9302 ops, fingerprint 0x88464036911d94e7
...
REPRO attempt 11, 8076 ops, fingerprint 0x35a52d5ac272c48e
Test failed with exception: Too many retries for workload generation; last known issue: WT-13232
```

Each attempt now generates a different workload, and the exhausted-retry message names the
issue. The instrumentation is throwaway and is not part of this change.
