### PR TITLE
WT-18367 Spell-check the prose in dist/*.py

### DIFF
--- a/dist/api_config.py
+++ b/dist/api_config.py
@@ -86,7 +86,7 @@ def gettype(c):
     return ctype or 'string'
 
 def typedesc(c):
-    '''Descripe what type of value is expected for the given config item'''
+    '''Describe what type of value is expected for the given config item'''
     checks = c.flags
     cmin = str(checks.get('min', ''))
     cmax = str(checks.get('max', ''))

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1828,7 +1828,7 @@ methods = {
                     ''',
                     type='boolean', undoc=True),
                 Config('cross_key', 'false', r'''
-                    Allow version cursos to walk across keys while calling next().
+                    Allow version cursors to walk across keys while calling next().
                     ''',
                     type='boolean', undoc=True),
                 Config('show_prepared_rollback', 'false', r'''
@@ -2202,7 +2202,7 @@ methods = {
             checkpoint, while higher values will result in crashes in the final phase of the
             checkpoint process''', type='int', min='0', max='1000'),
         Config('checkpoint_crash_trigger_point', '', r'''
-            enable code that performs a crash duriing checkpoint process with a goal of uncovering
+            enable code that performs a crash during checkpoint process with a goal of uncovering
             race conditions at unexpected times. This option is intended for use with internal
             testing of WiredTiger.''', undoc=True,
             choices=['before_metadata_sync', 'before_metadata_update',

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -220,7 +220,7 @@ for line in open('../src/include/wiredtiger.h.in', 'r'):
 tfile.close()
 compare_srcfile(tmp_file, '../src/include/wiredtiger.h.in')
 
-# Output the wiredtiger_strerror and wiredtiger_sterror_r code.
+# Output the wiredtiger_strerror and __wt_wiredtiger_error code.
 tmp_file = '__tmp_api_err' + str(os.getpid())
 tfile = open(tmp_file, 'w')
 tfile.write('''/* DO NOT EDIT: automatically built by dist/api_err.py. */

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 # This is the list of modules that have their respective headers located in the src/module/ folder
 # instead of in src/include/. As a result all relevant code is contained to a single folder.
 # Adding modules to this list will automatically generate those headers, and we expect this list to
-# grow as we modularise the code base.
+# grow as we split the code base into modules.
 SELF_CONTAINED_MODULES = ["checkpoint", "evict", "log", "reconcile", "live_restore"]
 
 DO_NOT_EDIT_BEGIN = "/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */\n"
@@ -226,7 +226,7 @@ def write_header_files(public_fns_dict, private_fns_dict, tests_dict):
             output(public_fns_dict[mod], tests_dict[mod], f"../src/{mod}/{mod}.h")
             if len(private_fns_dict[mod]) > 0:
                 # The second argument (tests_dict) is empty. These test functions are defined to
-                # expose module internals outside the module, so it doens't make sense for them
+                # expose module internals outside the module, so it doesn't make sense for them
                 # to be private.
                 output(private_fns_dict[mod], {}, f"../src/{mod}/{mod}_private.h")
 

--- a/dist/s_function_verbose.py
+++ b/dist/s_function_verbose.py
@@ -36,7 +36,7 @@ verbose_regex = re.compile('([0-9]+):\\s*__wt_verbose\\(.*?,(.*?)[\\"\\\']')
 bitwise_or_regex = re.compile(r'^.*(?<!\|)\|(?!\|).*$')
 for line in sys.stdin:
     # Find all uses of __wt_verbose in a given line, capturing the line number
-    # and 2nd paramter as groups.
+    # and 2nd parameter as groups.
     m = verbose_regex.findall(line)
     if len(m) != 0:
         for verb_match in m:

--- a/dist/s_string
+++ b/dist/s_string
@@ -23,6 +23,15 @@ type aspell > /dev/null 2>&1 || {
 #    Run aspell with the correct mode for a given file type.
 run_aspell_for() {
     case "$1" in
+    dist/*.py)
+        # The dist scripts hold the config and statistics descriptions that become the
+        # public documentation, so check triple-quoted strings as well as comments. The
+        # test suite is deliberately excluded: its triple-quoted strings hold code and
+        # config data, not prose, and checking them would swamp the custom word list.
+        aspell --clear-filter --add-filter=url --add-filter=context \
+            --clear-context-delimiters --add-context-delimiters='# \0' \
+            --add-context-delimiters="''' '''" --add-context-delimiters='""" """' \
+            --lang=en_US list;;
     *.yml|*.yaml|*.py)
         # aspell's built-in --mode=comment is broken
         # (see https://github.com/GNUAspell/aspell/issues/505). This combines the
@@ -55,7 +64,8 @@ check() {
     # Strip out double quote char literals ('"'), they confuse aspell.
     # Strip out calls to __wt_getopt so the option lists don't have to be spelling words.
     # Strip out C-style hex constants.
-    sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' -e 's/0x[[:xdigit:]]\{1,\}/ /g' ../$1 |
+    # Strip out backslash escapes, the dist scripts embed generated C in string literals.
+    sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' -e 's/0x[[:xdigit:]]\{1,\}/ /g' -e 's/\\[ntr]/ /g' ../$1 |
     run_aspell_for $1 |
     sort -u |
     comm -23 /dev/stdin $custom_words > $t
@@ -70,6 +80,7 @@ l=$(
   {
     cd ..
     find bench dist examples ext src test tools/checksum_bitflip -name '*.[chsy]' | grep -v 'test/3rdparty'
+    find dist -name '*.py'
     find src -name '*.in'
     find test -name '*.cpp' | grep -v 'test/3rdparty'
     find test -name '*.py' | grep -v 'test/3rdparty'

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -31,6 +31,7 @@ AssertionError
 Async
 Athlon
 Auth
+Autocommit
 AwsManager
 Axxx
 BBBBB
@@ -66,6 +67,7 @@ Buildvariants
 Bxxx
 C'd
 CACHEABLE
+CALLGRAPH
 CAS
 CBT
 CCCCCCCCCCCCCCCCCC
@@ -111,6 +113,7 @@ CloseHandle
 Cmd
 Codec
 Comparator
+Comparators
 ComplexDataSet
 ComplexDataStore
 ConcurrencyTestSuite
@@ -125,6 +128,7 @@ Crt
 Crummey
 CustomersPhone
 Cygwin
+DECL
 DENABLE
 DESC
 DEST
@@ -143,6 +147,7 @@ Decrementing
 Decrypt
 DeleteFileW
 Deterministically
+Dhandle
 DisAgg
 Disagg
 DisaggCorruptionMixin
@@ -191,6 +196,7 @@ FH
 FILEOPS
 FILETIME
 FIXME
+FIXMEs
 FLCS
 FLD
 FLSv
@@ -200,8 +206,10 @@ FOREACH
 FS
 FTDC
 FULLFSYNC
+FUNC
 FUNCSIG
 Failpoint
+FieldType
 FindClose
 FindFirstFile
 FindNextFileW
@@ -270,6 +278,7 @@ JSON
 Jira
 Jyrki
 KEK
+KNF
 KV
 Kanowski's
 Keyedness
@@ -312,6 +321,7 @@ MALLOC
 MByte
 MEM
 MERCHANTABILITY
+MODULARITY
 MONGODB
 MOVEFILE
 MRXB
@@ -330,6 +340,7 @@ Mellor
 MemorySanitizer
 Metrix
 Moby
+ModifyFile
 MongoDB
 MoveFileExW
 MultiByteToWideChar
@@ -364,6 +375,8 @@ OOM
 OOO
 OPLOG
 OPTRACK
+OPTYPE
+OR'd
 OVFL
 ObWgfvgw
 Og
@@ -382,12 +395,15 @@ PPC
 PREFETCH
 PRELOAD
 PREV
+PRINTLOG
 PRId
 PRIu
+PRIuPTR
 PRNG
 PSD
 PSE
 PTR
+PTRDIFF
 PYTHONMALLOC
 Palite
 Palites
@@ -516,6 +532,7 @@ TXN
 TerminateProcess
 TestSuiteConnection
 Testcases
+TextWrapper
 ThreadList
 ThreadListWrapper
 ThreadsafeForwardingResult
@@ -533,8 +550,10 @@ UIDs
 UINT
 ULF
 ULINE
+ULL
 UNC
 UNCOND
+UNITTEST
 UNSKIPPED
 UPD
 URI
@@ -547,7 +566,9 @@ Unadopted
 Unbuffered
 Uncomment
 Unencrypted
+Unformatted
 Unhandled
+Unittest
 UnixLib
 Unlink
 UnlockFile
@@ -660,10 +681,12 @@ allocator's
 allocators
 allocfile
 allocsize
+allowlist
 analytics
 aor
 ap
 api
+apis
 arg
 argc
 args
@@ -754,15 +777,20 @@ buildvariant
 builtins
 bulkload
 bursty
+bytecode
 bytestring
 byteswap
 byvalue
 bzip
+bzl
 cX
 cacheable
 calc
+callee
+callgraph
 calloc
 cancelling
+capname
 cas
 catfmt
 cb
@@ -918,6 +946,7 @@ dec
 decile
 deciles
 decl
+decls
 decodable
 decompressor
 decr
@@ -974,6 +1003,8 @@ dlsym
 dmalloc
 dmb
 dmsg
+docstring
+doxygen
 drealloc
 dropUntilSuccess
 droppable
@@ -1024,12 +1055,15 @@ entlist
 enum
 env
 eof
+ep
+epp
 eq
 equalp
 errline
 errno
 errx
 esc
+escapedp
 et
 ev
 evd
@@ -1072,20 +1106,25 @@ fh
 fhandle
 fid
 fifo
+fileAliases
 filecmp
 filefrag
 fileid
+filelist
 fileop
 fileops
 filesize
 filesystem
 filesystems
+fini
 firstfit
+fixme
 fixup
 floatnum
 fmt
 fmterr
 fn
+fns
 fnv
 fnvhash
 foc
@@ -1112,6 +1151,7 @@ fsyncing
 ftruncate
 func
 funcid
+funcs
 futex
 fuzzer
 fuzzutil
@@ -1186,9 +1226,11 @@ idxname
 ie
 iface
 ifdef
+ifdef'd
 ifdef's
 ifdefs
 iff
+ifndef
 iiSii
 iiiS
 ikey
@@ -1241,6 +1283,7 @@ isascii
 isb
 isdigit
 ish
+ishex
 ishld
 ishst
 islocked
@@ -1278,6 +1321,7 @@ lN
 lang
 las
 latin
+layercparse
 lazyfs
 lbrace
 lbracket
@@ -1294,6 +1338,7 @@ lexically
 lexicographically
 lf
 libdatasource
+libmagic
 libmemkind
 libpthread
 libpython
@@ -1326,6 +1371,7 @@ logop
 logpath
 logread
 logrec
+logrecp
 logsize
 logslot
 logtest
@@ -1387,6 +1433,7 @@ mmap
 mmrand
 mn
 mnt
+modularity
 mongo
 mongod
 mongodb
@@ -1417,6 +1464,7 @@ nTemp
 namespace
 namespaced
 namespaces
+nb
 nbits
 nclose
 nclr
@@ -1487,6 +1535,7 @@ nuris
 nvram
 objectid
 offpage
+offsetof
 offsetp
 ok
 olddir
@@ -1505,9 +1554,13 @@ opendir
 openfile
 oplist
 oplog
+opsize
+opsizep
 optrack
 optwt
 optype
+optypep
+opvar
 orchestrator
 ord
 ori
@@ -1542,6 +1595,7 @@ pipefail
 plh
 pluggable
 pmem
+png
 poptable
 popthreads
 portably
@@ -1551,6 +1605,7 @@ posix
 postrun
 postsize
 powershell
+pragma
 pre
 pread
 prealloc
@@ -1595,6 +1650,7 @@ pthread
 ptr
 ptrdiff
 pv
+pval
 pwrite
 py
 pygit
@@ -1617,8 +1673,10 @@ rbrace
 rbracket
 rc
 rdlock
+rdparty
 rdtsc
 rduppo
+reachability
 readdir
 readgen
 readline
@@ -1642,6 +1700,7 @@ reconfiguring
 reconfigwt
 recsize
 rectype
+rectypep
 recurse
 reentrant
 refp
@@ -1736,6 +1795,7 @@ spinlock
 spinlocks
 sqlite
 src
+srcfile
 srch
 srv
 ss
@@ -1759,6 +1819,7 @@ stepup
 stlr
 stlrb
 stlrh
+storer
 str
 strace
 strcat
@@ -1842,6 +1903,7 @@ testutil
 th
 there'll
 tid
+timeseries
 timeslice
 timespec
 timestamper
@@ -1850,6 +1912,7 @@ tinfo
 tlb
 tmalloc
 tmp
+tmpp
 tmstmp
 tnum
 tod
@@ -1943,6 +2006,7 @@ unnamespaced
 unpackv
 unposition
 unpositioned
+unreachability
 unredact
 unredacted
 unredacts
@@ -2017,6 +2081,8 @@ wakeup
 wakeups
 warmup
 whitespace
+whitespace's
+whitespaces
 wiredTiger
 wiredTigerTables
 wiredtiger

--- a/dist/stat.py
+++ b/dist/stat.py
@@ -24,7 +24,7 @@ from stat_data import dsrc_stats, conn_stats, conn_dsrc_stats, session_stats
 
 ##########################################
 # Check for duplicate stat descriptions:
-# Duplicate stat descpriptions within a category are not allowed.
+# Duplicate stat descriptions within a category are not allowed.
 # The list must be sorted by description.
 ##########################################
 def check_unique_description(sorted_list):
@@ -37,7 +37,7 @@ def check_unique_description(sorted_list):
 ##########################################
 # Check the description format.
 # Removes prefix from description before checking.
-# Checks for leading/trailing whitespace, newlines, and leading/trailing punctation.
+# Checks for leading/trailing whitespace, newlines, and leading/trailing punctuation.
 ##########################################
 def check_description_format(stat):
     desc = stat.desc.split(': ', 1)[1]

--- a/dist/wtperf_config.py
+++ b/dist/wtperf_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-''' Output a doxgen version of the wtperf configuration options. '''
+''' Output a doxygen version of the wtperf configuration options. '''
 import sys
 
 for line in sys.stdin:


### PR DESCRIPTION
## Summary

- `s_string` never spell-checked `dist/*.py`, so typos in the config and statistics descriptions that feed the public documentation went unreported. Two gaps: the file list only swept `dist` for `*.[chsy]`, and the `*.py` filter declared `'# \0'` as its only context delimiter, so prose held in triple-quoted strings was skipped.
- Added `find dist -name '*.py'` to the file list, and a `dist/*.py` arm to `run_aspell_for` that also treats `''' '''` and `""" """` as context delimiters.
- The new filter is matched on **path, not extension**, deliberately. `test/**/*.py` keeps the comment-only filter: its triple-quoted strings hold code and config data rather than prose, and checking them would add ~979 identifiers to `s_string.ok` versus 66 for `dist`, diluting the word list enough to hide future typos.
- Also strip `\n`/`\t`/`\r` escapes in `check()`, since the dist scripts embed generated C in string literals and the escapes otherwise leak words like `tmemset`.
- Second commit fixes the 10 typos this surfaces. Two needed more than a spelling correction: the `api_err.py` comment named `wiredtiger_sterror_r`, which does not exist in any spelling, so it now names the two functions the block actually emits; and `prototypes.py` used the British *modularise*, whose American spelling is also absent from aspell's dictionary, so the sentence is reworded rather than whitelisting a word used once.

## Out of scope

- Python under `bench/` (58 files), `tools/` (45), `lang/` (6), `examples/` (2) and `src/` (3) is still unchecked. None of it feeds the public documentation.
- `s_string` exits 0 when aspell is absent, and `s_all`'s `errchk` explicitly whitelists `.*skipped`. Deliberate for local development, but a CI image change would silently disable spell checking. Noted on the ticket as separate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)