### PR TITLE
WT-18362 Skip closed dhandles during checkpoint walks

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -752,7 +752,8 @@ __conn_btree_apply_internal(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle,
      * We need to pull the handle into the session handle cache and make sure it's referenced to
      * stop other internal code dropping the handle.
      */
-    if ((ret = __wt_session_get_dhandle(session, dhandle->name, dhandle->checkpoint, NULL, 0)) != 0)
+    if ((ret = __wt_session_get_dhandle(
+           session, dhandle->name, dhandle->checkpoint, NULL, WT_DHANDLE_SKIP_REOPEN)) != 0)
         return (ret == EBUSY ? 0 : ret);
 
     time_start = WT_SESSION_IS_CHECKPOINT(session) ? __wt_clock(session) : 0;

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -753,7 +753,7 @@ __conn_btree_apply_internal(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle,
      * stop other internal code dropping the handle.
      */
     if ((ret = __wt_session_get_dhandle(
-           session, dhandle->name, dhandle->checkpoint, NULL, WT_DHANDLE_SKIP_REOPEN)) != 0)
+           session, dhandle->name, dhandle->checkpoint, NULL, WT_DHANDLE_SKIP_OPEN)) != 0)
         return (ret == EBUSY ? 0 : ret);
 
     time_start = WT_SESSION_IS_CHECKPOINT(session) ? __wt_clock(session) : 0;

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -181,7 +181,7 @@ struct __wt_data_handle {
 #define WT_DHANDLE_LOCK_ONLY 0x100u    /* Handle only used as a lock */
 #define WT_DHANDLE_OPEN 0x200u         /* Handle is open */
 #define WT_DHANDLE_OUTDATED 0x400u     /* Handle is outdated */
-#define WT_DHANDLE_SKIP_REOPEN 0x800u  /* Do not reopen a closed handle */
+#define WT_DHANDLE_SKIP_OPEN 0x800u    /* Do not open a closed handle */
                                        /* AUTOMATIC FLAG VALUE GENERATION STOP 12 */
     uint16_t flags;
 

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -181,6 +181,7 @@ struct __wt_data_handle {
 #define WT_DHANDLE_LOCK_ONLY 0x100u    /* Handle only used as a lock */
 #define WT_DHANDLE_OPEN 0x200u         /* Handle is open */
 #define WT_DHANDLE_OUTDATED 0x400u     /* Handle is outdated */
+#define WT_DHANDLE_SKIP_REOPEN 0x800u  /* Do not reopen a closed handle */
                                        /* AUTOMATIC FLAG VALUE GENERATION STOP 12 */
     uint16_t flags;
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -64,6 +64,19 @@ __wt_session_dhandle_writeunlock(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __session_dhandle_exclusive_unlock --
+ *     Clear exclusive ownership and unlock a data handle.
+ */
+static void
+__session_dhandle_exclusive_unlock(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle)
+{
+    dhandle->excl_session = NULL;
+    dhandle->excl_ref = 0;
+    F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
+    WT_WITH_DHANDLE(session, dhandle, __wt_session_dhandle_writeunlock(session));
+}
+
+/*
  * __wt_session_dhandle_try_writelock --
  *     Try to acquire write lock for the session's current dhandle.
  */
@@ -949,13 +962,14 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
             continue;
         }
 
-        /* A handle closed by sweep is already durable, so do not reopen it for a dhandle walk. */
+        /*
+         * A handle closed by sweep is already durable, so do not reopen it for a dhandle walk.
+         * __wt_session_lock_dhandle gives us exclusive ownership for a closed handle; release it
+         * before returning EBUSY.
+         */
         if (LF_ISSET(WT_DHANDLE_SKIP_OPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
             WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE));
-            dhandle->excl_session = NULL;
-            dhandle->excl_ref = 0;
-            F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
-            WT_WITH_DHANDLE(session, dhandle, __wt_session_dhandle_writeunlock(session));
+            __session_dhandle_exclusive_unlock(session, dhandle);
             WT_ERR(EBUSY);
         }
 
@@ -975,10 +989,7 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
          * enforce this.
          */
         if (!FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA)) {
-            dhandle->excl_session = NULL;
-            dhandle->excl_ref = 0;
-            F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
-            WT_WITH_DHANDLE(session, dhandle, __wt_session_dhandle_writeunlock(session));
+            __session_dhandle_exclusive_unlock(session, dhandle);
 
             /*
              * FIXME-WT-16477: work around to ensure we always acquire the checkpoint lock before
@@ -1019,10 +1030,7 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
          * If we got the handle exclusive to open it but only want ordinary access, drop our lock
          * and retry the open.
          */
-        dhandle->excl_session = NULL;
-        dhandle->excl_ref = 0;
-        F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
-        WT_WITH_DHANDLE(session, dhandle, __wt_session_dhandle_writeunlock(session));
+        __session_dhandle_exclusive_unlock(session, dhandle);
         WT_ERR(ret);
     }
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -952,10 +952,10 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
         /* A handle closed by sweep is already durable, so do not reopen it for a dhandle walk. */
         if (LF_ISSET(WT_DHANDLE_SKIP_OPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
             WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE));
-            __wt_tsan_suppress_store_wt_session_impl_ptr(&dhandle->excl_session, NULL);
+            dhandle->excl_session = NULL;
             dhandle->excl_ref = 0;
             F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
-            __wt_session_dhandle_writeunlock(session);
+            WT_WITH_DHANDLE(session, dhandle, __wt_session_dhandle_writeunlock(session));
             WT_ERR(EBUSY);
         }
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -951,7 +951,11 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
 
         /* A handle closed by sweep is already durable, so do not reopen it for a dhandle walk. */
         if (LF_ISSET(WT_DHANDLE_SKIP_OPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
-            WT_TRET(__wt_session_release_dhandle(session));
+            WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE));
+            __wt_tsan_suppress_store_wt_session_impl_ptr(&dhandle->excl_session, NULL);
+            dhandle->excl_ref = 0;
+            F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
+            __wt_session_dhandle_writeunlock(session);
             WT_ERR(EBUSY);
         }
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -944,15 +944,15 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
         /* Try to lock the handle. */
         WT_ERR(__wt_session_lock_dhandle(session, flags, &is_dead));
         if (is_dead) {
-            if (LF_ISSET(WT_DHANDLE_SKIP_REOPEN))
+            if (LF_ISSET(WT_DHANDLE_SKIP_OPEN))
                 WT_ERR(EBUSY);
             continue;
         }
 
         /* A handle closed by sweep is already durable, so do not reopen it for a dhandle walk. */
-        if (LF_ISSET(WT_DHANDLE_SKIP_REOPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
+        if (LF_ISSET(WT_DHANDLE_SKIP_OPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
             WT_TRET(__wt_session_release_dhandle(session));
-            return (EBUSY);
+            WT_ERR(EBUSY);
         }
 
         /* If the handle is open in the mode we want, we're done. */

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -943,8 +943,11 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
 
         /* Try to lock the handle. */
         WT_ERR(__wt_session_lock_dhandle(session, flags, &is_dead));
-        if (is_dead)
+        if (is_dead) {
+            if (LF_ISSET(WT_DHANDLE_SKIP_REOPEN))
+                WT_ERR(EBUSY);
             continue;
+        }
 
         /* A handle closed by sweep is already durable, so do not reopen it for a dhandle walk. */
         if (LF_ISSET(WT_DHANDLE_SKIP_REOPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -946,6 +946,12 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
         if (is_dead)
             continue;
 
+        /* A handle closed by sweep is already durable, so do not reopen it for a dhandle walk. */
+        if (LF_ISSET(WT_DHANDLE_SKIP_REOPEN) && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
+            WT_TRET(__wt_session_release_dhandle(session));
+            return (EBUSY);
+        }
+
         /* If the handle is open in the mode we want, we're done. */
         if (LF_ISSET(WT_DHANDLE_LOCK_ONLY) ||
           (F_ISSET(dhandle, WT_DHANDLE_OPEN) && !LF_ISSET(WT_BTREE_SPECIAL_FLAGS)))

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -24,7 +24,7 @@
 TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle][dhandle_ebusy]")
 {
     const std::string home = "WT_TEST.dhandle_ebusy";
-    testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
+    utils::wiredtiger_cleanup(home);
 
     {
         connection_wrapper conn(home);

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -56,7 +56,7 @@ TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle][dh
 TEST_CASE("skip reopening a dhandle closed by sweep", "[dhandle][dhandle_skip_reopen]")
 {
     const std::string home = "WT_TEST.dhandle_skip_reopen";
-    testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
+    utils::wiredtiger_cleanup(home);
 
     {
         connection_wrapper conn(home);

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -73,7 +73,7 @@ TEST_CASE("skip reopening a dhandle closed by sweep", "[dhandle][dhandle_skip_re
 
         WT_SESSION_IMPL *session_impl_b = conn.create_session();
         int ret = __wt_session_get_dhandle(
-          session_impl_b, "file:t.wt", nullptr, nullptr, WT_DHANDLE_SKIP_REOPEN);
+          session_impl_b, "file:t.wt", nullptr, nullptr, WT_DHANDLE_SKIP_OPEN);
         CHECK(ret == EBUSY);
         CHECK(session_impl_b->dhandle == nullptr);
         CHECK(F_ISSET(dhandle, WT_DHANDLE_DEAD));

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -67,16 +67,16 @@ TEST_CASE("skip reopening a dhandle closed by sweep", "[dhandle][dhandle_skip_re
         REQUIRE(__wt_session_get_dhandle(session_impl, "file:t.wt", nullptr, nullptr, 0) == 0);
 
         WT_DATA_HANDLE *dhandle = session_impl->dhandle;
-        REQUIRE(__wt_conn_dhandle_close(session_impl, false, false, false) == 0);
+        REQUIRE(__wt_conn_dhandle_close(session_impl, false, true, false) == 0);
         REQUIRE(__wt_session_release_dhandle(session_impl) == 0);
-        CHECK_FALSE(F_ISSET(dhandle, WT_DHANDLE_OPEN));
+        CHECK(F_ISSET(dhandle, WT_DHANDLE_DEAD));
 
         WT_SESSION_IMPL *session_impl_b = conn.create_session();
         int ret = __wt_session_get_dhandle(
           session_impl_b, "file:t.wt", nullptr, nullptr, WT_DHANDLE_SKIP_REOPEN);
         CHECK(ret == EBUSY);
         CHECK(session_impl_b->dhandle == nullptr);
-        CHECK_FALSE(F_ISSET(dhandle, WT_DHANDLE_OPEN));
+        CHECK(F_ISSET(dhandle, WT_DHANDLE_DEAD));
     }
 
     utils::wiredtiger_cleanup(home);

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -52,3 +52,32 @@ TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle][dh
 
     utils::wiredtiger_cleanup(home);
 }
+
+TEST_CASE("skip reopening a dhandle closed by sweep", "[dhandle][dhandle_skip_reopen]")
+{
+    const std::string home = "WT_TEST.dhandle_skip_reopen";
+    testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
+
+    {
+        connection_wrapper conn(home);
+
+        WT_SESSION_IMPL *session_impl = conn.create_session();
+        WT_SESSION *session = &session_impl->iface;
+        REQUIRE(session->create(session, "file:t.wt", "key_format=i,value_format=i") == 0);
+        REQUIRE(__wt_session_get_dhandle(session_impl, "file:t.wt", nullptr, nullptr, 0) == 0);
+
+        WT_DATA_HANDLE *dhandle = session_impl->dhandle;
+        REQUIRE(__wt_conn_dhandle_close(session_impl, false, false, false) == 0);
+        REQUIRE(__wt_session_release_dhandle(session_impl) == 0);
+        CHECK_FALSE(F_ISSET(dhandle, WT_DHANDLE_OPEN));
+
+        WT_SESSION_IMPL *session_impl_b = conn.create_session();
+        int ret = __wt_session_get_dhandle(
+          session_impl_b, "file:t.wt", nullptr, nullptr, WT_DHANDLE_SKIP_REOPEN);
+        CHECK(ret == EBUSY);
+        CHECK(session_impl_b->dhandle == nullptr);
+        CHECK_FALSE(F_ISSET(dhandle, WT_DHANDLE_OPEN));
+    }
+
+    utils::wiredtiger_cleanup(home);
+}


### PR DESCRIPTION
Checkpoint and stat walks can race with sweep after releasing the handle-list read lock. This change prevents those walks from reopening a handle that sweep closed, avoiding redundant eviction and btree preload work while preserving lock and reference cleanup.