### PR TITLE
WT-18402 Give schema_disagg_abort an option for unique table names

### DIFF
--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -85,11 +85,8 @@ ckpt_lsn_stat(WT_SESSION *session, int stat_key)
 
 /*
  * ckpt_adopt_latest --
- *     Adopt the latest checkpoint before stepping up. A pick-up that lands while readers are still
- *     on an older checkpoint is deferred rather than applied, and stepping up discards a pending
- *     deferral, so wait until everything delivered to this connection has been adopted. Delivery is
- *     what a deferral outlives, so both sides of the comparison come from the connection rather
- *     than from the page log, which this thread may have read at a different time.
+ *     Adopt the latest checkpoint before stepping up. A pick-up can be deferred, and stepping up
+ *     discards a pending deferral, so wait for the adopted LSN to catch up with the delivered one.
  */
 void
 ckpt_adopt_latest(WORKLOAD_STATE *state)

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -64,8 +64,32 @@ ckpt_pick_up(WORKLOAD_STATE *state, WT_SESSION *session)
 }
 
 /*
+ * ckpt_lsn_stat --
+ *     Return one of the connection's checkpoint metadata LSN statistics.
+ */
+static uint64_t
+ckpt_lsn_stat(WT_SESSION *session, int stat_key)
+{
+    WT_CURSOR *stat_cursor;
+    testutil_check(session->open_cursor(session, "statistics:", NULL, NULL, &stat_cursor));
+    stat_cursor->set_key(stat_cursor, stat_key);
+    testutil_check(stat_cursor->search(stat_cursor));
+
+    int64_t value;
+    const char *desc, *pvalue;
+    testutil_check(stat_cursor->get_value(stat_cursor, &desc, &pvalue, &value));
+    testutil_check(stat_cursor->close(stat_cursor));
+
+    return ((uint64_t)value);
+}
+
+/*
  * ckpt_adopt_latest --
- *     Adopt the latest complete checkpoint.
+ *     Adopt the latest checkpoint before stepping up. A pick-up that lands while readers are still
+ *     on an older checkpoint is deferred rather than applied, and stepping up discards a pending
+ *     deferral, so wait until everything delivered to this connection has been adopted. Delivery is
+ *     what a deferral outlives, so both sides of the comparison come from the connection rather
+ *     than from the page log, which this thread may have read at a different time.
  */
 void
 ckpt_adopt_latest(WORKLOAD_STATE *state)
@@ -75,7 +99,26 @@ ckpt_adopt_latest(WORKLOAD_STATE *state)
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-    (void)ckpt_pick_up(state, session);
+    struct timespec start;
+    __wt_epoch(NULL, &start);
+    for (;;) {
+        (void)ckpt_pick_up(state, session);
+
+        const uint64_t delivered =
+          ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN);
+        const uint64_t adopted = ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN);
+        if (adopted >= delivered)
+            break;
+
+        struct timespec now;
+        __wt_epoch(NULL, &now);
+        if (WT_TIMEDIFF_SEC(now, start) > MAX_OP_WAIT)
+            testutil_die(ETIMEDOUT,
+              "Node %" PRIu32 ": checkpoint metadata LSN %" PRIu64
+              " not adopted in %d seconds, stalled at %" PRIu64,
+              state->cfg->node_id, delivered, MAX_OP_WAIT, adopted);
+        __wt_sleep(0, 10 * WT_THOUSAND);
+    }
 
     testutil_check(session->close(session, NULL));
 
@@ -219,11 +262,11 @@ follower_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 {
     WT_UNUSED(ckpt);
 
+    /* Adopted LSN is 0 until a checkpoint is picked up, so read it before the pick-up. */
+    const bool first_ckpt = state->adopted_ckpt_lsn == 0;
+
     if (!ckpt_pick_up(state, session))
         return;
-
-    /* Adopted LSN is 0 at the beginning. */
-    const bool first_ckpt = state->adopted_ckpt_lsn == 0;
 
     /* Each adoption is reported for a stepping-down peer. */
     adopted_lsn_publish(state->cfg->node_id, state->adopted_ckpt_lsn);

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -64,6 +64,8 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         /* The only move: a fresh table; its publish is a later event of its own. */
         ev.type = EVENT_CREATE;
         *slot_state = TABLE_CREATED;
+        if (state->cfg->unique_tables)
+            ++state->workers[t].slot_gen[slot];
         break;
     case TABLE_CREATED:
         switch (__wt_random(rnd) % 3) {
@@ -103,7 +105,8 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         return (false);
 
     ev.thread_id = t;
-    testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot);
+    testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot,
+      state->workers[t].slot_gen[slot]);
     if (ev.type == EVENT_INSERT) {
         ev.key_min = DATA_KEY_MIN;
         ev.key_max = DATA_KEY_MAX;
@@ -192,8 +195,8 @@ generator_flush_publishes(WORKLOAD_STATE *state)
             ev.type = *slot_state == TABLE_CREATED ? EVENT_PUBLISH_CREATE : EVENT_PUBLISH_DROP;
             ev.thread_id = t;
             ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
-            testutil_snprintf(
-              ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot);
+            testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t,
+              slot, state->workers[t].slot_gen[slot]);
 
             *slot_state = *slot_state == TABLE_CREATED ? TABLE_PUBLISHED : TABLE_NONE;
             generator_emit(state, &ev);

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -130,7 +130,7 @@ usage(void)
 {
     fprintf(stderr,
       "usage: %s [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N] [-T threads] "
-      "[-t time] [-u pool] [-v]\n",
+      "[-t time] [-U] [-u pool] [-v]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-b build directory (required for PALite extension)\n"
@@ -142,6 +142,7 @@ usage(void)
       "\t-s switch roles every N seconds\n"
       "\t-T number of schema threads\n"
       "\t-t total run time in seconds; the nodes stop gracefully unless killed\n"
+      "\t-U give every create a fresh table name, so no name is ever reused\n"
       "\t-u URI pool size per thread\n"
       "\t-v verify only\n");
     exit(EXIT_FAILURE);
@@ -225,10 +226,10 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
 
     *rand_thp = *rand_timep = true;
 
-    testutil_parse_begin_opt(argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:", cfg->opts);
+    testutil_parse_begin_opt(argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:U", cfg->opts);
 
     int ch;
-    while ((ch = __wt_getopt(progname, argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:U")) != EOF)
         switch (ch) {
         case 'A':
             if (strcmp(__wt_optarg, "l") == 0)
@@ -260,6 +261,9 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
         case 'T':
             *rand_thp = false;
             cfg->nth = parse_uint_in_range(__wt_optarg, 1, MAX_TH, "Thread count");
+            break;
+        case 'U':
+            cfg->unique_tables = true;
             break;
         case 'u':
             pool_size_set = true;

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -130,7 +130,7 @@ usage(void)
 {
     fprintf(stderr,
       "usage: %s [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N] [-T threads] "
-      "[-t time] [-U] [-u pool] [-v]\n",
+      "[-t time] [-q] [-u pool] [-v]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-b build directory (required for PALite extension)\n"
@@ -142,7 +142,7 @@ usage(void)
       "\t-s switch roles every N seconds\n"
       "\t-T number of schema threads\n"
       "\t-t total run time in seconds; the nodes stop gracefully unless killed\n"
-      "\t-U give every create a fresh table name, so no name is ever reused\n"
+      "\t-q give every create a fresh table name, so no name is ever reused\n"
       "\t-u URI pool size per thread\n"
       "\t-v verify only\n");
     exit(EXIT_FAILURE);
@@ -226,10 +226,10 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
 
     *rand_thp = *rand_timep = true;
 
-    testutil_parse_begin_opt(argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:U", cfg->opts);
+    testutil_parse_begin_opt(argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:q", cfg->opts);
 
     int ch;
-    while ((ch = __wt_getopt(progname, argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:U")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:q")) != EOF)
         switch (ch) {
         case 'A':
             if (strcmp(__wt_optarg, "l") == 0)
@@ -262,7 +262,7 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
             *rand_thp = false;
             cfg->nth = parse_uint_in_range(__wt_optarg, 1, MAX_TH, "Thread count");
             break;
-        case 'U':
+        case 'q':
             cfg->unique_tables = true;
             break;
         case 'u':

--- a/test/csuite/schema_disagg_abort/parent.c
+++ b/test/csuite/schema_disagg_abort/parent.c
@@ -110,7 +110,7 @@ spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool
     argv[n++] = "-u";
     argv[n++] = pool_arg;
     if (cfg->unique_tables)
-        argv[n++] = "-U";
+        argv[n++] = "-q";
     /* The node bounds how far its generator runs ahead so a hand-over drains inside a period. */
     if (cfg->switch_interval != 0) {
         argv[n++] = "-s";

--- a/test/csuite/schema_disagg_abort/parent.c
+++ b/test/csuite/schema_disagg_abort/parent.c
@@ -109,6 +109,8 @@ spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool
     argv[n++] = nth_arg;
     argv[n++] = "-u";
     argv[n++] = pool_arg;
+    if (cfg->unique_tables)
+        argv[n++] = "-U";
     /* The node bounds how far its generator runs ahead so a hand-over drains inside a period. */
     if (cfg->switch_interval != 0) {
         argv[n++] = "-s";

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -77,7 +77,11 @@
 /* URI / file name patterns; tables and record files are namespaced by owning node. */
 #define DATA_KEY_MIN 0
 #define DATA_KEY_MAX 9
-#define SCHEMA_TABLE_FMT "table:schema_%" PRIu32 "_%" PRIu32 "_%" PRIu32 /* node, thread, slot */
+/*
+ * node, thread, slot, generation. The generation stays zero unless -U asks for unique table names,
+ * so the name is the slot's whatever the mode, and the verifier parses one format either way.
+ */
+#define SCHEMA_TABLE_FMT "table:schema_%" PRIu32 "_%" PRIu32 "_%" PRIu32 "_%" PRIu32
 
 /*
  * Per-node, per-thread record files: "<records dir>/node<node>-<role>-<thread>", named for the role
@@ -162,6 +166,7 @@ typedef struct {
     char page_log_home[PATH_MAX];
     uint32_t nth;
     uint32_t pool_size;
+    bool unique_tables;               /* -U: never reuse a table name */
     uint32_t total_time;              /* -t: graceful stop after this many seconds */
     uint32_t switch_interval;         /* -s: switch roles every N seconds; 0: never */
     uint32_t kill_time[KILL_TARGETS]; /* -k [l|f]N: SIGKILL the target at N; 0: never */
@@ -239,6 +244,8 @@ typedef struct {
         uint64_t completed_ts; /* the latest published or committed timestamp; atomic access */
         /* Table state is carried across leader-follower transitions. */
         TABLE_STATE table_state[MAX_POOL_SIZE];
+        /* Advanced by every create under -U, so a slot's table name is never reused. */
+        uint32_t slot_gen[MAX_POOL_SIZE];
         /* Slot took an insert while stepping down; not droppable until the step-down completes. */
         bool stepdown_insert[MAX_POOL_SIZE];
     } workers[MAX_TH];

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -166,6 +166,7 @@ typedef struct {
     char page_log_home[PATH_MAX];
     uint32_t nth;
     uint32_t pool_size;
+    /* FIXME-WT-18403: Remove -U once all the known create/drop/create issues are gone. */
     bool unique_tables;               /* -U: never reuse a table name */
     uint32_t total_time;              /* -t: graceful stop after this many seconds */
     uint32_t switch_interval;         /* -s: switch roles every N seconds; 0: never */

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -78,7 +78,7 @@
 #define DATA_KEY_MIN 0
 #define DATA_KEY_MAX 9
 /*
- * node, thread, slot, generation. The generation stays zero unless -U asks for unique table names,
+ * node, thread, slot, generation. The generation stays zero unless -q asks for unique table names,
  * so the name is the slot's whatever the mode, and the verifier parses one format either way.
  */
 #define SCHEMA_TABLE_FMT "table:schema_%" PRIu32 "_%" PRIu32 "_%" PRIu32 "_%" PRIu32
@@ -166,8 +166,8 @@ typedef struct {
     char page_log_home[PATH_MAX];
     uint32_t nth;
     uint32_t pool_size;
-    /* FIXME-WT-18403: Remove -U once all the known create/drop/create issues are gone. */
-    bool unique_tables;               /* -U: never reuse a table name */
+    /* FIXME-WT-18403: Remove -q once all the known create/drop/create issues are gone. */
+    bool unique_tables;               /* -q: never reuse a table name */
     uint32_t total_time;              /* -t: graceful stop after this many seconds */
     uint32_t switch_interval;         /* -s: switch roles every N seconds; 0: never */
     uint32_t kill_time[KILL_TARGETS]; /* -k [l|f]N: SIGKILL the target at N; 0: never */
@@ -245,7 +245,7 @@ typedef struct {
         uint64_t completed_ts; /* the latest published or committed timestamp; atomic access */
         /* Table state is carried across leader-follower transitions. */
         TABLE_STATE table_state[MAX_POOL_SIZE];
-        /* Advanced by every create under -U, so a slot's table name is never reused. */
+        /* Advanced by every create under -q, so a slot's table name is never reused. */
         uint32_t slot_gen[MAX_POOL_SIZE];
         /* Slot took an insert while stepping down; not droppable until the step-down completes. */
         bool stepdown_insert[MAX_POOL_SIZE];

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -38,9 +38,9 @@ static bool
 parse_record_uri(
   const char *rec_uri, uint32_t node, uint32_t t, uint32_t pool_size, uint32_t *slotp)
 {
-    uint32_t n2, s, t2;
+    uint32_t g, n2, s, t2;
 
-    if (sscanf(rec_uri, SCHEMA_TABLE_FMT, &n2, &t2, &s) != 3 || n2 != node || t2 != t ||
+    if (sscanf(rec_uri, SCHEMA_TABLE_FMT, &n2, &t2, &s, &g) != 4 || n2 != node || t2 != t ||
       s >= pool_size)
         return (false);
     *slotp = s;

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -549,6 +549,24 @@ functions:
           fi
         done
 
+  # Every schema-disagg-abort task runs this loop and sets schema_args to pick the topology, the
+  # role switches, the kills and the table naming it exercises. The schema threads and the
+  # per-thread URI pool are maxed out throughout, for maximum schema churn.
+  "schema disagg abort":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        build_dir=$(cd ../../../ && pwd)
+        for i in $(seq ${times|10}); do
+          echo "Iteration $i/${times|10}"
+          ./test_schema_disagg_abort -b "$build_dir" ${schema_args} -T 12 -u 64 -t 300
+        done
+
   "timestamp abort disagg":
     command: shell.exec
     params:
@@ -658,181 +676,6 @@ variables:
         vars:
           times: 50
 
-  - &schema-disagg-abort-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # One node leading throughout. Max out the schema threads (-T) and the per-thread
-              # URI pool (-u) for maximum schema churn.
-              ./test_schema_disagg_abort -b "$build_dir" -r l -T 12 -u 64 -t 300
-            done
-
-  - &schema-disagg-abort-switch-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # One node stepping down and back up every 30 seconds (-s).
-              ./test_schema_disagg_abort -b "$build_dir" -r l -s 30 -T 12 -u 64 -t 300
-            done
-
-  - &schema-disagg-abort-crash-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # SIGKILL the lone node at 150s (-k), then recover and verify at the timeout.
-              ./test_schema_disagg_abort -b "$build_dir" -r l -k 150 -T 12 -u 64 -t 300
-            done
-
-  - &schema-disagg-abort-multi-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # Leader and follower (-r lf): the follower applies the relayed stream and picks up
-              # the leader's checkpoints.
-              ./test_schema_disagg_abort -b "$build_dir" -r lf -T 12 -u 64 -t 300
-            done
-
-  - &schema-disagg-abort-multi-crash-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # Kill the leader at 100s and the follower at 200s; each survivor carries on alone.
-              ./test_schema_disagg_abort -b "$build_dir" -r lf -k l100 -k f200 -T 12 -u 64 -t 300
-            done
-
-  # Two-node role switches. A step-up over a table the peer created.
-  - &schema-disagg-abort-multi-switch-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # The two nodes swap roles every 30 seconds.
-              ./test_schema_disagg_abort -b "$build_dir" -r lf -s 30 -T 12 -u 64 -t 300
-            done
-
-  # Same step-up exposure as above, with a kill on top.
-  - &schema-disagg-abort-multi-switch-crash-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # Swap roles every 30s and kill whoever leads at 150s; the survivor keeps switching
-              # by sentinel.
-              ./test_schema_disagg_abort -b "$build_dir" -r lf -s 30 -k l150 -T 12 -u 64 -t 300
-            done
-
-  - &schema-disagg-abort-follower-stepup-test-disagg
-    depends_on:
-        - name: compile
-    exec_timeout_secs: 7200
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            build_dir=$(cd ../../../ && pwd)
-            for i in $(seq ${times|10}); do
-              echo "Iteration $i/${times|10}"
-              # A lone follower generates its own workload and never checkpoints, then steps up over
-              # the operations it accumulated: the way a fresh node bootstraps its own tables before
-              # taking leadership.
-              ./test_schema_disagg_abort -b "$build_dir" -r f -s 30 -T 12 -u 64 -t 300
-            done
-
   - &schema-disagg-abort-smoke-test-disagg
     depends_on:
         - name: compile
@@ -923,37 +766,129 @@ tasks:
     name: timestamp-abort-test-disagg-2
     tags: ["stress-test-disagg-fail"]
 
-  - <<: *schema-disagg-abort-test-disagg
-    name: schema-disagg-abort-test-disagg-1
+  # The schema-disagg-abort matrix. The kill variants cover their graceful counterparts, since a
+  # kill lands halfway through the run and everything before it is the graceful workload.
+  - name: schema-disagg-abort-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          # One node leading throughout, SIGKILLed at 150s, then recovered and verified.
+          schema_args: -r l -k 150
 
-  - <<: *schema-disagg-abort-switch-test-disagg
-    name: schema-disagg-abort-switch-test-disagg-1
+  - name: schema-disagg-abort-switch-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          # One node stepping down and back up every 30 seconds.
+          schema_args: -r l -s 30
 
-  - <<: *schema-disagg-abort-crash-test-disagg
-    name: schema-disagg-abort-crash-test-disagg-1
+  - name: schema-disagg-abort-multi-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          # Leader and follower, each killed in turn, so each survivor carries on alone.
+          schema_args: -r lf -k l100 -k f200
 
-  - <<: *schema-disagg-abort-multi-test-disagg
-    name: schema-disagg-abort-multi-test-disagg-1
+  - name: schema-disagg-abort-multi-switch-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          # Two nodes swapping roles every 30s, killing whoever leads at 150s: a step-up over a
+          # table the peer created, with a crash on top.
+          schema_args: -r lf -s 30 -k l150
 
-  - <<: *schema-disagg-abort-multi-crash-test-disagg
-    name: schema-disagg-abort-multi-crash-test-disagg-1
+  - name: schema-disagg-abort-follower-stepup-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          # A lone follower generates its own workload and never checkpoints, then steps up over
+          # the operations it accumulated: the way a fresh node bootstraps its own tables before
+          # taking leadership.
+          schema_args: -r f -s 30
 
-  - <<: *schema-disagg-abort-multi-switch-test-disagg
-    name: schema-disagg-abort-multi-switch-test-disagg-1
+  # The same shapes with -U, where no table name is ever reused. Name reuse is what reaches
+  # create-drop-recreate of one table, so these runs isolate the rest of the schema behavior
+  # from it.
+  # FIXME-WT-18403: Remove these tasks once create-drop-recreate of one name passes.
+  - name: schema-disagg-abort-unique-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          schema_args: -r l -k 150 -U
 
-  - <<: *schema-disagg-abort-multi-switch-crash-test-disagg
-    name: schema-disagg-abort-multi-switch-crash-test-disagg-1
+  - name: schema-disagg-abort-unique-switch-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          schema_args: -r l -s 30 -U
 
-  - <<: *schema-disagg-abort-follower-stepup-test-disagg
-    name: schema-disagg-abort-follower-stepup-test-disagg-1
+  - name: schema-disagg-abort-unique-multi-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          schema_args: -r lf -k l100 -k f200 -U
+
+  - name: schema-disagg-abort-unique-multi-switch-crash-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          schema_args: -r lf -s 30 -k l150 -U
+
+  - name: schema-disagg-abort-unique-follower-stepup-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          schema_args: -r f -s 30 -U
 
   - <<: *schema-disagg-abort-smoke-test-disagg
     name: schema-disagg-abort-smoke-test-disagg-1

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -834,7 +834,7 @@ tasks:
   # The same shapes with -U, where no table name is ever reused. Name reuse is what reaches
   # create-drop-recreate of one table, so these runs isolate the rest of the schema behavior
   # from it.
-  # FIXME-WT-18403: Remove these tasks once create-drop-recreate of one name passes.
+  # FIXME-WT-18403: Remove these tasks once all the known create/drop/create issues are gone.
   - name: schema-disagg-abort-unique-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
     depends_on:

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -549,9 +549,6 @@ functions:
           fi
         done
 
-  # Every schema-disagg-abort task runs this loop and sets schema_args to pick the topology, the
-  # role switches, the kills and the table naming it exercises. The schema threads and the
-  # per-thread URI pool are maxed out throughout, for maximum schema churn.
   "schema disagg abort":
     command: shell.exec
     params:
@@ -831,9 +828,6 @@ tasks:
           # taking leadership.
           schema_args: -r f -s 30
 
-  # The same shapes with -U, where no table name is ever reused. Name reuse is what reaches
-  # create-drop-recreate of one table, so these runs isolate the rest of the schema behavior
-  # from it.
   # FIXME-WT-18403: Remove these tasks once all the known create/drop/create issues are gone.
   - name: schema-disagg-abort-unique-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -838,7 +838,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "schema disagg abort"
         vars:
-          schema_args: -r l -k 150 -U
+          schema_args: -r l -k 150 -q
 
   - name: schema-disagg-abort-unique-switch-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
@@ -849,7 +849,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "schema disagg abort"
         vars:
-          schema_args: -r l -s 30 -U
+          schema_args: -r l -s 30 -q
 
   - name: schema-disagg-abort-unique-multi-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
@@ -860,7 +860,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "schema disagg abort"
         vars:
-          schema_args: -r lf -k l100 -k f200 -U
+          schema_args: -r lf -k l100 -k f200 -q
 
   - name: schema-disagg-abort-unique-multi-switch-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
@@ -871,7 +871,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "schema disagg abort"
         vars:
-          schema_args: -r lf -s 30 -k l150 -U
+          schema_args: -r lf -s 30 -k l150 -q
 
   - name: schema-disagg-abort-unique-follower-stepup-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
@@ -882,7 +882,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "schema disagg abort"
         vars:
-          schema_args: -r f -s 30 -U
+          schema_args: -r f -s 30 -q
 
   - <<: *schema-disagg-abort-smoke-test-disagg
     name: schema-disagg-abort-smoke-test-disagg-1


### PR DESCRIPTION
`schema_disagg_abort` names tables after a fixed slot pool, so a slot's name is recycled on every create/drop cycle. That reuse is what reaches create-drop-recreate of one table, and it means a run can't be pointed at the rest of the schema behavior while that path fails.

Add `-U`: every create gets a fresh name. The generation counter is always in the name format and stays at zero without the option, so nothing downstream branches on the mode and the verifier parses one format either way.

Unique names can't reach the same-name recreate paths, and the verifier only checks the latest generation per slot. FIXME-WT-18403 tracks removing the option once those issues are gone.