### PR TITLE
WT-18373 Remove dead null check on history store cursor in __wt_hs_verify_one

### DIFF
--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -233,8 +233,7 @@ __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
     WT_ERR(__wt_btcur_close(&ds_cbt, false));
 
 err:
-    if (hs_cursor != NULL)
-        WT_TRET(hs_cursor->close(hs_cursor));
+    WT_TRET(hs_cursor->close(hs_cursor));
     return (ret);
 }
 


### PR DESCRIPTION
### Summary

Coverity flagged hs_cursor != NULL at src/history/hs_verify.c:236 as a redundant/dead condition (CID 207190). By the point execution reaches the err: label, hs_cursor is always non-NULL: __wt_hs_verify_one returns early at line 202/203-209 whenever __wt_hs_verify_cursor_open fails or hands back a NULL cursor, so every path that jumps to err: already holds a valid cursor.

Removes the unreachable null check before hs_cursor->close().

