### PR TITLE
WT-18351 Flaky test_checkpoint_scrub_evict.py on Windows

### DIFF
--- a/test/suite/test_checkpoint_scrub_evict.py
+++ b/test/suite/test_checkpoint_scrub_evict.py
@@ -59,9 +59,15 @@ class test_checkpoint_scrub_evict(wttest.WiredTigerTestCase):
 
     uri = 'table:scrub_evict'
 
+    # Turn scrub on rather than letting the auto cache-pressure heuristic decide for 
+    # precise checkpoints to make the assertion deterministic the test.
     ckpt_precision = [
-        ('precise', dict(precise=True,  ckpt_cfg='precise_checkpoint=true')),
-        ('fuzzy',   dict(precise=False, ckpt_cfg='precise_checkpoint=false')),
+        ('precise', dict(precise=True,
+                         ckpt_cfg='precise_checkpoint=true,'
+                                  'eviction=(checkpoint_scrub_eviction=on)')),
+        ('fuzzy',   dict(precise=False,
+                         ckpt_cfg='precise_checkpoint=false,'
+                                  'eviction=(checkpoint_scrub_eviction=auto)')),
     ]
     value_sz = [
         ('small',  dict(vsize=100)),

--- a/test/suite/test_checkpoint_scrub_evict.py
+++ b/test/suite/test_checkpoint_scrub_evict.py
@@ -59,8 +59,11 @@ class test_checkpoint_scrub_evict(wttest.WiredTigerTestCase):
 
     uri = 'table:scrub_evict'
 
-    # Turn scrub on rather than letting the auto cache-pressure heuristic decide for 
-    # precise checkpoints to make the assertion deterministic the test.
+    # Turn scrub on rather than letting the auto cache-pressure heuristic decide for precise
+    # checkpoints. These tests need eviction engaged to consume the retained images and eviction
+    # in scrub mode to produce them, and auto only scrubs below the dirty and updates
+    # target/trigger midpoints while dirty eviction only runs above their targets. That is a
+    # narrow window that makes auto unreliable for these tests.
     ckpt_precision = [
         ('precise', dict(precise=True,
                          ckpt_cfg='precise_checkpoint=true,'


### PR DESCRIPTION
We are seeing an intermittent assertion error in test_scrub_stat_after_checkpoint:
AssertionError: 0 not greater than 0 : cache_write_restore_scrub should increase after a precise checkpoint: before=0, after=0

The precise checkpoint scenarios asserted that cache_write_restore_scrub increases after a checkpoint, but left scrub eviction setting on auto with an intentionally small cache. The test can fail in scenarios where cache pressure would turn scrub eviction off. This fix explicitly sets precise checkpoint scrub eviction on. It leaves the fuzzy checkpoint on auto so the "must be zero" assertions for fuzzy checkpoint isn't trivially passing. 

test_checkpoint_scrub_evict_config also in this test file asserts the different on, off, and auto configs so we can leave the rest of the test with scrub turned on. [Stress test patch build here,](https://spruce.corp.mongodb.com/version/6a8529b0b633b90007e5ca3f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) no error after 280 iterations.