### PR TITLE
WT-18382 Tolerate an empty leaf page in the verify key order checks (reland)

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1256,11 +1256,13 @@ __verify_row_int_key_order(
     btree = S2BT(session);
 
     /*
-     * The maximum key is usually set from the leaf page first. If the first leaf page is corrupted,
-     * it is possible that the key is not set. In that case skip this check.
+     * The maximum key is usually set from the leaf page first. It can legitimately be unset here:
+     * the first leaf page is corrupted, or every leaf visited so far rebuilt from a base image and
+     * deltas with all of its keys dropped as globally visible deletes. In either case there is
+     * nothing to compare against, and the comparison below is skipped.
      */
     if (!vs->verify_err)
-        WT_ASSERT(session, vs->max_addr->size != 0);
+        WT_ASSERT(session, vs->max_addr->size != 0 || WT_DELTA_LEAF_ENABLED(session));
 
     /* Get the parent page's internal key. */
     __wt_ref_key(parent, ref, &item.data, &item.size);
@@ -1305,7 +1307,9 @@ __verify_row_leaf_key_order(WT_SESSION_IMPL *session, WT_REF *ref, WT_VSTUFF *vs
     page = ref->page;
 
     /*
-     * If a tree is empty (just created), it won't have keys; if there are no keys, we're done.
+     * A page has no keys when the tree is empty (just created), or when it was rebuilt from a base
+     * image and deltas and the merge dropped every key whose stop is globally visible. Either way
+     * there is nothing to compare, and the largest key we've seen so far stands.
      */
     if (page->entries == 0)
         return (0);

--- a/test/suite/test_layered_delta17.py
+++ b/test/suite/test_layered_delta17.py
@@ -37,10 +37,13 @@ from wtscenario import make_scenarios
 # key whose stop is globally visible. When all of a page's keys are dropped the
 # merge produces a leaf image with no entries; check the reader, verify, and
 # checkpoint all tolerate that empty reconstructed page (rather than tripping the
-# mutually-exclusive empty-value page flags during verification).
+# mutually-exclusive empty-value page flags during verification), both for a
+# single-leaf tree and for one where the empty page is the leftmost of several
+# children.
 @disagg_test_class
 class test_layered_delta17(wttest.WiredTigerTestCase):
-    uri = "table:test_layered_delta17"
+    test_name = __qualname__
+    uri = test_name
     conn_base_config = ('statistics=(all),transaction_sync=(enabled,method=fsync),'
                         'page_delta=(delta_pct=100,leaf_page_delta=true),precise_checkpoint=true,')
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -48,18 +51,23 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
 
     nitems = 10
 
+    # Row count and surviving tail for the multi-child tree below.
+    split_uri = test_name + '_split'
+    split_nitems = 400
+    split_keep = 20
+
     def conn_config(self):
         return self.conn_base_config + 'disaggregated=(role="leader")'
 
-    def rstat(self, key):
-        with wttest.open_cursor(self.session, "statistics:" + self.uri) as c:
+    def rstat(self, key, uri):
+        with wttest.open_cursor(self.session, "statistics:" + uri) as c:
             return c[key][2]
 
-    def evict(self, key):
+    def evict(self, key, uri):
         # Force the page holding key out of cache so the next access rebuilds it
         # from its base image and deltas.
         s = self.conn.open_session("debug=(release_evict_page)")
-        c = s.open_cursor(self.uri, None, None)
+        c = s.open_cursor(uri, None, None)
         s.begin_transaction()
         c.set_key(key)
         c.search_near()
@@ -68,13 +76,14 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         s.close()
 
     def test_empty_reconstructed_page(self):
-        self.session.create(self.uri, "key_format=S,value_format=S,block_manager=disagg")
+        uri = 'table:' + self.uri
+        self.session.create(uri, "key_format=S,value_format=S,block_manager=disagg")
         value = "a" * 20
 
         # Populate the leaf, delete every key, and checkpoint with the oldest
         # timestamp still behind the delete. The tombstones are retained and
         # written into the leaf's base image.
-        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor = self.session.open_cursor(uri, None, None)
         for i in range(self.nitems):
             self.session.begin_transaction()
             cursor[str(i)] = value
@@ -86,7 +95,7 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
             self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
         self.session.checkpoint()
-        self.evict(str(0))
+        self.evict(str(0), uri)
 
         # Add and then remove a throwaway key, checkpointing each change so the
         # page carries leaf deltas on top of the tombstone-bearing base image:
@@ -98,14 +107,14 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(12)}')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(12))
         self.session.checkpoint()
-        self.assertGreaterEqual(self.rstat(stat.dsrc.rec_page_delta_leaf), 1)
+        self.assertGreaterEqual(self.rstat(stat.dsrc.rec_page_delta_leaf, uri), 1)
         self.session.begin_transaction()
         cursor.set_key('zzz')
         cursor.remove()
         self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(14)}')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(14))
         self.session.checkpoint()
-        self.evict(str(0))
+        self.evict(str(0), uri)
 
         # Make every delete globally visible, then read the page back. The read
         # rebuilds it from the base image and deltas; every key is dropped and the
@@ -114,7 +123,7 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
                                 ',stable_timestamp=' + self.timestamp_str(20))
 
         cursor.close()
-        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor = self.session.open_cursor(uri, None, None)
 
         # Forward and backward scans see nothing.
         self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
@@ -127,5 +136,79 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         cursor.close()
 
         # The empty reconstructed page verifies and checkpoints cleanly.
-        self.session.verify(self.uri, None)
+        self.session.verify(uri, None)
+        self.session.checkpoint()
+
+    def test_empty_reconstructed_leftmost_page(self):
+        # Same empty reconstructed leaf, reached from a tree deep enough for the
+        # internal-page key order check to run. Verify compares an internal key
+        # against the largest key seen so far, but skips the 0th entry of every
+        # internal page, so a single-child tree never exercises the comparison.
+        # Here the leftmost leaf rebuilds empty while its siblings keep their
+        # keys, leaving no largest key recorded by the time the second entry is
+        # checked.
+        uri = 'table:' + self.split_uri
+        self.session.create(
+            uri, "key_format=S,value_format=S,block_manager=disagg,leaf_page_max=4KB")
+        value = "a" * 100
+
+        # Populate enough rows to split the leaf, giving the root several
+        # children.
+        cursor = self.session.open_cursor(uri, None, None)
+        for i in range(self.split_nitems):
+            self.session.begin_transaction()
+            cursor['%06d' % i] = value
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(5)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
+        self.session.checkpoint()
+
+        self.assertGreater(self.rstat(stat.dsrc.btree_row_internal, uri), 0)
+        self.assertGreater(self.rstat(stat.dsrc.btree_row_leaf, uri), 1)
+
+        # Delete every row but a trailing block. The survivors keep the last leaf
+        # populated, so the root retains more than one child while the leftmost
+        # leaf is left holding nothing but tombstones. The oldest timestamp stays
+        # behind the deletes, so those tombstones are retained on the page.
+        for i in range(self.split_nitems - self.split_keep):
+            self.session.begin_transaction()
+            cursor.set_key('%06d' % i)
+            cursor.remove()
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.evict('%06d' % 0, uri)
+
+        # Add and then remove a throwaway key sorting ahead of every row,
+        # checkpointing each change, so the leftmost leaf carries leaf deltas on
+        # top of its tombstone-bearing base image: rebuilding it now has to run
+        # the base+delta merge. The throwaway key nets out to nothing.
+        self.session.begin_transaction()
+        cursor['!'] = value
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(12)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(12))
+        self.session.checkpoint()
+        self.assertGreaterEqual(self.rstat(stat.dsrc.rec_page_delta_leaf, uri), 1)
+        self.session.begin_transaction()
+        cursor.set_key('!')
+        cursor.remove()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(14)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(14))
+        self.session.checkpoint()
+        cursor.close()
+        self.evict('%06d' % 0, uri)
+
+        # Make every delete globally visible. The leftmost leaf now rebuilds to
+        # an image with no entries, while its siblings still hold keys.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20) +
+                                ',stable_timestamp=' + self.timestamp_str(20))
+
+        # The surviving rows are still readable.
+        cursor = self.session.open_cursor(uri, None, None)
+        self.assertEqual(cursor.next(), 0)
+        self.assertEqual(cursor.get_key(), '%06d' % (self.split_nitems - self.split_keep))
+        cursor.close()
+
+        # Verifying the tree walks past the empty leftmost leaf into its
+        # siblings.
+        self.session.verify(uri, None)
         self.session.checkpoint()

--- a/test/suite/test_layered_delta17.py
+++ b/test/suite/test_layered_delta17.py
@@ -166,7 +166,7 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         # without that the tree stays one leaf deep and the internal-page check
         # below is never reached. Assert on the reconciliation counter rather than
         # btree_row_leaf: the latter is a tree-walk stat over the in-memory tree,
-        # which still holds a single unsplit leaf until something evicts it.
+        # which still holds the leaf as a single page until something evicts it.
         self.assertGreaterEqual(self.rstat(stat.dsrc.rec_multiblock_leaf, uri), 1)
 
         # Delete every row but a trailing block. The survivors keep the last leaf

--- a/test/suite/test_layered_delta17.py
+++ b/test/suite/test_layered_delta17.py
@@ -162,8 +162,12 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
         self.session.checkpoint()
 
-        self.assertGreater(self.rstat(stat.dsrc.btree_row_internal, uri), 0)
-        self.assertGreater(self.rstat(stat.dsrc.btree_row_leaf, uri), 1)
+        # Confirm the checkpoint really did write the leaf as several blocks —
+        # without that the tree stays one leaf deep and the internal-page check
+        # below is never reached. Assert on the reconciliation counter rather than
+        # btree_row_leaf: the latter is a tree-walk stat over the in-memory tree,
+        # which still holds a single unsplit leaf until something evicts it.
+        self.assertGreaterEqual(self.rstat(stat.dsrc.rec_multiblock_leaf, uri), 1)
 
         # Delete every row but a trailing block. The survivors keep the last leaf
         # populated, so the root retains more than one child while the leftmost


### PR DESCRIPTION
Reland of #14454, reverted in #14460.

`__verify_row_int_key_order` asserts a largest key has been recorded, but a leaf page rebuilt from its base image and deltas can legitimately end up with no entries, in which case none is. Relax the assertion the way `bt_delete.c` already does, and refresh the two stale comments.