### PR TITLE
WT-18396 Add a test to ensure we cannot drop a table with stable but uncheckpointed data

### DIFF
--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -195,6 +195,39 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.set_stable_epoch(8)
         self.leader_checkpoint(11)
 
+    def test_drop_published_with_uncheckpoint_stable_data(self):
+        # Create and publish at epoch 5.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+
+        # Write and checkpoint at ts 10, epoch 6. Epoch 6 > publish epoch 5, so
+        # the checkpoint covers the create and clears AWAITS_PUBLISH.
+        self.write_rows(commit_ts=10)
+        self.set_stable_epoch(6)
+        self.leader_checkpoint(10)
+
+        # Write new data at ts 11 and set stable ts to 11 -- stable, but uncheckpointed data.
+        self.write_rows(commit_ts=11)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(11))
+
+        # The drop must be refused: Deferring a drop to a later checkpoint is only safe when the
+        # table is fully checkpointed. A checkpoint taken before the drop's epoch becomes stable
+        # would still owe the writes at ts 11, which no existing checkpoint holds and a dropped
+        # table can no longer produce.
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(self.uri))
+        err, sub, msg = self.session.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
+        self.assertTrue('dirty data' in msg)
+
+        # Checkpoint to quiesce dirty state so teardown can close cleanly.
+        self.set_stable_epoch(8)
+        self.leader_checkpoint(12)
+
     def test_drop_with_drained_data_is_refused(self):
         # The step-up drain moves follower-era ingest rows into a stable constituent created
         # awaiting publication, so until a checkpoint publishes the table those rows exist only in

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -195,7 +195,7 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.set_stable_epoch(8)
         self.leader_checkpoint(11)
 
-    def test_drop_published_with_uncheckpoint_stable_data(self):
+    def test_drop_published_with_uncheckpointed_stable_data(self):
         # Create and publish at epoch 5.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
             ',oldest_timestamp=' + self.timestamp_str(1))


### PR DESCRIPTION
Adds test_drop_published_with_uncheckpointed_stable_data to test_layered_schema21.py, pinning down an invariant the schema epoch API relies on: a table with stable but uncheckpointed data cannot be dropped.

The schema epoch API may defer a table drop to a later checkpoint only when the table is fully checkpointed — the existing table entry can then be carried into that checkpoint unchanged. If uncheckpointed data exists at drop time, a checkpoint the drop is deferred past would still owe those writes based on the stable timestamp, and neither a preexisting checkpoint nor a dropped table can supply them.