### PR TITLE
WT-18322 Read the drop size from the shared metadata table instead of a queue entry snapshot

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1023,13 +1023,9 @@ __checkpoint_update_disagg_database_size(
         delta = session->ckpt.ckpt_size_delta - (int64_t)drop_size;
 
         if (delta > 0) {
-            uint64_t add;
-
-            add = (uint64_t)delta;
-            WT_ASSERT_ALWAYS(session, UINT64_MAX - db >= add,
-              "disaggregated database size overflow: incrementing %" PRIu64 " by %" PRIu64, db,
-              add);
-            __wt_disagg_set_database_size(session, db + add);
+            /* FIXME-WT-18423: Handle an overflow in the disaggregated database size accounting. */
+            WT_ASSERT(session, UINT64_MAX - db >= (uint64_t)delta);
+            __wt_disagg_set_database_size(session, db + (uint64_t)delta);
         } else if (delta < 0) {
             uint64_t sub, new_size;
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1023,8 +1023,13 @@ __checkpoint_update_disagg_database_size(
         delta = session->ckpt.ckpt_size_delta - (int64_t)drop_size;
 
         if (delta > 0) {
-            WT_ASSERT(session, UINT64_MAX - db >= (uint64_t)delta);
-            __wt_disagg_set_database_size(session, db + (uint64_t)delta);
+            uint64_t add;
+
+            add = (uint64_t)delta;
+            WT_ASSERT_ALWAYS(session, UINT64_MAX - db >= add,
+              "disaggregated database size overflow: incrementing %" PRIu64 " by %" PRIu64, db,
+              add);
+            __wt_disagg_set_database_size(session, db + add);
         } else if (delta < 0) {
             uint64_t sub, new_size;
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1009,8 +1009,11 @@ __checkpoint_update_disagg_database_size(
      * succeeded, unless the recompute above already replaced it. Positive deltas occur when data is
      * added during the checkpoint. Negative deltas occur when data is removed reducing the total
      * storage footprint. Guard against overflow/underflow in both cases.
+     *
+     * A drop size is an independent input: a checkpoint that only drops tables has no size delta of
+     * its own, so gating on the delta alone loses the drop.
      */
-    if (!recomputed && session->ckpt.ckpt_size_delta != 0) {
+    if (!recomputed && (session->ckpt.ckpt_size_delta != 0 || drop_size != 0)) {
         uint64_t db;
         int64_t delta;
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -8,8 +8,6 @@
 
 #include "wt_internal.h"
 
-static int __disagg_accumulate_drop_size(
-  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_size);
 static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
 
 /*
@@ -487,19 +485,24 @@ __wti_disagg_table_latest_create_remove(WT_SESSION_IMPL *session, const char *ta
 
 /*
  * __disagg_shared_metadata_op_helper --
- *     Perform the remove/update operation in the shared metadata table.
+ *     Perform the remove/update operation in the shared metadata table. When drop_sizep is set, a
+ *     REMOVE reads the checkpoint size from the row being deleted and adds it; a missing row
+ *     contributes nothing.
  */
 static int
-__disagg_shared_metadata_op_helper(
-  WT_SESSION_IMPL *session, const char *key, const char *value, WT_SHARED_METADATA_OP metadata_op)
+__disagg_shared_metadata_op_helper(WT_SESSION_IMPL *session, const char *key, const char *value,
+  WT_SHARED_METADATA_OP metadata_op, uint64_t *drop_sizep)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
+    uint64_t size;
     const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL};
+    const char *config;
 
     WT_ASSERT(session, __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     cursor = NULL;
+    config = NULL;
 
     WT_ERR(__wt_open_cursor(session, WT_DISAGG_METADATA_URI, NULL, cfg, &cursor));
     cursor->set_key(cursor, key);
@@ -516,7 +519,21 @@ __disagg_shared_metadata_op_helper(
          * Since either form may appear depending on how the table was created, it is acceptable for
          * some lookups to return WT_NOTFOUND.
          */
-        WT_ERR_NOTFOUND_OK(cursor->remove(cursor), false);
+        if (drop_sizep != NULL) {
+            size = 0;
+            WT_ERR_NOTFOUND_OK(cursor->search(cursor), true);
+            if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+                WT_ERR(cursor->get_value(cursor, &config));
+                WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, config, &size), true);
+                if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+                    *drop_sizep += size;
+                    __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
+                      "Accumulated drop size %" PRIu64 " for stable URI \"%s\"", size, key);
+                }
+                WT_ERR(cursor->remove(cursor));
+            }
+        } else
+            WT_ERR_NOTFOUND_OK(cursor->remove(cursor), false);
         break;
     case WT_SHARED_METADATA_CREATE:
     case WT_SHARED_METADATA_UPDATE:
@@ -545,7 +562,8 @@ err:
  *     Remove/update all relevant metadata entries of a table in the shared metadata table.
  */
 static int
-__disagg_shared_metadata_op(WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry)
+__disagg_shared_metadata_op(
+  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_sizep)
 {
     WT_DECL_ITEM(md_key);
     WT_DECL_RET;
@@ -553,18 +571,18 @@ __disagg_shared_metadata_op(WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *ent
     WT_ERR(__wt_scr_alloc(session, 0, &md_key));
     WT_ERR(__wt_buf_fmt(session, md_key, "colgroup:%s", entry->table_name));
     WT_ERR(__disagg_shared_metadata_op_helper(
-      session, md_key->data, entry->colgroup_value, entry->metadata_op));
+      session, md_key->data, entry->colgroup_value, entry->metadata_op, NULL));
 
     WT_ERR(__wt_buf_fmt(session, md_key, "layered:%s", entry->table_name));
     WT_ERR(__disagg_shared_metadata_op_helper(
-      session, md_key->data, entry->layered_value, entry->metadata_op));
+      session, md_key->data, entry->layered_value, entry->metadata_op, NULL));
 
     WT_ERR(__wt_buf_fmt(session, md_key, "table:%s", entry->table_name));
     WT_ERR(__disagg_shared_metadata_op_helper(
-      session, md_key->data, entry->table_value, entry->metadata_op));
+      session, md_key->data, entry->table_value, entry->metadata_op, NULL));
 
     WT_ERR(__disagg_shared_metadata_op_helper(
-      session, entry->stable_uri, entry->stable_value, entry->metadata_op));
+      session, entry->stable_uri, entry->stable_value, entry->metadata_op, drop_sizep));
 err:
     __wt_scr_free(session, &md_key);
     return (ret);
@@ -634,42 +652,6 @@ __disagg_handle_create_remove_pairing(WT_SESSION_IMPL *session, WT_CONNECTION_IM
 }
 
 /*
- * __disagg_accumulate_drop_size --
- *     Accumulate the drop size if the entry represents a table drop operation.
- */
-int
-__disagg_accumulate_drop_size(
-  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_sizep)
-{
-    WT_DECL_RET;
-    char *stable_config;
-
-    stable_config = NULL;
-
-    if (!(entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL))
-        return (0);
-
-    /* The stable entry is gone only after a real drop; a rolled-back drop leaves it. */
-    WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, entry->stable_uri, &stable_config), true);
-
-    if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-        uint64_t size = 0;
-        /* A table dropped before it was ever checkpointed has no checkpoint entry. */
-        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), true);
-        if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-            *drop_sizep += size;
-            __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-              "Accumulated drop size %" PRIu64 " for table \"%s\" (stable URI \"%s\")", size,
-              entry->table_name, entry->stable_uri);
-        }
-    }
-
-err:
-    __wt_free(session, stable_config);
-    return (ret);
-}
-
-/*
  * __disagg_requeue_skipped_creates --
  *     Return parked create entries to the head of the shared metadata queue, restoring their
  *     original order, so a later checkpoint revisits them.
@@ -694,8 +676,8 @@ __disagg_requeue_skipped_creates(
 
 /*
  * __wt_disagg_shared_metadata_queue_process --
- *     Process the update metadata list, returning the total checkpoint size of the tables actually
- *     dropped so the caller can reduce the database size accordingly.
+ *     Process the update metadata list, returning the total checkpoint size of the shared rows the
+ *     REMOVE entries deleted so the caller can reduce the database size accordingly.
  */
 int
 __wt_disagg_shared_metadata_queue_process(
@@ -752,9 +734,7 @@ __wt_disagg_shared_metadata_queue_process(
         }
 
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
-        WT_ERR(__disagg_shared_metadata_op(session, entry));
-
-        WT_ERR(__disagg_accumulate_drop_size(session, entry, drop_sizep));
+        WT_ERR(__disagg_shared_metadata_op(session, entry, drop_sizep));
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -486,8 +486,8 @@ __wti_disagg_table_latest_create_remove(WT_SESSION_IMPL *session, const char *ta
 /*
  * __disagg_shared_metadata_op_helper --
  *     Perform the remove/update operation in the shared metadata table. When drop_sizep is set, a
- *     REMOVE reads the checkpoint size from the row being deleted and adds it; a missing row
- *     contributes nothing.
+ *     REMOVE sets it to the checkpoint size of the row it deletes, and leaves it alone when the row
+ *     carries no size; the caller owns the default.
  */
 static int
 __disagg_shared_metadata_op_helper(WT_SESSION_IMPL *session, const char *key, const char *value,
@@ -520,15 +520,14 @@ __disagg_shared_metadata_op_helper(WT_SESSION_IMPL *session, const char *key, co
          * some lookups to return WT_NOTFOUND.
          */
         if (drop_sizep != NULL) {
-            size = 0;
             WT_ERR_NOTFOUND_OK(cursor->search(cursor), true);
             if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
                 WT_ERR(cursor->get_value(cursor, &config));
                 WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, config, &size), true);
                 if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-                    *drop_sizep += size;
+                    *drop_sizep = size;
                     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-                      "Accumulated drop size %" PRIu64 " for stable URI \"%s\"", size, key);
+                      "Drop size %" PRIu64 " for stable URI \"%s\"", size, key);
                 }
                 WT_ERR(cursor->remove(cursor));
             }
@@ -559,7 +558,8 @@ err:
 
 /*
  * __disagg_shared_metadata_op --
- *     Remove/update all relevant metadata entries of a table in the shared metadata table.
+ *     Remove/update all relevant metadata entries of a table in the shared metadata table,
+ *     returning the checkpoint size a REMOVE took out of the shared metadata table.
  */
 static int
 __disagg_shared_metadata_op(
@@ -567,6 +567,9 @@ __disagg_shared_metadata_op(
 {
     WT_DECL_ITEM(md_key);
     WT_DECL_RET;
+
+    /* Only the stable constituent carries a size, and only a REMOVE takes one out. */
+    *drop_sizep = 0;
 
     WT_ERR(__wt_scr_alloc(session, 0, &md_key));
     WT_ERR(__wt_buf_fmt(session, md_key, "colgroup:%s", entry->table_name));
@@ -687,6 +690,7 @@ __wt_disagg_shared_metadata_queue_process(
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
+    uint64_t entry_drop_size;
 
     WT_ASSERT(session, drop_sizep != NULL);
     conn = S2C(session);
@@ -734,7 +738,8 @@ __wt_disagg_shared_metadata_queue_process(
         }
 
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
-        WT_ERR(__disagg_shared_metadata_op(session, entry, drop_sizep));
+        WT_ERR(__disagg_shared_metadata_op(session, entry, &entry_drop_size));
+        *drop_sizep += entry_drop_size;
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -518,6 +518,10 @@ __disagg_shared_metadata_op_helper(WT_SESSION_IMPL *session, const char *key, co
          *
          * Since either form may appear depending on how the table was created, it is acceptable for
          * some lookups to return WT_NOTFOUND.
+         *
+         * Only the stable constituent carries a checkpoint size, so only that lookup asks for one.
+         * Take it from the row being deleted: that is the size the metadata walk stops counting,
+         * and deleting the row keeps the subtraction to one per dropped table.
          */
         if (drop_sizep != NULL) {
             WT_ERR_NOTFOUND_OK(cursor->search(cursor), true);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -222,13 +222,9 @@ __drop_layered(
     }
 
     /*
-     * Snapshot the stable table's configuration before the local metadata is removed. The shared
-     * metadata REMOVE enqueued below needs it for drop-size accounting, and by then the local rows
-     * are gone. The stable table may have no local row on a follower or for a table created after
-     * the step-down timestamp was set.
-     *
-     * FIXME-WT-18322: Read the size from the shared metadata table when the REMOVE is applied,
-     * removing the need for this snapshot.
+     * Read the stable table's configuration before the local rows go away: the enqueue below would
+     * otherwise look it up in local metadata and find nothing. The stable table may have no local
+     * row on a follower or for a table created after the step-down timestamp was set.
      */
     WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, stable_uri, &stable_value), false);
 

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -187,10 +187,7 @@ __drop_layered(
     WT_DECL_ITEM(ingest_uri_buf);
     WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
-    char *stable_value;
     const char *ingest_uri, *stable_uri, *tablename;
-
-    stable_value = NULL;
 
     WT_UNUSED(force);
 
@@ -220,13 +217,6 @@ __drop_layered(
               "stable constituent \"%s\" not found when dropping \"%s\" on leader", stable_uri,
               uri);
     }
-
-    /*
-     * Read the stable table's configuration before the local rows go away: the enqueue below would
-     * otherwise look it up in local metadata and find nothing. The stable table may have no local
-     * row on a follower or for a table created after the step-down timestamp was set.
-     */
-    WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, stable_uri, &stable_value), false);
 
     /*
      * Drop the layered table constituents. The stable table may not exist locally: a follower never
@@ -259,13 +249,12 @@ __drop_layered(
      */
     WT_SAVE_DHANDLE(session,
       ret = __wt_disagg_enqueue_metadata_operation(session, stable_uri, tablename,
-        WT_SHARED_METADATA_REMOVE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, stable_value));
+        WT_SHARED_METADATA_REMOVE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL));
     WT_ERR(ret);
 
 err:
     __wt_scr_free(session, &ingest_uri_buf);
     __wt_scr_free(session, &stable_uri_buf);
-    __wt_free(session, stable_value);
 
     return (ret);
 }

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -46,6 +46,12 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
     victim_uri = "layered:victim_table"
     victim_base = "victim_table"
 
+    # The shared metadata table. Its own checkpoint size moves with the drop.
+    shared_uri = "file:WiredTigerShared.wt_stable"
+
+    # The fixed overhead every database size carries for the KEK table and shared turtle page.
+    WT_DISAGG_CHECKPOINT_SIZE_BUFFER = 1024 * 1024
+
     value_size = 8000
     num_failed_ckpts = 4
 
@@ -72,24 +78,38 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
             cursor[str(i)] = str(i) + 'x' * self.value_size
         cursor.close()
 
+    def get_checkpoint_size(self, uri):
+        """The size of a file's most recent checkpoint, as the database size counts it."""
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(uri)
+        self.assertEqual(meta_cursor.search(), 0)
+        sizes = re.findall(r',size=(\d+),', meta_cursor.get_value())
+        meta_cursor.close()
+        self.assertGreater(len(sizes), 0, f"no checkpoint size in the metadata for {uri}")
+        return int(sizes[-1])
+
+    def accumulated_stable_size(self):
+        """The database size as the metadata defines it: every stable file's last checkpoint."""
+        total = 0
+        with WiredTigerCursor(self.session, 'metadata:') as cursor:
+            while cursor.next() == 0:
+                uri = cursor.get_key()
+                if not uri.startswith('file:') or not uri.endswith('.wt_stable'):
+                    continue
+                sizes = re.findall(r',size=(\d+),', cursor.get_value())
+                if sizes:
+                    total += int(sizes[-1])
+        return total
+
     def database_size_check(self, context_message=""):
         self.session.checkpoint()
 
-        # Calculate reference value from sum of all the collections
-        accumulated_database_size = 0
-        with WiredTigerCursor(self.session, 'metadata:') as cursor:
-            while cursor.next() == 0:
-                value = cursor.get_value()
-                checkpoints = re.findall(r',checkpoint=([^)]+),', value)
-                if checkpoints:
-                    sizes = re.findall(r',size=(\d+),', checkpoints[0])
-                    if sizes:
-                        accumulated_database_size += int(sizes[-1])
-
+        accumulated_database_size = \
+            self.accumulated_stable_size() + self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER
         database_size = self.get_database_size()
-        self.assertGreaterEqual(database_size, accumulated_database_size,
-            f"database size {database_size} should be greater or equal to "
-            f"accumulated {accumulated_database_size} : {context_message}")
+        self.assertEqual(database_size, accumulated_database_size,
+            f"database size {database_size} should equal the metadata's own total "
+            f"{accumulated_database_size} : {context_message}")
 
     def test_failed_drop_does_not_shrink_database_size(self):
         # Filler table for headroom.
@@ -131,12 +151,21 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         busy_session.close()
         self.assertTrue(self.exists(self.victim_uri))
 
-        # We should see the drop size for a successful drop
-        with self.expectedStdoutPattern('.*Accumulated drop size.*', maxchars=1000000):
-            self.conn.reconfigure("verbose=[disaggregated_storage:2]")
-            self.session.drop(self.victim_uri, None)
-            self.session.checkpoint()
-            self.conn.reconfigure("verbose=[disaggregated_storage:0]")
+        # A successful drop takes the collection's whole size out of the database size. The same
+        # checkpoint applies the drop's removal to the shared metadata table, whose own checkpoint
+        # size moves as a result; that part of the change does not belong to the collection.
+        victim_size = self.get_checkpoint_size("file:" + self.victim_base + ".wt_stable")
+        shared_before_drop = self.get_checkpoint_size(self.shared_uri)
+        size_before_drop = self.get_database_size()
+        self.session.drop(self.victim_uri, None)
+        self.session.checkpoint()
+        shared_after_drop = self.get_checkpoint_size(self.shared_uri)
+        size_after_drop = self.get_database_size()
+        self.assertEqual(size_before_drop - size_after_drop,
+            victim_size - (shared_after_drop - shared_before_drop),
+            f"a successful drop must remove the collection's size ({victim_size}) from the database "
+            f"size: {size_before_drop} -> {size_after_drop}, shared metadata "
+            f"{shared_before_drop} -> {shared_after_drop}")
 
         self.assertFalse(self.exists(self.victim_uri))
         self.database_size_check("after successful drop")

--- a/test/suite/test_disagg_checkpoint_size23.py
+++ b/test/suite/test_disagg_checkpoint_size23.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_disagg_checkpoint_size23.py
+#   Database size accounting across the events a URI's metadata entry goes through: created,
+#   checkpointed, dropped, and created again under the same name before the drop was processed.
+#
+#   Three values are checked together at every step, because they fail independently:
+#     - the size published in the checkpoint metadata, which is what another node adopts;
+#     - the maintained running size;
+#     - the from-scratch recompute from the metadata, which is the definition the verify path uses.
+#   A one-sided check on the published value alone cannot see an over-subtraction, and equality
+#   between the maintained and recomputed sizes alone cannot see a value that never reaches a
+#   checkpoint.
+
+import re, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+@disagg_test_class
+class test_disagg_checkpoint_size23(DisaggConfigMixin, wttest.WiredTigerTestCase):
+
+    conn_base_config = 'statistics=(all),disaggregated=(lose_all_my_data=true),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+    conn_follow_config = conn_base_config + 'disaggregated=(role="follower")'
+
+    table_name = "reused_table"
+    uri = "layered:" + table_name
+    stable_uri = "file:" + table_name + ".wt_stable"
+    table_config = 'key_format=i,value_format=S'
+
+    # The fixed overhead every database size carries for the KEK table and shared turtle page.
+    WT_DISAGG_CHECKPOINT_SIZE_BUFFER = 1024 * 1024
+
+    def published_size(self, conn=None):
+        """The database size in the newest complete checkpoint, as another node would read it."""
+        match = re.search(r'database_size=(\d+)', self.disagg_get_complete_checkpoint_meta(conn))
+        self.assertIsNotNone(match)
+        return int(match.group(1))
+
+    def maintained_and_recomputed(self, conn=None):
+        """The running database size, and the same value summed from the metadata."""
+        if conn is None:
+            conn = self.conn
+        local = wiredtiger.wiredtiger_repair(conn, 'fetch_database_size=(local=true)')
+        recomputed = wiredtiger.wiredtiger_repair(conn, 'fetch_database_size=(local=false)')
+        local = re.search(r'fetch_database_size\(local\): (\d+)', local)
+        recomputed = re.search(r'fetch_database_size\(recompute\): (\d+)', recomputed)
+        self.assertIsNotNone(local)
+        self.assertIsNotNone(recomputed)
+        return int(local.group(1)), int(recomputed.group(1))
+
+    def stable_uri_present(self, stable_uri, conn=None):
+        """Whether a stable file has a metadata entry, in the view the size walk itself reads."""
+        if conn is None:
+            conn = self.conn
+        report = wiredtiger.wiredtiger_repair(
+            conn, f'fetch_metadata=(local=true,uri="{stable_uri}")')
+        return '<no matching metadata entry' not in report
+
+    def check_consistent(self, label, conn=None):
+        """The published, running and recomputed sizes must all be the same number."""
+        local, recomputed = self.maintained_and_recomputed(conn)
+        published = self.published_size(conn)
+        self.pr(f"{label}: published={published}, local={local}, recomputed={recomputed}, "
+            f"drift={local - recomputed}")
+        self.assertEqual(local, recomputed,
+            f"{label}: maintained database size {local} != recomputed {recomputed} "
+            f"(drift {local - recomputed})")
+        self.assertEqual(published, local,
+            f"{label}: published database size {published} != maintained {local}")
+        return local
+
+    def populate(self, session=None, rows=1000):
+        if session is None:
+            session = self.session
+        cursor = session.open_cursor(self.uri)
+        for i in range(rows):
+            cursor[i] = 'a' * 500
+        cursor.close()
+
+    # A dropped table's size must leave the database size even when the name is taken again before
+    # the checkpoint processes the removal, which a recreated metadata entry under the same name
+    # used to hide.
+    def test_recreate_between_drops_does_not_leak(self):
+        self.session.create(self.uri, self.table_config)
+        self.session.checkpoint()
+        size_empty = self.published_size()
+        self.check_consistent("after create")
+
+        self.populate()
+        self.session.checkpoint()
+        size_with_data = self.published_size()
+        self.assertGreater(size_with_data, size_empty)
+        self.check_consistent("after populate")
+
+        # Take the name again before the checkpoint processes the removal, so the removal is
+        # processed while the name belongs to a later table. Then drop that one too: nothing is left
+        # behind, so the data's size must leave the database size.
+        self.session.drop(self.uri)
+        self.session.create(self.uri, self.table_config)
+        self.session.checkpoint()
+        self.session.drop(self.uri)
+        self.session.checkpoint()
+        self.session.checkpoint()
+
+        size_after = self.published_size()
+        self.pr(f"empty={size_empty}, with_data={size_with_data}, after_all_dropped={size_after}")
+
+        # Nothing of the table may be left in the metadata. With its entry gone the recompute
+        # cannot count it, so the equality check below is what proves the maintained size does not
+        # either. Note the size does not return to size_empty: the shared metadata table's own
+        # stable file is counted too, and the creates and drops above grew it.
+        self.assertFalse(self.stable_uri_present(self.stable_uri),
+            f"the dropped table's stable file must not remain: {self.stable_uri}")
+        # What is left above the fixed overhead is that shared file, not the data we inserted.
+        self.assertLess(size_after - self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER,
+            size_with_data - size_empty,
+            f"the dropped data must not stay in the database size: empty={size_empty}, "
+            f"with_data={size_with_data}, after_all_dropped={size_after}")
+        self.check_consistent("after all dropped")
+
+    # The same name reused repeatedly, with each removal processed while the name belongs to a later
+    # table. An over-subtraction shows up as a drift between the maintained and recomputed sizes.
+    def test_reuse_churn(self):
+        for i in range(10):
+            self.session.create(self.uri, self.table_config)
+            self.populate(rows=100)
+            self.session.checkpoint()
+
+            self.session.drop(self.uri)
+            self.session.create(self.uri, self.table_config)
+            if i % 2 == 0:
+                self.populate(rows=50)
+            # A table must be checkpointed before it can be dropped.
+            self.session.checkpoint()
+            self.session.drop(self.uri)
+            self.session.checkpoint()
+
+            self.check_consistent(f"cycle {i}")
+
+        self.session.checkpoint()
+        self.check_consistent("after churn")
+
+    # A node that learns of a table by adopting a checkpoint, rather than by creating it, must
+    # account for the size that arrives with it: the table's metadata entry appears complete with a
+    # checkpoint. Stepping the follower up makes it publish a size of its own.
+    def test_size_arriving_with_a_checkpoint(self):
+        self.session.create(self.uri, self.table_config)
+        self.populate()
+        self.session.checkpoint()
+        leader_size = self.published_size()
+        self.assertGreater(leader_size, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER)
+
+        conn_follow = self.wiredtiger_open(
+            'follower', self.extensionsConfig() + ',create,' + self.conn_follow_config)
+        try:
+            session_follow = conn_follow.open_session('')
+
+            # Give the follower a table of its own and checkpoint it, so its size accounting is
+            # already established before the pickup brings a table it has never seen.
+            session_follow.create("table:follower_local", self.table_config)
+            local_cursor = session_follow.open_cursor("table:follower_local")
+            for i in range(100):
+                local_cursor[i] = 'b' * 500
+            local_cursor.close()
+            session_follow.checkpoint()
+
+            # The follower has never seen the table; the pickup brings its metadata entry, and its
+            # checkpoint size along with it.
+            self.disagg_advance_checkpoint(conn_follow)
+
+            # The pickup must really have brought the table over, or the rest proves nothing.
+            meta = session_follow.open_cursor('metadata:')
+            meta.set_key(self.stable_uri)
+            self.assertEqual(meta.search(), 0,
+                "the pickup did not bring the table's stable file into the local metadata")
+            meta.close()
+            _, follower_recomputed = self.maintained_and_recomputed(conn_follow)
+            self.assertGreater(follower_recomputed, self.WT_DISAGG_CHECKPOINT_SIZE_BUFFER,
+                "the follower's metadata must account for the adopted table's data")
+            self.check_consistent("follower after pickup", conn_follow)
+
+            # Give the step up a checkpoint the follower has not already adopted.
+            self.populate(rows=50)
+            self.session.checkpoint()
+            leader_size = self.published_size()
+
+            # As the new leader it publishes a size, which must still cover the adopted table.
+            self.disagg_switch_follower_and_leader(conn_follow)
+            session_follow.checkpoint()
+            follower_size = self.check_consistent("follower after step up", conn_follow)
+            self.assertGreaterEqual(follower_size, leader_size,
+                f"the size adopted with the checkpoint must survive a step up: leader published "
+                f"{leader_size}, new leader has {follower_size}")
+            session_follow.close()
+        finally:
+            conn_follow.close()
+
+if __name__ == "__main__":
+    wttest.run()


### PR DESCRIPTION
Take the dropped table's checkpoint size from the shared metadata row the REMOVE deletes, rather than from a pre drop config snapshot on local metadata. A name that is recreated before the checkpoint processes the removal no longer leaks its size into database_size.