### PR TITLE
WT-18390 Disable blind write path in __clayered_remove_from_ingest (#14452)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1606,12 +1606,7 @@ cursor_runtime_config = [
         configures whether the cursor's insert and update methods check the existing state of
         the record. If \c overwrite is \c false, WT_CURSOR::insert fails with ::WT_DUPLICATE_KEY
         if the record exists, and WT_CURSOR::update fails with ::WT_NOTFOUND if the record does
-        not exist. On a follower of a layered table with no read timestamp, \c overwrite set to
-        \c true causes WT_CURSOR::remove to write a tombstone to the ingest table without checking
-        the stable table; the caller must guarantee that the key being removed exists. If the key is
-        already deleted in ingest or by the truncate list, the operation violates that guarantee.
-        A write conflict with a concurrent, not-yet-visible change to the same key can still fail
-        the call. This layered-follower remove behavior does not apply on a leader.''',
+        not exist''',
         type='boolean'),
     Config('prefix_search', 'false', r'''
         this option is no longer supported, retained for backward compatibility.''',

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2761,19 +2761,8 @@ __clayered_remove_from_ingest(WTI_CLAYERED_OP *op, const WT_ITEM *key, bool posi
     WT_CURSOR *const c_ingest = op->ingest;
     WT_DECL_RET;
     WT_ITEM value;
-    bool blind_remove;
-    bool found_local;
 
     WT_CLEAR(value);
-    found_local = true;
-
-    /*
-     * A NULL operation stable cursor has two meanings: this operation may have deliberately hidden
-     * an available stable cursor for an overwrite follower write, or the follower may not have a
-     * checkpoint yet. Only the former can assume a key missed by ingest exists in stable.
-     */
-    blind_remove = op->stable == NULL && clayered->stable_cursor != NULL &&
-      F_ISSET(&clayered->iface, WT_CURSTD_OVERWRITE);
 
     WT_RET(__clayered_modify_check(session, clayered, key));
 
@@ -2781,22 +2770,10 @@ __clayered_remove_from_ingest(WTI_CLAYERED_OP *op, const WT_ITEM *key, bool posi
     bool hold_value =
       clayered->current_cursor != NULL && F_ISSET(clayered->current_cursor, WT_CURSTD_VALUE_INT);
 
-    if (blind_remove || !positioned || !hold_value) {
+    if (!positioned || !hold_value) {
         /* Cached value isn't reliable (unpositioned or not holding the value ref); re-read it. */
         WT_ASSERT(session, F_ISSET(&clayered->iface, WT_CURSTD_KEY_EXT));
-        if (blind_remove) {
-            ret = __clayered_lookup_ingest_and_truncate(op, &value, &found_local);
-            if (ret == WT_NOTFOUND && found_local) {
-                /* A local deletion marker violates the caller's live-key guarantee. */
-                WT_ASSERT_ALWAYS(
-                  session, false, "overwrite=true should guarantee the key exists for remove()");
-                return (0);
-            }
-
-            if (ret == WT_NOTFOUND && !found_local)
-                ret = 0;
-        } else
-            ret = __clayered_lookup(op, &value);
+        ret = __clayered_lookup(op, &value);
         if (ret != 0) {
             WT_TRET(__clayered_reset_cursors(clayered, false));
             return (ret);
@@ -2809,14 +2786,8 @@ __clayered_remove_from_ingest(WTI_CLAYERED_OP *op, const WT_ITEM *key, bool posi
             return (WT_NOTFOUND);
     }
 
-    /*
-     * If ingest wasn't confirmed positioned on this key (found_local is false, whether because the
-     * key was only in stable, or -- for overwrite=true -- because neither ingest nor the truncate
-     * list had an entry for it), current_cursor can still be whatever an unrelated earlier
-     * operation on this cursor left it as -- WT_CURSOR::set_key doesn't clear it. Never trust it in
-     * that case: always set the key explicitly rather than risk writing under a stale one.
-     */
-    if (!found_local || clayered->current_cursor != c_ingest)
+    /* If we are positioned on the stable table, we need to set the key. */
+    if (clayered->current_cursor != c_ingest)
         c_ingest->set_key(c_ingest, key);
 
     /*

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -699,13 +699,7 @@ struct __wt_cursor {
      * @config{overwrite, configures whether the cursor's insert and update methods check the
      * existing state of the record.  If \c overwrite is \c false\, WT_CURSOR::insert fails with
      * ::WT_DUPLICATE_KEY if the record exists\, and WT_CURSOR::update fails with ::WT_NOTFOUND if
-     * the record does not exist.  On a follower of a layered table with no read timestamp\, \c
-     * overwrite set to \c true causes WT_CURSOR::remove to write a tombstone to the ingest table
-     * without checking the stable table; the caller must guarantee that the key being removed
-     * exists.  If the key is already deleted in ingest or by the truncate list\, the operation
-     * violates that guarantee.  A write conflict with a concurrent\, not-yet-visible change to the
-     * same key can still fail the call.  This layered-follower remove behavior does not apply on a
-     * leader., a boolean flag; default \c true.}
+     * the record does not exist., a boolean flag; default \c true.}
      * @configend
      * @errors
      */
@@ -1043,13 +1037,7 @@ struct __wt_session {
      * @config{overwrite, configures whether the cursor's insert and update methods check the
      * existing state of the record.  If \c overwrite is \c false\, WT_CURSOR::insert fails with
      * ::WT_DUPLICATE_KEY if the record exists\, and WT_CURSOR::update fails with ::WT_NOTFOUND if
-     * the record does not exist.  On a follower of a layered table with no read timestamp\, \c
-     * overwrite set to \c true causes WT_CURSOR::remove to write a tombstone to the ingest table
-     * without checking the stable table; the caller must guarantee that the key being removed
-     * exists.  If the key is already deleted in ingest or by the truncate list\, the operation
-     * violates that guarantee.  A write conflict with a concurrent\, not-yet-visible change to the
-     * same key can still fail the call.  This layered-follower remove behavior does not apply on a
-     * leader., a boolean flag; default \c true.}
+     * the record does not exist., a boolean flag; default \c true.}
      * @config{raw, ignore the encodings for the key and value\, manage data as if the formats were
      * \c "u". See @ref cursor_raw for details., a boolean flag; default \c false.}
      * @config{read_once, results that are brought into cache from disk by this cursor will be given


### PR DESCRIPTION
This change reverts the blind remove path added by [WT-17254](https://jira.mongodb.org/browse/WT-17254) - we have seen a lot of errors indirectly caused by allowing blind removes, and this is intended to be a temporary change to ensure this class of issues don't show up in the next disagg release.

This is a cherry pick of WT-18390. The original PR is: https://github.com/wiredtiger/wiredtiger/pull/14452