### PR TITLE
WT-18048 Fix use-after-free of the cached checkpoint list in the extent-list dump (9.0)

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -1212,13 +1212,26 @@ __wti_block_checkpoint_extlist_dump(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_BLOCK_CKPT *ci;
     WT_CKPT *ckpt_iter, *ckptbase;
+    WT_DECL_ITEM(name_buf);
     WT_DECL_RET;
-    size_t ckpt_bytes_allocated;
+    char *config;
+    const char *fname;
 
     ckptbase = NULL;
+    config = NULL;
 
-    WT_ERR(__wt_meta_ckptlist_get(
-      session, session->dhandle->name, false, &ckptbase, &ckpt_bytes_allocated));
+    /*
+     * Build a private checkpoint list from the metadata rather than calling __wt_meta_ckptlist_get,
+     * which in its cached path hands back the btree's live checkpoint list by reference. This
+     * function attaches transient block manager state to every entry and frees the list when done,
+     * so operating on the shared list would corrupt it. It also runs in the middle of checkpoint
+     * processing after a read error, where the cached list legitimately differs from the metadata
+     * and would trip the checkpoint-validate diagnostics.
+     */
+    fname = session->dhandle->name;
+    WT_ERR(__wt_btree_shared_base_name(session, &fname, NULL, &name_buf));
+    WT_ERR(__wt_metadata_search(session, fname, &config));
+    WT_ERR(__wt_meta_ckptlist_get_from_config(session, false, &ckptbase, NULL, config));
     WT_CKPT_FOREACH (ckptbase, ckpt_iter) {
         WT_ERR(__wt_calloc(session, 1, sizeof(WT_BLOCK_CKPT), &ckpt_iter->bpriv));
         ci = ckpt_iter->bpriv;
@@ -1249,6 +1262,9 @@ err:
             __wti_block_ckpt_destroy(session, ci);
 
     __wt_ckptlist_free(session, &ckptbase);
+
+    __wt_scr_free(session, &name_buf);
+    __wt_free(session, config);
 
     return (ret);
 }

--- a/test/suite/test_corrupt01.py
+++ b/test/suite/test_corrupt01.py
@@ -35,7 +35,7 @@ import wiredtiger
 # Test the verbose log messages in the event of a corrupted block. We should expect to see a dump
 # of the block bytes along with a dump of each checkpoints extent lists.
 # FIXME-WT-15064: This test is disabled until we have a way to implement corruption tests for DisAgg.
-@wttest.skip_for_hook("disagg", "Verify is not supported with disaggregated storage (yet)")
+@wttest.skip_for_hook("disagg", "corrupts blocks which are not relevant for disagg")
 class test_corrupt01(wttest.WiredTigerTestCase, suite_subprocess):
     test_name = __qualname__
     uri = f'table:{test_name}'

--- a/test/suite/test_corrupt02.py
+++ b/test/suite/test_corrupt02.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, re, sys
+import wiredtiger, wttest
+
+# When a checkpoint drops a previous checkpoint, it reads that checkpoint's extent lists. If the
+# extent-list block is corrupt, the read fails its checksum and drives the diagnostic extent-list
+# dump path. That path used to fetch the btree's cached checkpoint list by reference, attach
+# transient block manager state to it and then free it, which corrupted the shared list (a
+# use-after-free), and it also tripped the checkpoint-validate diagnostics with a spurious
+# "__assert_ckpt_matches" abort. With corruption_abort disabled the corrupt read should now surface
+# as an ordinary WT_PANIC the application can handle, not a crash.
+@wttest.skip_for_hook("tiered", "corrupts local block files not used by tiered storage")
+@wttest.skip_for_hook("disagg", "corrupts blocks which are not relevant for disagg")
+@wttest.skip_for_hook("parallel_checkpoint", "FIXME-WT-18134: deliberately fails a checkpoint; parallel checkpoint tears down worker threads mid-transaction")
+class test_corrupt02(wttest.WiredTigerTestCase):
+    conn_config = ('cache_size=50MB,statistics=(fast),debug_mode=(corruption_abort=false),'
+                   'eviction_dirty_trigger=50,eviction_updates_trigger=50')
+
+    test_name = __qualname__
+    uri = f'table:{test_name}'
+    tablename = f'{test_name}.wt'
+    allocsize = 4096
+
+    def alloc_extlist_blocks(self):
+        # Decode every checkpoint's address cookie from the metadata and return the (offset, size) of
+        # each alloc extent-list block that lives in its own on-disk block.
+        tools_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'tools')
+        if tools_dir not in sys.path:
+            sys.path.append(tools_dir)
+        from py_common.binary_data import unpack_int
+
+        cursor = self.session.open_cursor('metadata:', None, None)
+        cursor.set_key('file:' + self.tablename)
+        self.assertEqual(cursor.search(), 0)
+        config = cursor.get_value()
+        cursor.close()
+
+        blocks = []
+        for cookie in re.findall(r'addr="([0-9a-fA-F]+)"', config):
+            addr = bytes(bytearray.fromhex(cookie))
+            # A regular checkpoint cookie is version 1 followed by 14 packed ints: the root, alloc,
+            # avail and discard triples then the file and checkpoint sizes.
+            if addr[0] != 1:
+                continue
+            addr = addr[1:]
+            values = []
+            while True:
+                try:
+                    v, addr = unpack_int(addr)
+                    values.append(v)
+                except Exception:
+                    break
+            if len(values) != 14:
+                continue
+            off, size, _ = values[3:6]
+            if size != 0:
+                blocks.append(((off + 1) * self.allocsize, size * self.allocsize))
+        return blocks
+
+    def write_rows(self, start, count):
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(start, start + count):
+            cursor[str(i)] = b'a' * 500
+        cursor.close()
+
+    def test_corrupt02(self):
+        self.session.create(self.uri, 'key_format=S,value_format=u')
+
+        # Load enough data that the alloc extent list is large enough to be written as its own block.
+        self.write_rows(1, 12000)
+        self.session.checkpoint()
+
+        # Corrupt every alloc extent-list block the checkpoint cookies point at, leaving the rest of
+        # the file intact.
+        blocks = self.alloc_extlist_blocks()
+        self.assertGreater(len(blocks), 0,
+            "expected at least one on-disk alloc extent-list block to corrupt")
+        with open(self.tablename, 'r+b') as f:
+            for offset, size in blocks:
+                f.seek(offset)
+                f.write(b'Bad!' * (size // 4))
+
+        # Dirty the tree and checkpoint again. The new checkpoint drops the previous one and reads
+        # its now-corrupt alloc extent list. This must surface as a handled WT_PANIC.
+        self.write_rows(12000, 1000)
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError, lambda: self.session.checkpoint())
+
+        # The connection has panicked; every subsequent call including close returns WT_PANIC.
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError, lambda: self.close_conn())
+
+        # The corrupt-block read logs the corruption on stderr and dumps the extent lists on stdout.
+        self.ignoreStdoutPatternIfExists('extent list')
+        self.ignoreStderrPatternIfExists('checksum error')


### PR DESCRIPTION
Backport of WT-18048 to `mongodb-9.0` (BACKPORT-29403). Cherry-pick of da715fcf70 (#14257).