### PR TITLE
WT-18069 memory leak during failing checkpoint (9.0)

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -448,8 +448,15 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
           session->reconcile_timeline.total_reentry_hs_eviction_time;
 
 err:
-    if (ret != 0)
+    if (ret != 0) {
+        /*
+         * The reconcile-local block array is normally freed by cleanup when wrapping up the
+         * reconciliation, which this path skips. If cleanup has not run, free it here.
+         */
+        if (r->multi != NULL)
+            WT_TRET(__rec_cleanup(session, r));
         WT_RET_PANIC(session, ret, "reconciliation failed after building the disk image");
+    }
     return (ret);
 }
 


### PR DESCRIPTION
There is a memory leak when the row-store internal page's reconcile builds r->multi, then a step fails. WT_ERR jumps to err: in __reconcile. The reconcile local block array is normally freed by __rec_cleanup in __reconcile_post_wrapup, but the jump skips it, and __rec_destroy doesn't free r->multi so the array is leaked. A non-NULL r->multi means that cleanup has not run, so we should free it in the error path.
