### PR TITLE
WT-18391 Publish prepare-rollback update-chain appends with a release store

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -274,7 +274,7 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
     }
 
     /* Append the new entry into the update list. */
-    WT_RELEASE_WRITE_WITH_BARRIER(upd->next, append);
+    __wt_atomic_store_ptr_release(&upd->next, append);
 
     __wt_cache_page_inmem_incr(session, page, total_size, false);
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1105,8 +1105,12 @@ __txn_prepare_rollback_restore_hs_update(
             break;
     }
 
-    /* Append the update to the end of the chain. */
-    __wt_atomic_store_ptr_relaxed(&upd_chain->next, upd);
+    /*
+     * Append the update to the end of the chain. Readers walk this chain with relaxed loads, so the
+     * link must be published with a release store to order it after the update's initializing
+     * stores above.
+     */
+    __wt_atomic_store_ptr_release(&upd_chain->next, upd);
 
     __wt_cache_page_inmem_incr(session, page, total_size, false);
 
@@ -1206,7 +1210,11 @@ __txn_prepare_rollback_delete_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UP
     while (upd_chain->next != NULL)
         upd_chain = upd_chain->next;
 
-    __wt_atomic_store_ptr_relaxed(&upd_chain->next, tombstone);
+    /*
+     * Readers walk this chain with relaxed loads, so the link must be published with a release
+     * store to order it after the tombstone's initializing stores above.
+     */
+    __wt_atomic_store_ptr_release(&upd_chain->next, tombstone);
 
     __wt_cache_page_inmem_incr(session, page, size, false);
 


### PR DESCRIPTION
## Summary

Fixes a use-of-uninitialized-memory race that segfaulted `format-stress-test-disagg-multi` (WT-18391): the prepare-rollback path appended new tail updates to a *live* update chain with a relaxed store. Readers walk that chain with relaxed loads and have no other synchronization with the appending writer, so on a weakly ordered CPU (this hit on arm64) the new tail pointer could become visible to a reader before the appended update's own initializing stores did, letting the reader dereference not-yet-written memory and follow a garbage `next` pointer off into the weeds.

Root-caused from a core dump: full analysis on the ticket. In short, the crashing thread was walking a chain ending in a rolled-back prepared update followed by the globally-visible tombstone `__txn_prepare_rollback_delete_key` appends to mark the key deleted; the append is exactly the relaxed store fixed here, and the rolled-back transaction's id falls inside the crashing reader's snapshot window, confirming the two were concurrent.

`__txn_prepare_rollback_restore_hs_update`'s HS-restore tail append has the identical pattern and gets the identical fix. `__rec_append_orig_value` was already doing this correctly via `WT_RELEASE_WRITE_WITH_BARRIER`; converted to the plain atomic-release helper for consistency with the other two sites.