### PR TITLE
WT-18158 Skip queuing non-evictable stale disaggregated pages during eviction walk

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -451,7 +451,7 @@ conn_stats = [
     EvictStat('eviction_server_skip_pages_prune_timestamp_not_move', 'eviction server skips pages that have been reconciled previously at the same prune timestamp'),
     EvictStat('eviction_server_skip_pages_retry', 'eviction server skips pages that previously failed eviction and likely will again'),
     EvictStat('eviction_server_skip_stable_trees', 'eviction server skips stable btrees in disagg'),
-    EvictStat('eviction_server_skip_stale_disagg_pages_busy', 'eviction server skips pages on an outdated disaggregated read-only btree that a reader still has open'),
+    EvictStat('eviction_server_skip_stale_disagg_pages', 'eviction server skips pages on an outdated disaggregated read-only btree that a reader still has open'),
     EvictStat('eviction_server_skip_trees_eviction_disabled', 'eviction server skips trees that disable eviction'),
     EvictStat('eviction_server_skip_trees_not_useful_before', 'eviction server skips trees that were not useful before'),
     EvictStat('eviction_server_skip_trees_read_only', 'eviction server skips trees that are read-only if it is not looking for clean pages'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -451,6 +451,7 @@ conn_stats = [
     EvictStat('eviction_server_skip_pages_prune_timestamp_not_move', 'eviction server skips pages that have been reconciled previously at the same prune timestamp'),
     EvictStat('eviction_server_skip_pages_retry', 'eviction server skips pages that previously failed eviction and likely will again'),
     EvictStat('eviction_server_skip_stable_trees', 'eviction server skips stable btrees in disagg'),
+    EvictStat('eviction_server_skip_stale_disagg_pages_busy', 'eviction server skips pages on an outdated disaggregated read-only btree that a reader still has open'),
     EvictStat('eviction_server_skip_trees_eviction_disabled', 'eviction server skips trees that disable eviction'),
     EvictStat('eviction_server_skip_trees_not_useful_before', 'eviction server skips trees that were not useful before'),
     EvictStat('eviction_server_skip_trees_read_only', 'eviction server skips trees that are read-only if it is not looking for clean pages'),

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2357,7 +2357,7 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-insert", (void *)ref);
 
-    if (__wt_btree_is_stale_disagg(session))
+    if (__wt_btree_is_outdated_disagg(session))
         return (__wt_set_return(session, EBUSY));
 
     /*
@@ -2484,7 +2484,7 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-multi", (void *)ref);
 
-    if (__wt_btree_is_stale_disagg(session))
+    if (__wt_btree_is_outdated_disagg(session))
         ret = __wt_set_return(session, EBUSY);
     else
         /*
@@ -2526,7 +2526,7 @@ __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: reverse-split", (void *)ref);
 
-    if (__wt_btree_is_stale_disagg(session))
+    if (__wt_btree_is_outdated_disagg(session))
         return (__wt_set_return(session, EBUSY));
 
     /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -474,7 +474,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * from the gate: its disk image is fully described by the page's address, so it can be re-read
      * from storage and eviction may discard it normally even with readers present.
      */
-    if (__wt_btree_is_stale_disagg(session) && !__wt_page_evict_clean(page)) {
+    if (__wt_btree_is_outdated_disagg(session) && !__wt_page_evict_clean(page)) {
         if (__wt_atomic_load_int32_relaxed(&session->dhandle->session_inuse) > 0) {
             ret = __wt_set_return(session, EBUSY);
             goto err;
@@ -535,13 +535,13 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_internal);
 
     /*
-     * Figure out whether reconciliation was done on the page. A stale disaggregated page has had
-     * its dirty flag cleared above, but a non-zero reconciliation result left over from the leader
-     * era keeps the clean check false and would route the page to a dirty split that can never
-     * write back to shared storage. Force clean eviction so the page is discarded instead of
+     * Figure out whether reconciliation was done on the page. An outdated disaggregated page has
+     * had its dirty flag cleared above, but a non-zero reconciliation result left over from the
+     * leader era keeps the clean check false and would route the page to a dirty split that can
+     * never write back to shared storage. Force clean eviction so the page is discarded instead of
      * trapped in cache.
      */
-    if (__wt_page_evict_clean(page) || __wt_btree_is_stale_disagg(session)) {
+    if (__wt_page_evict_clean(page) || __wt_btree_is_outdated_disagg(session)) {
         evict_clean = true;
         FLD_SET(stats_flags, WT_EVICT_STATS_CLEAN);
     }

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1251,7 +1251,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
         return;
 
     /*
-     * A busy stale-disagg page that is not clean-evictable is ignored for queuing. Unlike ordinary
+     * A stale-disagg page that is not clean-evictable is ignored for queuing. Unlike ordinary
      * pages, whose content remains readable from storage after eviction, this page's content cannot
      * be reproduced once discarded: it belongs to an outdated checkpoint that shared storage no
      * longer serves. A reader positioned elsewhere on this tree may still navigate back to it, so

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1250,6 +1250,22 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     if (!__wt_evict_aggressive(session) && modified && __evict_skip_dirty_candidate(session, page))
         return;
 
+    /*
+     * A busy stale-disagg page that is not clean-evictable is ignored for queuing. Unlike ordinary
+     * pages, whose content remains readable from storage after eviction, this page's content cannot
+     * be reproduced once discarded: it belongs to an outdated checkpoint that shared storage no
+     * longer serves. A reader positioned elsewhere on this tree may still navigate back to it, so
+     * any reader on the tree, not just one holding this page, must be treated as blocking eviction;
+     * that tree-wide state is tracked by session_inuse rather than this page's own hazard pointer.
+     * The walk itself holds one session_inuse reference on the tree it is currently visiting, so a
+     * genuine external reader shows up as a count greater than one.
+     */
+    if (__wt_btree_is_stale_disagg(session) && !__wt_page_evict_clean(page) &&
+      __wt_atomic_load_int32_relaxed(&session->dhandle->session_inuse) > 1) {
+        WT_STAT_CONN_INCR(session, eviction_server_skip_stale_disagg_pages_busy);
+        return;
+    }
+
 fast:
     /* If the page can't be evicted, give up. */
     if (!__wt_page_can_evict(session, ref, NULL))

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1251,7 +1251,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
         return;
 
     /*
-     * A stale-disagg page that is not clean-evictable is ignored for queuing. Unlike ordinary
+     * An outdated-disagg page that is not clean-evictable is ignored for queuing. Unlike ordinary
      * pages, whose content remains readable from storage after eviction, this page's content cannot
      * be reproduced once discarded: it belongs to an outdated checkpoint that shared storage no
      * longer serves. A reader positioned elsewhere on this tree may still navigate back to it, so
@@ -1260,7 +1260,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
      * The walk itself holds one session_inuse reference on the tree it is currently visiting, so a
      * genuine external reader shows up as a count greater than one.
      */
-    if (__wt_btree_is_stale_disagg(session) && !__wt_page_evict_clean(page) &&
+    if (__wt_btree_is_outdated_disagg(session) && !__wt_page_evict_clean(page) &&
       __wt_atomic_load_int32_relaxed(&session->dhandle->session_inuse) > 1) {
         WT_STAT_CONN_INCR(session, eviction_server_skip_stale_disagg_pages);
         return;

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1262,7 +1262,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
      */
     if (__wt_btree_is_stale_disagg(session) && !__wt_page_evict_clean(page) &&
       __wt_atomic_load_int32_relaxed(&session->dhandle->session_inuse) > 1) {
-        WT_STAT_CONN_INCR(session, eviction_server_skip_stale_disagg_pages_busy);
+        WT_STAT_CONN_INCR(session, eviction_server_skip_stale_disagg_pages);
         return;
     }
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -37,11 +37,11 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_btree_is_stale_disagg --
+ * __wt_btree_is_outdated_disagg --
  *     Return whether the current btree belongs to an outdated disaggregated generation.
  */
 static WT_INLINE bool
-__wt_btree_is_stale_disagg(WT_SESSION_IMPL *session)
+__wt_btree_is_outdated_disagg(WT_SESSION_IMPL *session)
 {
     return ((F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) ||
               F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY)) &&

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2055,7 +2055,7 @@ static WT_INLINE bool __wt_btree_can_discard(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_btree_disagg_checkpointed(WT_SESSION_IMPL *session, WT_BTREE *btree)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_btree_is_stale_disagg(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_btree_is_outdated_disagg(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_btree_syncing_by_other_sessions(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -590,7 +590,7 @@ struct __wt_connection_stats {
     int64_t eviction_server_skip_ingest_trees;
     int64_t eviction_server_skip_intl_page_with_active_child;
     int64_t eviction_server_skip_metatdata_with_history;
-    int64_t eviction_server_skip_stale_disagg_pages_busy;
+    int64_t eviction_server_skip_stale_disagg_pages;
     int64_t eviction_server_skip_pages_checkpoint_timestamp;
     int64_t eviction_server_skip_pages_last_running;
     int64_t eviction_server_skip_pages_prune_timestamp;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -590,6 +590,7 @@ struct __wt_connection_stats {
     int64_t eviction_server_skip_ingest_trees;
     int64_t eviction_server_skip_intl_page_with_active_child;
     int64_t eviction_server_skip_metatdata_with_history;
+    int64_t eviction_server_skip_stale_disagg_pages_busy;
     int64_t eviction_server_skip_pages_checkpoint_timestamp;
     int64_t eviction_server_skip_pages_last_running;
     int64_t eviction_server_skip_pages_prune_timestamp;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6877,2452 +6877,2457 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! cache: eviction server skips metadata pages with history */
 #define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1163
 /*!
+ * cache: eviction server skips pages on an outdated disaggregated read-
+ * only btree that a reader still has open
+ */
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STALE_DISAGG_PAGES_BUSY	1164
+/*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the checkpoint timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_CHECKPOINT_TIMESTAMP	1164
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_CHECKPOINT_TIMESTAMP	1165
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1165
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1166
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the prune timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP	1166
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP	1167
 /*!
  * cache: eviction server skips pages that have been reconciled
  * previously at the same prune timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP_NOT_MOVE	1167
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP_NOT_MOVE	1168
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1168
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1169
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1169
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1170
 /*! cache: eviction server skips stable btrees in disagg */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STABLE_TREES	1170
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STABLE_TREES	1171
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1171
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1172
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1172
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1173
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1173
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1174
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1174
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1175
 /*!
  * cache: eviction server skips trees that are read-only if it is not
  * looking for clean pages
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1175
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1176
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1176
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1177
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1177
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1178
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1178
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1179
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1179
+#define	WT_STAT_CONN_EVICTION_SLOW			1180
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1180
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1181
 /*!
  * cache: eviction server walks trees within their walk period because
  * they dominate the cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_WALK_DOMINATING_CACHE	1181
+#define	WT_STAT_CONN_EVICTION_SERVER_WALK_DOMINATING_CACHE	1182
 /*!
  * cache: eviction server walks trees within their walk period because
  * they dominate the cache but queues no pages
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_WALK_DOMINATING_CACHE_UNPRODUCTIVE	1182
+#define	WT_STAT_CONN_EVICTION_SERVER_WALK_DOMINATING_CACHE_UNPRODUCTIVE	1183
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1183
+#define	WT_STAT_CONN_EVICTION_STATE			1184
 /*!
  * cache: eviction threshold cache full target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1184
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1185
 /*!
  * cache: eviction threshold cache full trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1185
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1186
 /*! cache: eviction threshold dirty target multiplied by 100 for precision */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1186
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1187
 /*!
  * cache: eviction threshold dirty trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1187
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1188
 /*!
  * cache: eviction threshold updates target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1188
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1189
 /*!
  * cache: eviction threshold updates trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1189
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1190
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1190
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1191
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1191
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1192
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1192
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1193
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1193
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1194
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1194
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1195
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1196
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1196
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1197
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1197
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1198
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1198
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1199
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1199
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1200
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1200
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1201
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1201
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1202
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1202
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1203
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1203
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1204
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1204
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1205
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1205
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1206
 /*! cache: eviction walk target strategy clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1206
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1207
 /*! cache: eviction walk target strategy dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1207
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1208
 /*! cache: eviction walk target strategy pages with updates */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1208
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1209
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1209
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1210
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1210
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1211
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1211
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1212
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1212
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1213
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1213
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1214
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1214
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1215
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1215
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1216
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1216
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1217
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1217
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1218
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1218
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1219
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1219
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1220
 /*!
  * cache: evictions that found no snapshot published by the running
  * checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_CKPT_SNAPSHOT_DECLINED	1220
+#define	WT_STAT_CONN_EVICTION_CKPT_SNAPSHOT_DECLINED	1221
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1221
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1222
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1222
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1223
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1223
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1224
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1224
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1225
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1225
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1226
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1226
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1227
 /*!
  * cache: forced eviction - pages evicted belonging to ingest btrees
  * count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1227
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1228
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1228
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1229
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1229
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1230
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1230
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1231
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1231
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1232
 /*!
  * cache: forced eviction - pages selected belonging to ingest btrees
  * unable to be evicted count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1232
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1233
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1233
+#define	WT_STAT_CONN_EVICTION_FORCE			1234
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1234
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1235
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1235
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1236
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1236
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1237
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1237
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1238
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1238
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1239
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1239
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1240
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1240
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1241
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1241
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1242
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1242
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1243
 /*! cache: history store table key to be processed */
-#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1243
+#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1244
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1244
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1245
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1245
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1246
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1246
+#define	WT_STAT_CONN_CACHE_HS_READ			1247
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1247
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1248
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1248
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1249
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1249
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1250
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1250
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1251
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1251
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1252
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1252
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1253
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1253
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1254
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1254
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1255
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1255
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1256
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1256
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1257
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1257
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1258
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1258
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1259
 /*! cache: history store table update to be processed */
-#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1259
+#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1260
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1260
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1261
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1261
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1262
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1262
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1263
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1263
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1264
 /*! cache: in-memory page splits performed on ingest btree pages */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1264
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1265
 /*! cache: ingest pages evicted */
-#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1265
+#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1266
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1266
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1267
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1267
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1268
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1268
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1269
 /*! cache: internal pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1269
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1270
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1270
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1271
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1271
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1272
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1272
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1273
 /*! cache: leaf pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1273
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1274
 /*! cache: leaf pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_LEAF			1274
+#define	WT_STAT_CONN_CACHE_READ_LEAF			1275
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1275
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1276
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1276
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1277
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1277
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1278
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1278
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1279
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1279
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1280
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1280
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1281
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1281
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1282
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1282
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1283
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1283
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1284
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1284
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1285
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1285
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1286
 /*!
  * cache: maximum number of times a page tried to be added to eviction
  * queue but fail
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1286
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1287
 /*! cache: maximum number of times a page tried to be evicted */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1287
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1288
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1288
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1289
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1289
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1290
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1290
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1291
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1291
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1292
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1292
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1293
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1293
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1294
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1294
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1295
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1295
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1296
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1296
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1297
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1297
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1298
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1298
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1299
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1299
+#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1300
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1300
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1301
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1301
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1302
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1302
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1303
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1303
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1304
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1304
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1305
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1305
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1306
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1306
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1307
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1307
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1308
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1308
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1309
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1309
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1310
 /*! cache: pages already in queue when topping up */
-#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1310
+#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1311
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1311
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1312
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1312
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1313
 /*! cache: pages currently held in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1313
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1314
 /*! cache: pages currently held in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1314
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1315
 /*! cache: pages dirtied by fast-truncate in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_TRUNCATE_TXN_UNCOMMITTED_BYTES	1315
+#define	WT_STAT_CONN_CACHE_TRUNCATE_TXN_UNCOMMITTED_BYTES	1316
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1316
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1317
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1317
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1318
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1318
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1319
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1319
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1320
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1320
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1321
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1321
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1322
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1322
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1323
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1323
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1324
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1324
+#define	WT_STAT_CONN_CACHE_READ				1325
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1325
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1326
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1326
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1327
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1327
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1328
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1328
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1329
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1329
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1330
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1330
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1331
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1331
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1332
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1332
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1333
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1333
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1334
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1334
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1335
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1335
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1336
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1336
+#define	WT_STAT_CONN_EVICTION_FAIL			1337
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1337
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1338
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1338
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1339
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1339
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1340
 /*!
  * cache: pages selected for eviction unable to be evicted belonging to
  * ingest btrees
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1340
+#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1341
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1341
+#define	WT_STAT_CONN_EVICTION_WALK			1342
 /*!
  * cache: pages with a clean re-instantiation image retained by
  * checkpoint scrub
  */
-#define	WT_STAT_CONN_CACHE_SCRUB_IMAGE_PAGES		1342
+#define	WT_STAT_CONN_CACHE_SCRUB_IMAGE_PAGES		1343
 /*!
  * cache: pages with an unresolved multiblock split flagged by checkpoint
  * to be evicted soon
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1343
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1344
 /*!
  * cache: pages with an unresolved multiblock split re-reconciled by
  * checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1344
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1345
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1345
+#define	WT_STAT_CONN_CACHE_WRITE			1346
 /*!
  * cache: pages written requiring in-memory restoration due to checkpoint
  * scrub
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB_CHECKPOINT	1346
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB_CHECKPOINT	1347
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1347
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1348
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1348
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1349
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1349
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1350
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1350
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1351
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1351
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1352
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1352
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1353
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1353
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1354
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1354
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1355
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1355
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1356
 /*! cache: shared disk bucket lock contention count */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1356
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1357
 /*! cache: shared disk bytes saved by sharing duplicate disk images */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1357
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1358
 /*! cache: shared disk hash table size */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1358
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1359
 /*! cache: shared disk hit */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1359
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1360
 /*! cache: shared disk miss */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1360
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1361
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1361
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1362
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1362
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1363
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1363
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1364
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1364
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1365
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1365
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1366
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1366
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1367
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1367
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1368
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1368
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1369
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1369
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1370
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1370
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1371
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1371
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1372
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1372
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1373
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1373
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1374
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1374
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1375
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1375
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1376
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1376
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1377
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1377
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1378
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1378
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1379
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1379
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1380
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1380
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1381
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1381
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1382
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1382
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1383
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1383
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1384
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1384
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1385
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1385
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1386
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1386
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1387
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1387
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1388
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1388
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1389
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1389
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1390
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1390
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1391
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1391
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1392
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1392
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1393
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1393
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1394
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1394
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1395
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1395
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1396
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1396
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1397
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1397
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1398
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1398
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1399
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1399
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1400
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1400
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1401
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1401
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1402
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1402
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1403
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1403
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1404
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1404
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1405
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1405
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1406
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1406
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1407
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1407
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1408
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1408
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1409
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1409
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1410
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1410
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1411
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1411
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1412
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1412
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1413
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1413
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1414
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1414
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1415
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1415
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1416
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1416
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1417
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1417
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1418
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1418
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1419
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1419
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1420
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1420
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1421
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1421
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1422
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1422
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1423
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1423
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1424
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1424
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1425
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1425
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1426
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1426
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1427
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1427
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1428
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1428
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1429
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1429
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1430
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1430
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1431
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1431
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1432
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1432
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1433
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1433
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1434
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1434
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1435
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1435
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1436
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1436
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1437
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1437
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1438
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1438
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1439
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1439
+#define	WT_STAT_CONN_CHECKPOINTS_API			1440
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1440
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1441
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1441
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1442
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1442
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1443
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1443
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1444
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1444
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1445
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1445
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1446
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1446
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1447
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1447
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1448
 /*!
  * checkpoint: number of pages whose reconciliation was skipped because
  * eviction already reconciled them under the checkpoint snapshot
  */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILIATION_SKIPPED_EVICT_SNAPSHOT	1448
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILIATION_SKIPPED_EVICT_SNAPSHOT	1449
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1449
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1450
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1450
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1451
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1451
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1452
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1452
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1453
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1453
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1454
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1454
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1455
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1455
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1456
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1456
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1457
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1457
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1458
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1458
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1459
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1459
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1460
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1460
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1461
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1461
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1462
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1462
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1463
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1463
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1464
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1464
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1465
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1465
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1466
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1466
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1467
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1467
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1468
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1468
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1469
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1469
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1470
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1470
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1471
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1471
+#define	WT_STAT_CONN_BTREE_OPEN				1472
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1472
+#define	WT_STAT_CONN_TIME_TRAVEL			1473
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1473
+#define	WT_STAT_CONN_FILE_OPEN				1474
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1474
+#define	WT_STAT_CONN_BUCKETS_DH				1475
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1475
+#define	WT_STAT_CONN_BUCKETS				1476
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1476
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1477
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1477
+#define	WT_STAT_CONN_MEMORY_FREE			1478
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1478
+#define	WT_STAT_CONN_MEMORY_GROW			1479
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1479
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1480
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1480
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1481
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1481
+#define	WT_STAT_CONN_COND_WAIT				1482
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1482
+#define	WT_STAT_CONN_RWLOCK_READ			1483
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1483
+#define	WT_STAT_CONN_RWLOCK_WRITE			1484
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1484
+#define	WT_STAT_CONN_FSYNC_IO				1485
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1485
+#define	WT_STAT_CONN_READ_IO				1486
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1486
+#define	WT_STAT_CONN_WRITE_IO				1487
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1487
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1488
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1488
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1489
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1489
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1490
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1490
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1491
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1491
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1492
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1492
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1493
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1493
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1494
 /*!
  * cursor: Total number of times a tree walk waited for the page lock
  * during the page skip check
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_SKIP_LOCK_CONTENDED	1494
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_SKIP_LOCK_CONTENDED	1495
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1495
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1496
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1496
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1497
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1497
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1498
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1498
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1499
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1499
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1500
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1500
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1501
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1501
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1502
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1502
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1503
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1503
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1504
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1504
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1505
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1505
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1506
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1506
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1507
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1507
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1508
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1508
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1509
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1509
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1510
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1510
+#define	WT_STAT_CONN_CURSOR_CACHE			1511
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1511
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1512
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1512
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1513
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1513
+#define	WT_STAT_CONN_CURSOR_CREATE			1514
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1514
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1515
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1515
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1516
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1516
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1517
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1517
+#define	WT_STAT_CONN_CURSOR_INSERT			1518
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1518
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1519
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1519
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1520
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1520
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1521
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1521
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1522
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1522
+#define	WT_STAT_CONN_CURSOR_MODIFY			1523
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1523
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1524
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1524
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1525
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1525
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1526
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1526
+#define	WT_STAT_CONN_CURSOR_NEXT			1527
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1527
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1528
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1528
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1529
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1529
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1530
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1530
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1531
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1531
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1532
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1532
+#define	WT_STAT_CONN_CURSOR_RESTART			1533
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1533
+#define	WT_STAT_CONN_CURSOR_PREV			1534
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1534
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1535
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1535
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1536
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1536
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1537
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1537
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1538
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1538
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1539
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1539
+#define	WT_STAT_CONN_CURSOR_REMOVE			1540
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1540
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1541
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1541
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1542
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1542
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1543
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1543
+#define	WT_STAT_CONN_CURSOR_RESERVE			1544
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1544
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1545
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1545
+#define	WT_STAT_CONN_CURSOR_RESET			1546
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1546
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1547
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1547
+#define	WT_STAT_CONN_CURSOR_SEARCH			1548
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1548
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1549
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1549
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1550
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1550
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1551
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1551
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1552
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1552
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1553
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1553
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1554
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1554
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1555
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1555
+#define	WT_STAT_CONN_CURSOR_SWEEP			1556
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1556
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1557
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1557
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1558
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1558
+#define	WT_STAT_CONN_CURSOR_UPDATE			1559
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1559
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1560
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1560
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1561
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1561
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1562
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1562
+#define	WT_STAT_CONN_CURSOR_REOPEN			1563
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1563
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1564
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1564
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1565
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1565
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1566
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1566
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1567
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1567
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1568
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1568
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1569
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1569
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1570
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1570
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1571
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1571
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1572
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1572
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1573
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1573
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1574
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1574
+#define	WT_STAT_CONN_DH_SWEEP_REF			1575
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1575
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1576
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1576
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1577
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1577
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1578
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1578
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1579
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1579
+#define	WT_STAT_CONN_DH_SWEEPS				1580
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1580
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1581
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1581
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1582
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1582
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1583
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1583
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1584
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1584
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1585
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1585
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1586
 /*!
  * disagg: checkpoint metadata compatible version of the most recently
  * picked up checkpoint: 0 none
  */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_COMPATIBLE_VERSION	1586
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_COMPATIBLE_VERSION	1587
 /*! disagg: checkpoint metadata compatible version this binary supports */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_COMPATIBLE_VERSION	1587
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_COMPATIBLE_VERSION	1588
 /*!
  * disagg: checkpoint metadata version of the most recently picked up
  * checkpoint: 0 none
  */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_VERSION	1588
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_VERSION	1589
 /*! disagg: checkpoint metadata version this binary writes */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_VERSION	1589
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_VERSION	1590
 /*! disagg: checkpoint pick-ups deferred for active transaction snapshots */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DEFER		1590
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DEFER		1591
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1591
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1592
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1592
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1593
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1593
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1594
 /*! disagg: ingest-to-stable tombstone escape bytes stripped */
-#define	WT_STAT_CONN_DISAGG_INGEST_STABLE_TOMBSTONE_STRIPPED	1594
+#define	WT_STAT_CONN_DISAGG_INGEST_STABLE_TOMBSTONE_STRIPPED	1595
 /*! disagg: most recently adopted checkpoint metadata LSN */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN		1595
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN		1596
 /*! disagg: most recently delivered checkpoint metadata LSN */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN	1596
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN	1597
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1597
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1598
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1598
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1599
 /*! disagg: pick up checkpoint time at startup (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME_STARTUP	1599
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME_STARTUP	1600
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1600
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1601
 /*!
  * disagg: snapshots rebuilt after racing a checkpoint pick-up or role
  * change
  */
-#define	WT_STAT_CONN_DISAGG_SNAPSHOT_REBUILD		1601
+#define	WT_STAT_CONN_DISAGG_SNAPSHOT_REBUILD		1602
 /*!
  * disagg: stable tombstone encoding mode: 0 not yet determined, 1 legacy
  * escaped, 2 unescaped
  */
-#define	WT_STAT_CONN_DISAGG_STABLE_TOMBSTONE_ENCODING	1602
+#define	WT_STAT_CONN_DISAGG_STABLE_TOMBSTONE_ENCODING	1603
 /*! disagg: step down in progress */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_IN_PROGRESS	1603
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_IN_PROGRESS	1604
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1604
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1605
 /*! disagg: step up in progress */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_IN_PROGRESS		1605
+#define	WT_STAT_CONN_DISAGG_STEP_UP_IN_PROGRESS		1606
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1606
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1607
 /*!
  * disagg: tables created without a stable constituent while the step-
  * down timestamp is set
  */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_WINDOW_CREATES	1607
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_WINDOW_CREATES	1608
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1608
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1609
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1609
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1610
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1610
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1611
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1611
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1612
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1612
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1613
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1613
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1614
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1614
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1615
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1615
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1616
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1616
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1617
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1617
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1618
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1618
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1619
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1619
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1620
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1620
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1621
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1621
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1622
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1622
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1623
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1623
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1624
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1624
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1625
 /*!
  * layered: Layered table cursor stable open refused to preserve a
  * transaction snapshot
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_REFUSED	1625
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_REFUSED	1626
 /*!
  * layered: Layered table cursor stable open rolled back after racing a
  * step-down
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_STEPDOWN_RACE	1626
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_STEPDOWN_RACE	1627
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1627
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1628
 /*! layered: Layered table live stable open refused on a follower */
-#define	WT_STAT_CONN_LAYERED_STABLE_LIVE_OPEN_REFUSED	1628
+#define	WT_STAT_CONN_LAYERED_STABLE_LIVE_OPEN_REFUSED	1629
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a non-tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1629
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1630
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1630
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1631
 /*!
  * layered: Layered table stable values equal to the tombstone byte
  * sequence
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1631
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1632
 /*! layered: Layered table stable values equal to three tombstone bytes */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1632
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1633
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1633
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1634
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1634
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1635
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1635
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1636
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1636
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1637
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1637
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1638
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1638
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1639
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1639
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1640
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1640
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1641
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1641
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1642
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1642
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1643
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1643
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1644
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1644
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1645
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1645
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1646
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1646
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1647
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1647
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1648
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1648
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1649
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1649
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1650
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1650
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1651
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1651
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1652
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1652
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1653
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1653
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1654
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1654
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1655
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1655
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1656
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1656
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1657
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1657
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1658
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1658
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1659
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1659
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1660
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1660
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1661
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1661
+#define	WT_STAT_CONN_READ_LOAD				1662
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1662
+#define	WT_STAT_CONN_WRITE_LOAD				1663
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1663
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1664
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1664
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1665
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1665
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1666
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1666
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1667
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1667
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1668
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1668
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1669
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1669
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1670
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1670
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1671
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1671
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1672
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1672
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1673
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1673
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1674
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1674
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1675
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1675
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1676
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1676
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1677
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1677
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1678
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1678
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1679
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1679
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1680
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1680
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1681
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1681
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1682
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1682
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1683
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1683
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1684
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1684
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1685
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1685
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1686
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1686
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1687
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1687
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1688
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1688
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1689
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1689
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1690
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1690
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1691
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1691
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1692
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1692
+#define	WT_STAT_CONN_LOG_FLUSH				1693
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1693
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1694
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1694
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1695
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1695
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1696
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1696
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1697
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1697
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1698
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1698
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1699
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1699
+#define	WT_STAT_CONN_LOG_SCANS				1700
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1700
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1701
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1701
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1702
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1702
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1703
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1703
+#define	WT_STAT_CONN_LOG_SYNC				1704
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1704
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1705
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1705
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1706
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1706
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1707
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1707
+#define	WT_STAT_CONN_LOG_WRITES				1708
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1708
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1709
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1709
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1710
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1710
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1711
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1711
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1712
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1712
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1713
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1713
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1714
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1714
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1715
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1715
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1716
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1716
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1717
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1717
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1718
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1718
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1719
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1719
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1720
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1720
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1721
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1721
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1722
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1722
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1723
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1723
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1724
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1724
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1725
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1725
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1726
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1726
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1727
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1727
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1728
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1728
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1729
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1729
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1730
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1730
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1731
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1731
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1732
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1732
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1733
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1733
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1734
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1734
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1735
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1735
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1736
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1736
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1737
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1737
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1738
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1738
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1739
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1739
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1740
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1740
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1741
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1741
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1742
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1742
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1743
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1743
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1744
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1744
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1745
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1745
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1746
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1746
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1747
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1747
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1748
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1748
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1749
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1749
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1750
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1750
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1751
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1751
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1752
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1752
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1753
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1753
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1754
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1754
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1755
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1755
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1756
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1756
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1757
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1757
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1758
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1758
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1759
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1759
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1760
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1760
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1761
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1761
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1762
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1762
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1763
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1763
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1764
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1764
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1765
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1765
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1766
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1766
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1767
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1767
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1768
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1768
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1769
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1769
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1770
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1770
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1771
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1771
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1772
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1772
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1773
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1773
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1774
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1774
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1775
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1775
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1776
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1776
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1777
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1777
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1778
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1778
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1779
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1779
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1780
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1780
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1781
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1781
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1782
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1782
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1783
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1783
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1784
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1784
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1785
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1785
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1786
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1786
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1787
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1787
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1788
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1788
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1789
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1789
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1790
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1790
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1791
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1791
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1792
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1792
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1793
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1793
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1794
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1794
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1795
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1795
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1796
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1796
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1797
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1797
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1798
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1798
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1799
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1799
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1800
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1800
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1801
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1801
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1802
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1802
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1803
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1803
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1804
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1804
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1805
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1805
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1806
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1806
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1807
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1807
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1808
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1808
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1809
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1809
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1810
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1810
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1811
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1811
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1812
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1812
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1813
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1813
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1814
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1814
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1815
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1815
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1816
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1816
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1817
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1817
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1818
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1818
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1819
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1819
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1820
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1820
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1821
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1821
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1822
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1822
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1823
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1823
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1824
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1824
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1825
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1825
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1826
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1826
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1827
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1827
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1828
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1828
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1829
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1829
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1830
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1830
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1831
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1831
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1832
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1832
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1833
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1833
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1834
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1834
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1835
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1835
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1836
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1836
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1837
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1837
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1838
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1838
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1839
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1839
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1840
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1840
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1841
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1841
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1842
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1842
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1843
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1843
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1844
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1844
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1845
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1845
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1846
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1846
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1847
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1847
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1848
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1848
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1849
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1849
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1850
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1850
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1851
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1851
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1852
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1852
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1853
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1853
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1854
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1854
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1855
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1855
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1856
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1856
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1857
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1857
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1858
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1858
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1859
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1859
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1860
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1860
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1861
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1861
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1862
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1862
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1863
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1863
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1864
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1864
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1865
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1865
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1866
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1866
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1867
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1867
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1868
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1868
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1869
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1869
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1870
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1870
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1871
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1871
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1872
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1872
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1873
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1873
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1874
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1874
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1875
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1875
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1876
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1876
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1877
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1877
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1878
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1878
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1879
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1879
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1880
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1880
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1881
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1881
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1882
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1882
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1883
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1883
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1884
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1884
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1885
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1885
+#define	WT_STAT_CONN_REC_PAGES				1886
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1886
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1887
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1887
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1888
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1888
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1889
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1889
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1890
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1890
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1891
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1891
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1892
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1892
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1893
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1893
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1894
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1894
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1895
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1895
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1896
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1896
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1897
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1897
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1898
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1898
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1899
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1899
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1900
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1900
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1901
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1901
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1902
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1902
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1903
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1903
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1904
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1904
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1905
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1905
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1906
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1906
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1907
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1907
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1908
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1908
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1909
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1909
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1910
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1910
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1911
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1911
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1912
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1912
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1913
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1913
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1914
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1914
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1915
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1915
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1916
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1916
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1917
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1917
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1918
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1918
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1919
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1919
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1920
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1920
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1921
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1921
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1922
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1922
+#define	WT_STAT_CONN_SESSION_OPEN			1923
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1923
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1924
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1924
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1925
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1925
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1926
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1926
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1927
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1927
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1928
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1928
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1929
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1929
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1930
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1930
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1931
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1931
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1932
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1932
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1933
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1933
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1934
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1934
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1935
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1935
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1936
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1936
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1937
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1937
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1938
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1938
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1939
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1939
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1940
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1940
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1941
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1941
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1942
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1942
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1943
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1943
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1944
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1944
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1945
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1945
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1946
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1946
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1947
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1947
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1948
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1948
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1949
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1949
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1950
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1950
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1951
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1951
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1952
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1952
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1953
 /*! session: table verify number of keys checked against the history store */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1953
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1954
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1954
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1955
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1955
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1956
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1956
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1957
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1957
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1958
 /*!
  * thread-yield: application thread eviction used the published
  * checkpoint snapshot for visibility
  */
-#define	WT_STAT_CONN_APPLICATION_EVICT_CHECKPOINT_SNAPSHOT	1958
+#define	WT_STAT_CONN_APPLICATION_EVICT_CHECKPOINT_SNAPSHOT	1959
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1959
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1960
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1960
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1961
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1961
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1962
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1962
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1963
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1963
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1964
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1964
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1965
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1965
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1966
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1966
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1967
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1967
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1968
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1968
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1969
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1969
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1970
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1970
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1971
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1971
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1972
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1972
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1973
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1973
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1974
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1974
+#define	WT_STAT_CONN_PAGE_SLEEP				1975
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1975
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1976
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1976
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1977
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1977
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1978
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1978
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1979
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1979
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1980
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1980
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1981
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1981
+#define	WT_STAT_CONN_FLUSH_TIER				1982
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1982
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1983
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1983
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1984
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1984
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1985
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1985
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1986
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1986
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1987
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1987
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1988
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1988
+#define	WT_STAT_CONN_TIERED_RETENTION			1989
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1989
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1990
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1990
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1991
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1991
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1992
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1992
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1993
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1993
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1994
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1994
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1995
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1995
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1996
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1996
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1997
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1997
+#define	WT_STAT_CONN_TXN_PREPARE			1998
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1998
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1999
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1999
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			2000
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		2000
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		2001
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			2001
+#define	WT_STAT_CONN_TXN_QUERY_TS			2002
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	2002
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	2003
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		2003
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		2004
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				2004
+#define	WT_STAT_CONN_TXN_RTS				2005
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2005
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2006
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2006
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2007
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		2007
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		2008
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		2008
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		2009
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		2009
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		2010
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	2010
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	2011
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	2011
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	2012
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		2012
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		2013
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	2013
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	2014
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	2014
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	2015
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		2015
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		2016
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	2016
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	2017
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		2017
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		2018
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		2018
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		2019
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		2019
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		2020
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		2020
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		2021
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2021
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2022
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	2022
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	2023
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		2023
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		2024
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2024
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2025
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			2025
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			2026
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		2026
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		2027
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2027
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2028
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2028
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2029
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				2029
+#define	WT_STAT_CONN_TXN_SET_TS				2030
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2030
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2031
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2031
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2032
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2032
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2033
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2033
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2034
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2034
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2035
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2035
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2036
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2036
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2037
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2037
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2038
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2038
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2039
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2039
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2040
 /*! transaction: step-down disaggregated schema epoch is currently set */
-#define	WT_STAT_CONN_TXN_STEPDOWN_EPOCH_SET		2040
+#define	WT_STAT_CONN_TXN_STEPDOWN_EPOCH_SET		2041
 /*! transaction: step-down timestamp is currently set */
-#define	WT_STAT_CONN_TXN_STEPDOWN_TS_SET		2041
+#define	WT_STAT_CONN_TXN_STEPDOWN_TS_SET		2042
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				2042
+#define	WT_STAT_CONN_TXN_BEGIN				2043
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2043
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2044
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2044
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2045
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2045
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2046
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2046
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2047
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2047
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2048
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2048
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2049
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2049
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2050
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2050
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2051
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2051
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2052
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2052
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2053
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2053
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2054
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2054
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2055
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2055
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2056
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2056
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2057
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2057
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2058
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2058
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2059
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2059
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2060
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2060
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2061
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2061
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2062
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2062
+#define	WT_STAT_CONN_TXN_COMMIT				2063
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2063
+#define	WT_STAT_CONN_TXN_ROLLBACK			2064
 /*!
  * transaction: transactions rolled back because their own dirty content
  * exceeds the eviction updates or dirty trigger
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2064
+#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2065
 /*!
  * transaction: truncate operations rolled back because they pinned too
  * much dirty cache
  */
-#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2065
+#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2066
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2066
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2067
 /*!
  * transaction: write transactions rolled back for straddling the step-
  * down timestamp setting boundary
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2067
+#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2068
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6880,7 +6880,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * cache: eviction server skips pages on an outdated disaggregated read-
  * only btree that a reader still has open
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STALE_DISAGG_PAGES_BUSY	1164
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STALE_DISAGG_PAGES	1164
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the checkpoint timestamp

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -3363,7 +3363,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->eviction_server_skip_ingest_trees = 0;
     stats->eviction_server_skip_intl_page_with_active_child = 0;
     stats->eviction_server_skip_metatdata_with_history = 0;
-    stats->eviction_server_skip_stale_disagg_pages_busy = 0;
+    stats->eviction_server_skip_stale_disagg_pages = 0;
     stats->eviction_server_skip_pages_checkpoint_timestamp = 0;
     stats->eviction_server_skip_pages_last_running = 0;
     stats->eviction_server_skip_pages_prune_timestamp = 0;
@@ -4501,8 +4501,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
       WT_STAT_CONN_READ(from, eviction_server_skip_intl_page_with_active_child);
     to->eviction_server_skip_metatdata_with_history +=
       WT_STAT_CONN_READ(from, eviction_server_skip_metatdata_with_history);
-    to->eviction_server_skip_stale_disagg_pages_busy +=
-      WT_STAT_CONN_READ(from, eviction_server_skip_stale_disagg_pages_busy);
+    to->eviction_server_skip_stale_disagg_pages +=
+      WT_STAT_CONN_READ(from, eviction_server_skip_stale_disagg_pages);
     to->eviction_server_skip_pages_checkpoint_timestamp +=
       WT_STAT_CONN_READ(from, eviction_server_skip_pages_checkpoint_timestamp);
     to->eviction_server_skip_pages_last_running +=

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2210,6 +2210,8 @@ static const char *const __stats_connection_desc[] = {
   "cache: eviction server skips ingest btrees in disagg",
   "cache: eviction server skips internal pages as it has an active child",
   "cache: eviction server skips metadata pages with history",
+  "cache: eviction server skips pages on an outdated disaggregated read-only btree that a reader "
+  "still has open",
   "cache: eviction server skips pages that are written with transactions greater than the "
   "checkpoint timestamp",
   "cache: eviction server skips pages that are written with transactions greater than the last "
@@ -3361,6 +3363,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->eviction_server_skip_ingest_trees = 0;
     stats->eviction_server_skip_intl_page_with_active_child = 0;
     stats->eviction_server_skip_metatdata_with_history = 0;
+    stats->eviction_server_skip_stale_disagg_pages_busy = 0;
     stats->eviction_server_skip_pages_checkpoint_timestamp = 0;
     stats->eviction_server_skip_pages_last_running = 0;
     stats->eviction_server_skip_pages_prune_timestamp = 0;
@@ -4498,6 +4501,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
       WT_STAT_CONN_READ(from, eviction_server_skip_intl_page_with_active_child);
     to->eviction_server_skip_metatdata_with_history +=
       WT_STAT_CONN_READ(from, eviction_server_skip_metatdata_with_history);
+    to->eviction_server_skip_stale_disagg_pages_busy +=
+      WT_STAT_CONN_READ(from, eviction_server_skip_stale_disagg_pages_busy);
     to->eviction_server_skip_pages_checkpoint_timestamp +=
       WT_STAT_CONN_READ(from, eviction_server_skip_pages_checkpoint_timestamp);
     to->eviction_server_skip_pages_last_running +=


### PR DESCRIPTION
Pages on a outdated disaggregated read-only btree (`WT_BTREE_DISAGGREGATED | WT_BTREE_READONLY` with an `OUTDATED` dhandle) that are not clean-evictable only ever get `EBUSY` from `__wt_evict` while a reader elsewhere on the tree still holds the handle open. The eviction walk currently queues these pages anyway, so a worker thread wastes an attempt discovering that.
