### PR TITLE
WT-13640 Implement Locking Mechanism for default session scratch buffer operations

### DIFF
--- a/src/include/session.h
+++ b/src/include/session.h
@@ -157,9 +157,10 @@ struct __wt_session_impl {
     WT_RWLOCK *current_rwlock;
     uint8_t current_rwticket;
 
-    WT_ITEM **scratch;     /* Temporary memory for any function */
-    u_int scratch_alloc;   /* Currently allocated */
-    size_t scratch_cached; /* Scratch bytes cached */
+    WT_ITEM **scratch;        /* Temporary memory for any function */
+    u_int scratch_alloc;      /* Currently allocated */
+    size_t scratch_cached;    /* Scratch bytes cached */
+    WT_SPINLOCK scratch_lock; /* Scratch buffer lock */
 #ifdef HAVE_DIAGNOSTIC
 
     /* Enforce the contract that a session is only used by a single thread at a time. */

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -407,6 +407,9 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
     /* Decrement the count of open sessions. */
     WT_STAT_CONN_DECR(session, session_open);
 
+    __wt_spin_unlock_if_owned(session, &session->scratch_lock);
+    __wt_spin_destroy(session, &session->scratch_lock);
+
 #ifdef HAVE_DIAGNOSTIC
     /*
      * Unlock the thread_check mutex if we own it, this a bit of a cheeky workaround as there's one
@@ -2633,6 +2636,8 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
 #ifdef HAVE_DIAGNOSTIC
     WT_ERR(__wt_spin_init(session, &session_ret->thread_check.lock, "thread check lock"));
 #endif
+
+    WT_ERR(__wt_spin_init(session, &session_ret->scratch_lock, "scratch buffer lock"));
 
     /*
      * Initialize the pseudo random number generator. We're not seeding it, so all of the sessions

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -274,6 +274,15 @@ __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp
     size_t allocated;
     u_int i;
 
+    /*
+     * To prevent concurrent access to the scratch buffer, a lock should be acquired for internal
+     * sessions, which are shared across multiple threads. This is necessary to avoid situations
+     * where multiple threads attempt to access the same scratch buffer slot simultaneously,
+     * potentially leading to race condition.
+     */
+    if (F_ISSET(session, WT_SESSION_INTERNAL))
+        __wt_spin_lock(session, &session->scratch_lock);
+
     /* Don't risk the caller not catching the error. */
     *scratchp = NULL;
 
@@ -349,9 +358,15 @@ __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp
 #endif
 
     *scratchp = *best;
+    if (F_ISSET(session, WT_SESSION_INTERNAL))
+        __wt_spin_unlock(session, &session->scratch_lock);
+
     return (0);
 
 err:
+    if (F_ISSET(session, WT_SESSION_INTERNAL))
+        __wt_spin_unlock(session, &session->scratch_lock);
+
     WT_RET_MSG(session, ret, "session unable to allocate a scratch buffer");
 }
 


### PR DESCRIPTION
This pull request Implements a locking mechanism to prevent concurrent access to the scratch buffer while using the connections default session.