### PR TITLE
WT-15591 Check the disaggregated shared metadata alongside the local metadata

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -613,7 +613,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
      * - the debug flag is set where we do not clear the record's txn IDs. Visibility rules may not
      * work correctly when we do not clear the record's txn IDs.
      */
-    skip_hs = strcmp(name, WT_METAFILE_URI) == 0 || WT_IS_URI_HS(name) ||
+    skip_hs = WT_IS_URI_METADATA(name) || WT_IS_URI_HS(name) ||
       F_ISSET(session, WT_SESSION_DEBUG_DO_NOT_CLEAR_TXN_ID);
 
     /* Loop through the file's checkpoints, verifying each one. */

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3265,7 +3265,7 @@ fake:
      * that case, we need to sync the file here or we could roll forward the metadata in recovery
      * and open a checkpoint that isn't yet durable.
      */
-    if (WT_IS_METADATA(dhandle) || !F_ISSET(session->txn, WT_TXN_RUNNING))
+    if (WT_IS_ANY_METADATA(dhandle) || !F_ISSET(session->txn, WT_TXN_RUNNING))
         WT_ERR_MSG_CHK(
           session, __wt_checkpoint_sync(session, NULL), "checkpoint failed during file sync");
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -495,6 +495,9 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
     /* Should not be called with anything other than a live btree handle. */
     WT_ASSERT(session, WT_DHANDLE_BTREE(session->dhandle) && !WT_READING_CHECKPOINT(session));
 
+    /* Both handle walks skip the metadata trees; they are checkpointed on their own at the end. */
+    WT_ASSERT(session, !WT_IS_ANY_METADATA(session->dhandle));
+
     btree = S2BT(session);
 
     /*
@@ -513,9 +516,6 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
         return (0);
 
     if (__wt_conn_is_disagg(session)) {
-        /* Skip the shared metadata table for disaggregated storage; we'll checkpoint it later. */
-        if (WT_IS_DISAGG_META(btree->dhandle))
-            return (0);
         /* Skip checkpointing shared tables if we are not a leader. */
         if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
           !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
@@ -546,7 +546,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
         S2C(session)->ckpt.handle_stats.meta_check_time += time_diff;
         if (ret == WT_ROLLBACK) {
             /*
-             * If create or drop or any schema operation of a table is with in an user transaction
+             * If create or drop or any schema operation of a table is within an user transaction
              * then checkpoint can see the dhandle before the commit, which will lead to the
              * rollback error. We will ignore this dhandle as part of this checkpoint by returning
              * from here.

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -817,7 +817,7 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
             if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
               F_ISSET(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_OUTDATED) ||
               !WT_DHANDLE_BTREE(dhandle) || dhandle->checkpoint != NULL ||
-              WT_IS_METADATA(dhandle) || WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
+              WT_IS_ANY_METADATA(dhandle) || WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
                 continue;
 
             WT_ERR(__conn_btree_apply_internal(session, dhandle, file_func, name_func, cfg));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1201,7 +1201,7 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
         cursor->modify = __curfile_modify;
 
     /* Cursors on metadata should not be cached, doing so interferes with named checkpoints. */
-    if (cacheable && strcmp(WT_METAFILE_URI, cursor->internal_uri) != 0)
+    if (cacheable && !WT_IS_URI_METADATA(cursor->internal_uri))
         F_SET(cursor, WT_CURSTD_CACHEABLE);
 
     WT_ERR(__wt_cursor_init(cursor, cursor->internal_uri, owner, cfg, cursorp));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1201,7 +1201,7 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
         cursor->modify = __curfile_modify;
 
     /* Cursors on metadata should not be cached, doing so interferes with named checkpoints. */
-    if (cacheable && !WT_IS_URI_METADATA(cursor->internal_uri))
+    if (cacheable && strcmp(WT_METAFILE_URI, cursor->internal_uri) != 0)
         F_SET(cursor, WT_CURSTD_CACHEABLE);
 
     WT_ERR(__wt_cursor_init(cursor, cursor->internal_uri, owner, cfg, cursorp));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1202,8 +1202,8 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
 
     /*
      * Cursors on metadata should not be cached, doing so interferes with named checkpoints. The
-     * shared metadata is cached instead: it has no per-session cursor of its own and is opened once
-     * per queued metadata operation.
+     * shared metadata is cached instead: it has no per-session cursor of its own and a cursor is
+     * opened and closed for every key it writes.
      */
     if (cacheable && strcmp(WT_METAFILE_URI, cursor->internal_uri) != 0)
         F_SET(cursor, WT_CURSTD_CACHEABLE);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1200,7 +1200,11 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
       __wt_version_gte(S2C(session)->compat_version, WT_LOG_V2_VERSION))
         cursor->modify = __curfile_modify;
 
-    /* Cursors on metadata should not be cached, doing so interferes with named checkpoints. */
+    /*
+     * Cursors on metadata should not be cached, doing so interferes with named checkpoints. The
+     * shared metadata is cached instead: it has no per-session cursor of its own and is opened once
+     * per queued metadata operation.
+     */
     if (cacheable && strcmp(WT_METAFILE_URI, cursor->internal_uri) != 0)
         F_SET(cursor, WT_CURSTD_CACHEABLE);
 

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -141,7 +141,7 @@ __wt_curhs_cache(WT_SESSION_IMPL *session)
      */
     if (F_ISSET(conn, WT_CONN_IN_MEMORY | WT_CONN_RECOVERING_METADATA) ||
       F_ISSET(session, WT_SESSION_NO_RECONCILE) ||
-      (session->dhandle != NULL && WT_IS_METADATA(S2BT(session)->dhandle)) ||
+      (session->dhandle != NULL && WT_IS_ANY_METADATA(S2BT(session)->dhandle)) ||
       session == conn->default_session)
         return (0);
 

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -933,7 +933,8 @@ __wt_evict_app_assist_worker_check(WT_SESSION_IMPL *session, bool busy, bool rea
      * other resources that could block checkpoints or eviction.
      */
     WT_BTREE *btree = S2BT_SAFE(session);
-    if (btree != NULL && (F_ISSET(btree, WT_BTREE_NO_EVICT) || WT_IS_METADATA(session->dhandle)))
+    if (btree != NULL &&
+      (F_ISSET(btree, WT_BTREE_NO_EVICT) || WT_IS_ANY_METADATA(session->dhandle)))
         return (0);
 
     /* Check if eviction is needed. */

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1218,7 +1218,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
      * Since there is no history store for metadata, we won't be able to serve an older reader if we
      * evict this page.
      */
-    if (WT_IS_METADATA(session->dhandle) && F_ISSET(evict, WT_EVICT_CACHE_CLEAN_HARD) &&
+    if (WT_IS_ANY_METADATA(session->dhandle) && F_ISSET(evict, WT_EVICT_CACHE_CLEAN_HARD) &&
       F_ISSET(ref, WT_REF_FLAG_LEAF) && !modified && page->modify != NULL &&
       !__wt_txn_visible_all(session, page->modify->rec_max_txn, page->modify->rec_max_timestamp)) {
         WT_STAT_CONN_INCR(session, eviction_server_skip_metatdata_with_history);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2626,7 +2626,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     }
 
     /* If the metadata page is clean but has modifications that appear too new to evict, skip it. */
-    if (WT_IS_METADATA(btree->dhandle) && !modified &&
+    if (WT_IS_ANY_METADATA(btree->dhandle) && !modified &&
       !__wt_txn_visible_all(session, mod->rec_max_txn, mod->rec_max_timestamp)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_recently_modified);
         return (false);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -110,7 +110,7 @@ __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recno)
     op = txn->mod + txn->mod_count - 1;
 
     if (WT_SESSION_IS_CHECKPOINT(session) || WT_IS_HS(op->btree->dhandle) ||
-      WT_IS_METADATA(op->btree->dhandle))
+      WT_IS_ANY_METADATA(op->btree->dhandle))
         return;
 
     WT_ASSERT(session, op->type == WT_TXN_OP_BASIC_COL || op->type == WT_TXN_OP_INMEM_COL);
@@ -144,7 +144,7 @@ __txn_op_need_set_key(WT_TXN *txn, WT_TXN_OP *op)
         return (false);
 
     /* Metadata writes cannot be prepared. */
-    if (WT_IS_METADATA(op->btree->dhandle))
+    if (WT_IS_ANY_METADATA(op->btree->dhandle))
         return (false);
 
     /* Auto transactions cannot be prepared. */
@@ -2481,7 +2481,7 @@ __wt_txn_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE 
     }
 
     /* Everything is OK, optionally rollback for testing (skipping metadata operations). */
-    if (!WT_IS_METADATA(cbt->dhandle)) {
+    if (!WT_IS_ANY_METADATA(cbt->dhandle)) {
         txn_global = &S2C(session)->txn_global;
         if (txn_global->debug_rollback != 0 &&
           ++txn_global->debug_ops % txn_global->debug_rollback == 0)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1814,7 +1814,7 @@ retry:
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (!__wt_btree_stays_in_memory(S2BT(session)) &&
       F_ISSET_ATOMIC_32(S2C(session), WT_CONN_HS_OPEN) &&
-      !F_ISSET(session->dhandle, WT_DHANDLE_HS) && !WT_IS_METADATA(session->dhandle)) {
+      !F_ISSET(session->dhandle, WT_DHANDLE_HS) && !WT_IS_ANY_METADATA(session->dhandle)) {
         /*
          * Stressing this code path may slow down the system too much. To minimize the impact, sleep
          * on every random 100th iteration when this is enabled.

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -892,7 +892,7 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
     /*
      * The metadata is tracked specially because of optimizations for checkpoints.
      */
-    if (session->dhandle != NULL && WT_IS_METADATA(session->dhandle))
+    if (session->dhandle != NULL && WT_IS_ANY_METADATA(session->dhandle))
         return (__wt_atomic_load_uint64_v_relaxed(&txn_global->metadata_pinned));
 
     /*

--- a/src/meta/meta_apply.c
+++ b/src/meta/meta_apply.c
@@ -26,7 +26,7 @@ __meta_btree_apply(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
      * Accumulate errors but continue through to the end of the metadata.
      */
     while ((t_ret = cursor->next(cursor)) == 0) {
-        if ((t_ret = cursor->get_key(cursor, &uri)) != 0 || strcmp(uri, WT_METAFILE_URI) == 0) {
+        if ((t_ret = cursor->get_key(cursor, &uri)) != 0 || WT_IS_URI_METADATA(uri)) {
             WT_TRET(t_ret);
             continue;
         }

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -445,8 +445,8 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
 
     while ((ret = cursor->next(cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));
-        /* Only interested in btree handles that aren't the metadata */
-        if (!WT_BTREE_PREFIX(uri) || strcmp(uri, WT_METAFILE_URI) == 0)
+        /* Only interested in btree handles that aren't a metadata tree */
+        if (!WT_BTREE_PREFIX(uri) || WT_IS_URI_METADATA(uri))
             continue;
         WT_ERR_NOTFOUND_OK(cursor->get_value(cursor, &config), true);
         if (ret == WT_NOTFOUND)

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -824,7 +824,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
              * can't discard the uncommitted updates.
              */
             if (upd_select->upd != NULL) {
-                WT_ASSERT_ALWAYS(session, WT_IS_METADATA(session->dhandle),
+                WT_ASSERT_ALWAYS(session, WT_IS_ANY_METADATA(session->dhandle),
                   "Uncommitted update followed by committed update in a non-metadata file");
                 return (__wt_set_return(session, EBUSY));
             }
@@ -991,7 +991,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
          * with read uncommitted isolation and we may see a committed update followed by uncommitted
          * updates
          */
-        if (!F_ISSET(r, WT_REC_EVICT) || !WT_IS_METADATA(session->dhandle))
+        if (!F_ISSET(r, WT_REC_EVICT) || !WT_IS_ANY_METADATA(session->dhandle))
             break;
     }
 
@@ -1064,8 +1064,8 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
 
             continue;
         }
-        /* Give up if the update is from this transaction and on the metadata file. */
-        if (WT_IS_METADATA(session->dhandle) && session_txnid != WT_TXN_NONE &&
+        /* Give up if the update is from this transaction and on a metadata tree. */
+        if (WT_IS_ANY_METADATA(session->dhandle) && session_txnid != WT_TXN_NONE &&
           upd->txnid == session_txnid)
             return (__wt_set_return(session, EBUSY));
         /* Track the first update in the chain that is not aborted */
@@ -1100,7 +1100,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
              * can't discard the uncommitted updates.
              */
             if (upd_select->upd != NULL) {
-                WT_ASSERT_ALWAYS(session, WT_IS_METADATA(session->dhandle),
+                WT_ASSERT_ALWAYS(session, WT_IS_ANY_METADATA(session->dhandle),
                   "Uncommitted update followed by committed update in a non-metadata file");
                 return (__wt_set_return(session, EBUSY));
             }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -824,7 +824,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
              * can't discard the uncommitted updates.
              */
             if (upd_select->upd != NULL) {
-                WT_ASSERT_ALWAYS(session, WT_IS_ANY_METADATA(session->dhandle),
+                WT_ASSERT_ALWAYS(session, WT_IS_METADATA(session->dhandle),
                   "Uncommitted update followed by committed update in a non-metadata file");
                 return (__wt_set_return(session, EBUSY));
             }
@@ -991,7 +991,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
          * with read uncommitted isolation and we may see a committed update followed by uncommitted
          * updates
          */
-        if (!F_ISSET(r, WT_REC_EVICT) || !WT_IS_ANY_METADATA(session->dhandle))
+        if (!F_ISSET(r, WT_REC_EVICT) || !WT_IS_METADATA(session->dhandle))
             break;
     }
 
@@ -1100,7 +1100,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
              * can't discard the uncommitted updates.
              */
             if (upd_select->upd != NULL) {
-                WT_ASSERT_ALWAYS(session, WT_IS_ANY_METADATA(session->dhandle),
+                WT_ASSERT_ALWAYS(session, WT_IS_METADATA(session->dhandle),
                   "Uncommitted update followed by committed update in a non-metadata file");
                 return (__wt_set_return(session, EBUSY));
             }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1601,7 +1601,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * checkpoint in a concurrent session.
      */
     WT_ASSERT_ALWAYS(session,
-      !WT_IS_METADATA(session->dhandle) || upd == NULL || upd->txnid == WT_TXN_NONE ||
+      !WT_IS_ANY_METADATA(session->dhandle) || upd == NULL || upd->txnid == WT_TXN_NONE ||
         upd->txnid !=
           __wt_atomic_load_uint64_v_relaxed(&S2C(session)->txn_global.checkpoint_txn_shared.id) ||
         WT_SESSION_IS_CHECKPOINT(session),

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -155,7 +155,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
 
     /* Can't do history store eviction for history store itself or for metadata. */
     WT_ASSERT(session,
-      !LF_ISSET(WT_REC_HS) || (!WT_IS_HS(btree->dhandle) && !WT_IS_METADATA(btree->dhandle)));
+      !LF_ISSET(WT_REC_HS) || (!WT_IS_HS(btree->dhandle) && !WT_IS_ANY_METADATA(btree->dhandle)));
     /* Flag as unused for non diagnostic builds. */
     WT_UNUSED(btree);
 
@@ -980,7 +980,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
      */
     r->hs_clear_on_tombstone = F_ISSET(r, WT_REC_HS) &&
       !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
-      !WT_IS_METADATA(btree->dhandle);
+      !WT_IS_ANY_METADATA(btree->dhandle);
 
 /*
  * If we allocated the reconciliation structure and there was an error, clean up. If our caller


### PR DESCRIPTION
WT-18364 added `WT_IS_ANY_METADATA` but converted only the sites that already tested both flags. This converts the rest of the checks that hold for the shared metadata as much as the local one: the history store ones, since `__evict_reconcile()` never sets `WT_REC_HS` for either tree and neither has history to fall back on; verify's history store skip and prepared discovery, which have no business touching either tree; the metadata pinned ID, eviction assistance, prepare key and recno tracking, the debug rollback injection, the post-checkpoint sync and the concurrent-checkpoint-write assertion. Name-based sites use the existing `WT_IS_URI_METADATA` rather than an open-coded compare.

Converting `__wt_txn_oldest_id()` is what gives the eviction guards teeth on the shared metadata: the tree is bounded by `metadata_pinned` rather than the plain `oldest_id`, so a page whose last written transaction is the running checkpoint's own is no longer globally visible and is left in cache. Without that, the guards would only ever engage on the timestamp half.

The checkpoint's two handle walks each skipped the local metadata only, leaving `__wt_checkpoint_get_handles()` to bounce the shared metadata itself. Both walks now skip both trees and the checkpoint asserts it never sees either; each is checkpointed on its own at the end. The metadata walk is shared with the backup cursor, which disaggregated storage does not use, and the open handle walk is shared with statistics logging, which already omits the local metadata for the same reason.

Three sites stay narrow, and must. The two "uncommitted update followed by committed update" assertions and the walk-the-whole-chain condition exist because the local metadata skips the snapshot modify-check in `__wt_txn_modify_check()` and so can build a chain where a committed update sits above an uncommitted one. The shared metadata does not skip that check, cannot build such a chain, and widening the assertions would silence a real ordering bug rather than fix a false one. That also means the modify-check exemption itself has to keep testing the local metadata alone.

Cursor caching stays on for the shared metadata too, with a comment recording why. The local metadata is excluded from the cursor cache because it has a per-session cursor of its own; the shared metadata has none and opens a cursor for every key it writes, so excluding it triples the cursor creates a standby does at open.
