### PR TITLE
WT-18405 Do not drop a table on the follower with uncheckpointed data

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -358,6 +358,64 @@ __wti_conn_dhandle_outdated(WT_SESSION_IMPL *session, const char *uri)
 }
 
 /*
+ * __conn_dhandle_check_drop_durable --
+ *     Refuse a drop-time close that would discard a layered constituent's committed data when no
+ *     checkpoint covers it. Must run under the exclusive dhandle lock used for the close, after the
+ *     transaction visibility check, so a commit cannot slip between the check and the close.
+ */
+static int
+__conn_dhandle_check_drop_durable(WT_SESSION_IMPL *session)
+{
+    WT_BTREE *btree = S2BT(session);
+    const char *uri = session->dhandle->name;
+
+    if (WT_URI_IS_INGEST(uri)) {
+        /*
+         * An ingest tree is in-memory, so closing it discards its content instead of taking the
+         * dirty-data path that refuses to close a durable tree. The node has no other copy of
+         * writes the leader has not yet checkpointed, so bound the drop by the maximum write
+         * timestamp, a possibly conservative upper bound on the durable timestamps the tree holds,
+         * which the checkpoint must cover.
+         *
+         * The bound is the adopted disaggregated checkpoint, not the last local one: a local
+         * checkpoint persists nothing of an in-memory tree, so its timestamp says nothing about
+         * whether these writes survive the close.
+         *
+         * This guard exists because schema-epoch ordering can defer the drop past a later
+         * checkpoint: if this node steps up, it can owe that checkpoint the table's pre-drop
+         * writes, which closing the ingest tree has already discarded. It applies regardless of the
+         * node's role: transactions committed after the step-down timestamp was set write to ingest
+         * while the connection is still a leader.
+         */
+        WT_DISAGGREGATED_STORAGE *disagg = &S2C(session)->disaggregated_storage;
+        wt_timestamp_t max_write_ts = __wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts);
+        wt_timestamp_t bound = __wt_atomic_load_uint64_acquire(&disagg->last_checkpoint_timestamp);
+
+        if (max_write_ts != WT_TS_NONE && max_write_ts > bound)
+            WT_RET_SUB(session, EBUSY, WT_DIRTY_DATA,
+              "the table has ingested data that no checkpoint covers and must not be dropped yet");
+
+    } else if (WT_URI_IS_STABLE(uri)) {
+        if (F_ISSET_ATOMIC_32(btree, WT_BTREE_AWAITS_PUBLISH)) {
+            /*
+             * A table awaiting publication has never been checkpointed, so closing its handle loses
+             * any committed data it holds. An empty table may be modified in memory yet hold
+             * nothing committed, so this must not fall through to the generic modified check.
+             */
+            if (__wt_atomic_load_uint64_relaxed(&btree->min_unpublished_durable_ts) != WT_TS_NONE)
+                WT_RET_SUB(session, EBUSY, WT_DIRTY_DATA,
+                  "the table has unpublished data and must be checkpointed before it can be "
+                  "dropped");
+        } else if (btree->modified)
+            /* Reached when the drop marks the handle dead, skipping the checkpoint-close check. */
+            WT_RET_SUB(
+              session, EBUSY, WT_DIRTY_DATA, "the table has dirty data and cannot be closed yet");
+    }
+
+    return (0);
+}
+
+/*
  * __wt_conn_dhandle_close --
  *     Sync and close the underlying btree handle.
  */
@@ -400,6 +458,9 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
             if (!__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
                 WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
                   "the table has uncommitted data and cannot be closed yet");
+
+            /* A drop must not discard layered constituent data that no checkpoint covers. */
+            WT_RET(__conn_dhandle_check_drop_durable(session));
         }
 
         /* Turn off eviction. */

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -255,6 +255,9 @@ __drop_layered(
      * Refuse a follower's drop while its ingest constituent holds writes no picked-up checkpoint
      * covers. A leader reaches the equivalent guard through the stable constituent, which is
      * durable and refuses to close while it holds uncheckpointed data.
+     *
+     * FIXME-WT-18500: Make this check atomic with closing the ingest tree. Otherwise, a concurrent
+     * write can commit after the check and be discarded without being covered by a checkpoint.
      */
     if (!leader)
         WT_ERR(__drop_layered_check_ingest_durable(session, ingest_uri));

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -199,12 +199,17 @@ __drop_layered_check_ingest_durable(WT_SESSION_IMPL *session, const char *ingest
     /*
      * An ingest tree is in-memory, so closing it discards its content instead of taking the
      * dirty-data path that refuses to close a durable tree. A follower has no other copy of writes
-     * the leader has not yet checkpointed, so bound the drop by the same rule sweep uses before it
-     * closes an ingest tree: the maximum write timestamp is a possibly conservative upper bound on
-     * the durable timestamps the tree holds, and the checkpoint must cover it.
+     * the leader has not yet checkpointed, so bound the drop by the maximum write timestamp, a
+     * possibly conservative upper bound on the durable timestamps the tree holds, which the
+     * checkpoint must cover.
+     *
+     * The bound is the adopted disaggregated checkpoint, not the last local one: a local checkpoint
+     * persists nothing of an in-memory tree, so its timestamp says nothing about whether these
+     * writes survive the close.
      */
     max_write_ts = __wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts);
-    ckpt_ts = __wt_atomic_load_uint64_acquire(&S2C(session)->txn_global.last_ckpt_timestamp);
+    ckpt_ts = __wt_atomic_load_uint64_acquire(
+      &S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
     if (max_write_ts != WT_TS_NONE && max_write_ts > ckpt_ts)
         WT_ERR_SUB(session, EBUSY, WT_DIRTY_DATA,
           "the table has ingested data that no checkpoint covers and must not be dropped yet");

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -234,7 +234,6 @@ __drop_layered(
     const char *ingest_uri, *stable_uri, *tablename;
     bool leader;
 
-    leader = __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader);
     stable_value = NULL;
 
     WT_UNUSED(force);
@@ -250,6 +249,7 @@ __drop_layered(
     ingest_uri = ingest_uri_buf->data;
     WT_ERR(__wt_buf_fmt(session, stable_uri_buf, "file:%s.wt_stable", tablename));
     stable_uri = stable_uri_buf->data;
+    leader = __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader);
 
     /*
      * Refuse a follower's drop while its ingest constituent holds writes no picked-up checkpoint

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -176,6 +176,44 @@ err:
     WT_TRET(__wt_session_release_dhandle(session));
     return (ret);
 }
+
+/*
+ * __drop_layered_check_ingest_durable --
+ *     Refuse to drop a follower's layered table while its ingest constituent holds writes the
+ *     node's last picked-up checkpoint does not cover.
+ */
+static int
+__drop_layered_check_ingest_durable(WT_SESSION_IMPL *session, const char *ingest_uri)
+{
+    WT_BTREE *btree;
+    WT_DECL_RET;
+    wt_timestamp_t ckpt_ts, max_write_ts;
+
+    ret = __wt_session_get_dhandle(session, ingest_uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE);
+    if (ret == EBUSY)
+        WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
+    WT_RET(ret);
+
+    btree = S2BT(session);
+
+    /*
+     * An ingest tree is in-memory, so closing it discards its content instead of taking the
+     * dirty-data path that refuses to close a durable tree. A follower has no other copy of writes
+     * the leader has not yet checkpointed, so bound the drop by the same rule sweep uses before it
+     * closes an ingest tree: the maximum write timestamp is a possibly conservative upper bound on
+     * the durable timestamps the tree holds, and the checkpoint must cover it.
+     */
+    max_write_ts = __wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts);
+    ckpt_ts = __wt_atomic_load_uint64_acquire(&S2C(session)->txn_global.last_ckpt_timestamp);
+    if (max_write_ts != WT_TS_NONE && max_write_ts > ckpt_ts)
+        WT_ERR_SUB(session, EBUSY, WT_DIRTY_DATA,
+          "the table has ingested data that no checkpoint covers and must not be dropped yet");
+
+err:
+    WT_TRET(__wt_session_release_dhandle(session));
+    return (ret);
+}
+
 /*
  * __drop_layered --
  *     WT_SESSION::drop for a layered table.
@@ -189,7 +227,9 @@ __drop_layered(
     WT_DECL_RET;
     char *stable_value;
     const char *ingest_uri, *stable_uri, *tablename;
+    bool leader;
 
+    leader = __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader);
     stable_value = NULL;
 
     WT_UNUSED(force);
@@ -207,11 +247,19 @@ __drop_layered(
     stable_uri = stable_uri_buf->data;
 
     /*
+     * Refuse a follower's drop while its ingest constituent holds writes no picked-up checkpoint
+     * covers. A leader reaches the equivalent guard through the stable constituent, which is
+     * durable and refuses to close while it holds uncheckpointed data.
+     */
+    if (!leader)
+        WT_ERR(__drop_layered_check_ingest_durable(session, ingest_uri));
+
+    /*
      * Only the leader can issue a trim command, and only for a constituent that exists: a table
      * created after the step-down timestamp was set has no stable pages to trim. The schema lock
      * held here serializes the timestamp, making the relaxed loads safe.
      */
-    if (__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader)) {
+    if (leader) {
         WT_ERR_ERROR_OK(__drop_issue_trim(session, stable_uri), ENOENT, true);
         if (WT_CHECK_AND_RESET(ret, ENOENT) &&
           __wt_atomic_load_uint64_relaxed(&S2C(session)->txn_global.step_down_timestamp) ==
@@ -239,8 +287,7 @@ __drop_layered(
      * leader outside that window always has the constituent, so treat ENOENT as an error there.
      */
     WT_ERR_ERROR_OK(__wt_schema_drop(session, stable_uri, cfg, check_visibility), ENOENT, true);
-    if (WT_CHECK_AND_RESET(ret, ENOENT) &&
-      __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader) &&
+    if (WT_CHECK_AND_RESET(ret, ENOENT) && leader &&
       __wt_atomic_load_uint64_relaxed(&S2C(session)->txn_global.step_down_timestamp) == WT_TS_NONE)
         WT_ERR_MSG(session, ENOENT,
           "stable constituent \"%s\" not found when dropping \"%s\" on leader", stable_uri, uri);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -178,53 +178,6 @@ err:
 }
 
 /*
- * __drop_layered_check_ingest_durable --
- *     Refuse to drop a follower's layered table while its ingest constituent holds writes the
- *     node's last picked-up checkpoint does not cover.
- */
-static int
-__drop_layered_check_ingest_durable(WT_SESSION_IMPL *session, const char *ingest_uri)
-{
-    WT_BTREE *btree;
-    WT_DECL_RET;
-    wt_timestamp_t ckpt_ts, max_write_ts;
-
-    ret = __wt_session_get_dhandle(session, ingest_uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE);
-    if (ret == EBUSY)
-        WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
-    WT_RET(ret);
-
-    btree = S2BT(session);
-
-    /*
-     * An ingest tree is in-memory, so closing it discards its content instead of taking the
-     * dirty-data path that refuses to close a durable tree. A follower has no other copy of writes
-     * the leader has not yet checkpointed, so bound the drop by the maximum write timestamp, a
-     * possibly conservative upper bound on the durable timestamps the tree holds, which the
-     * checkpoint must cover.
-     *
-     * The bound is the adopted disaggregated checkpoint, not the last local one: a local checkpoint
-     * persists nothing of an in-memory tree, so its timestamp says nothing about whether these
-     * writes survive the close.
-     *
-     * This guard exists because schema-epoch ordering can defer the drop past a later checkpoint:
-     * if this follower steps up, it can owe that checkpoint the table's pre-drop writes, which
-     * closing the ingest tree has already discarded. The alternative would be to allow the drop and
-     * verify on step-up that all drops are published and the stable schema epoch covers them.
-     */
-    max_write_ts = __wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts);
-    ckpt_ts = __wt_atomic_load_uint64_acquire(
-      &S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
-    if (max_write_ts != WT_TS_NONE && max_write_ts > ckpt_ts)
-        WT_ERR_SUB(session, EBUSY, WT_DIRTY_DATA,
-          "the table has ingested data that no checkpoint covers and must not be dropped yet");
-
-err:
-    WT_TRET(__wt_session_release_dhandle(session));
-    return (ret);
-}
-
-/*
  * __drop_layered --
  *     WT_SESSION::drop for a layered table.
  */
@@ -255,17 +208,6 @@ __drop_layered(
     WT_ERR(__wt_buf_fmt(session, stable_uri_buf, "file:%s.wt_stable", tablename));
     stable_uri = stable_uri_buf->data;
     leader = __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader);
-
-    /*
-     * Refuse a follower's drop while its ingest constituent holds writes no picked-up checkpoint
-     * covers. A leader reaches the equivalent guard through the stable constituent, which is
-     * durable and refuses to close while it holds uncheckpointed data.
-     *
-     * FIXME-WT-18500: Make this check atomic with closing the ingest tree. Otherwise, a concurrent
-     * write can commit after the check and be discarded without being covered by a checkpoint.
-     */
-    if (!leader)
-        WT_ERR(__drop_layered_check_ingest_durable(session, ingest_uri));
 
     /*
      * Only the leader can issue a trim command, and only for a constituent that exists: a table

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -206,6 +206,11 @@ __drop_layered_check_ingest_durable(WT_SESSION_IMPL *session, const char *ingest
      * The bound is the adopted disaggregated checkpoint, not the last local one: a local checkpoint
      * persists nothing of an in-memory tree, so its timestamp says nothing about whether these
      * writes survive the close.
+     *
+     * This guard exists because schema-epoch ordering can defer the drop past a later checkpoint:
+     * if this follower steps up, it can owe that checkpoint the table's pre-drop writes, which
+     * closing the ingest tree has already discarded. The alternative would be to allow the drop and
+     * verify on step-up that all drops are published and the stable schema epoch covers them.
      */
     max_write_ts = __wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts);
     ckpt_ts = __wt_atomic_load_uint64_acquire(

--- a/test/suite/test_layered_async_stepdown04.py
+++ b/test/suite/test_layered_async_stepdown04.py
@@ -26,6 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import errno
 import wiredtiger, wttest
 from wiredtiger import stat
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -102,6 +103,38 @@ class test_layered_async_stepdown04(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.complete_step_down(20)
         self.assertRaisesException(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor(self.uri, None, None))
+
+    # A drop during a planned step-down is refused while the ingest constituent holds committed
+    # writes no checkpoint covers, even though the connection is still the leader: writes that
+    # began after the step-down timestamp route to ingest, and dropping the table would discard
+    # their only copy.
+    def test_drop_refused_for_stepdown_ingest_data(self):
+        self.set_global_ts(1, 1)
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.write_at(self.uri, {'k1': 'stable'}, 10)
+
+        # Checkpoint covering the stable write, so that only the post-cutoff ingest write is
+        # unaccounted for.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        ckpt_session = self.conn.open_session()
+        ckpt_session.checkpoint()
+        ckpt_session.close()
+
+        self.set_step_down_ts(20)
+        self.write_at(self.uri, {'k2': 'ingest'}, 30)
+        self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), {'k2'})
+
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(self.uri))
+        err, sub, msg = self.session.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
+        self.assertTrue('no checkpoint covers' in msg)
+
+        # The refused drop left no partial state.
+        self.assertEqual(self.read_keys_at(self.uri, 40), {'k1', 'k2'})
+        self.complete_step_down(20)
+        self.assertEqual(self.read_keys_at(self.uri, 40), {'k1', 'k2'})
 
     # A cursor reused from the cache picks up the new routing: its writes go to ingest.
     def test_cached_cursor_reuse_across_step_down_ts(self):

--- a/test/suite/test_layered_async_stepdown08.py
+++ b/test/suite/test_layered_async_stepdown08.py
@@ -370,11 +370,14 @@ class test_layered_async_stepdown08(
     def test_window_create_then_drop(self):
         """
         A table created and dropped entirely inside the window never existed for any checkpoint, so
-        the queued create and remove cancel out instead of tripping the violation check.
+        the queued create and remove cancel out instead of tripping the violation check. The table
+        must be empty: rows committed inside the window live only in the ingest constituent, which
+        no checkpoint covers, so a table holding them cannot be dropped.
         """
         self.enter_window()
 
-        uri, _ = self.create_with_rows('window_drop', 6)
+        uri = self.uri('window_drop')
+        self.session.create(uri, self.table_config)
         self.publish_if_epochs(uri, 20)
         self.dropUntilSuccess(self.session, uri)
         self.publish_if_epochs(uri, 20)

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -62,17 +62,21 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
 
-    def write_rows(self, commit_ts=None):
-        """Write nrows to the table, then commit at commit_ts or roll back if it is None."""
-        self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
-        for i in range(1, self.nrows + 1):
+    def write_rows(self, commit_ts=None, session=None, keys=None):
+        """Write rows to the table, then commit at commit_ts or roll back if it is None."""
+        if session is None:
+            session = self.session
+        if keys is None:
+            keys = range(1, self.nrows + 1)
+        session.begin_transaction()
+        cursor = session.open_cursor(self.uri)
+        for i in keys:
             cursor[i] = 'value'
         cursor.close()
         if commit_ts is None:
-            self.session.rollback_transaction()
+            session.rollback_transaction()
         else:
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
     def assert_all_rows(self, session):
         """Assert that every written row is readable through the given session."""
@@ -115,6 +119,49 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         """Drop the table and confirm it is gone from local metadata."""
         self.session.drop(self.uri)
         self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+    def count_rows(self, session):
+        """Return the number of rows readable through the given session."""
+        cursor = session.open_cursor(self.uri)
+        count = 0
+        while cursor.next() == 0:
+            count += 1
+        cursor.close()
+        return count
+
+    def publish_checkpoint_and_open_follower(self):
+        """Publish and checkpoint the table on the leader, then open a follower holding it."""
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+        self.set_stable_epoch(10)
+        self.leader_checkpoint(1)
+        return self.open_follower()
+
+    def leader_write_and_checkpoint(self, commit_ts, keys=None):
+        """Write the same rows on the leader and checkpoint them, covering the follower's copy."""
+        self.write_rows(commit_ts=commit_ts, keys=keys)
+        self.leader_checkpoint(commit_ts)
+
+    def set_follower_stable(self, conn, stable_ts):
+        """Advance a follower's stable timestamp without delivering a checkpoint to it."""
+        conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable_ts))
+
+    def assert_follower_drop_refused(self, session, config=None):
+        """Assert that dropping on a follower is refused because no checkpoint covers its data."""
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: session.drop(self.uri, config))
+        err, sub, msg = session.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
+        self.assertTrue('no checkpoint covers' in msg)
+
+    def assert_follower_drop_succeeds(self, conn, session):
+        """Drop the table on a follower and confirm its ingest constituent is gone."""
+        session.drop(self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn, self.uri))
 
     #
     # Drop lifecycle tests
@@ -314,3 +361,163 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         session_follower.close()
         conn_follower.close()
         self.assert_drop_succeeds()
+
+    #
+    # Follower drop tests
+    #
+    # A follower's writes land in its ingest constituent, which is in-memory and never checkpointed
+    # locally. Closing it discards its content rather than taking the dirty-data path a durable tree
+    # takes, so the drop is bounded by the checkpoint the follower has picked up.
+    #
+
+    def test_drop_on_follower_with_uncheckpointed_data_is_refused(self):
+        # Rows written on a follower exist only in its ingest constituent until a leader checkpoint
+        # accounts for them, so dropping the table would discard the only copy.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.assert_follower_drop_refused(session_follower)
+
+        # The refused drop left no partial state: the rows are readable and the table still exists.
+        self.assert_all_rows(session_follower)
+        self.assertTrue(self.uri_in_local_metadata(conn_follower, self.uri))
+
+        # Once the leader has checkpointed the same rows and the follower picks that checkpoint up,
+        # the ingest content is accounted for and the drop is a normal drop.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_before_pickup_is_refused(self):
+        # The bound is the checkpoint the follower has picked up, not the newest one the leader has
+        # taken: a covering checkpoint the follower has not adopted must not unblock the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.leader_write_and_checkpoint(3)
+        self.assert_follower_drop_refused(session_follower)
+
+        # Picking the checkpoint up is what makes the difference.
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_with_partially_covered_data_is_refused(self):
+        # A checkpoint that covers only some of the follower's writes still leaves the rest as the
+        # only copy, so partial coverage must not unblock the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        early_keys = range(1, self.nrows // 2 + 1)
+        late_keys = range(self.nrows // 2 + 1, self.nrows + 1)
+        self.write_rows(commit_ts=3, session=session_follower, keys=early_keys)
+        self.write_rows(commit_ts=7, session=session_follower, keys=late_keys)
+
+        # The picked-up checkpoint covers the timestamp-3 rows but not the timestamp-7 rows.
+        self.leader_write_and_checkpoint(3, keys=early_keys)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_refused(session_follower)
+        self.assertEqual(self.count_rows(session_follower), self.nrows)
+
+        # A checkpoint that covers the timestamp-7 rows as well releases the drop.
+        self.leader_write_and_checkpoint(7, keys=late_keys)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_empty_on_follower_is_allowed(self):
+        # A follower that has never written holds nothing the checkpoint could fail to account for.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_rolled_back_on_follower_is_allowed(self):
+        # Rolled-back writes never reach a durable timestamp, so they leave nothing to protect.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=None, session=session_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_force_on_follower_with_uncheckpointed_data_is_refused(self):
+        # Forcing a drop only turns a missing table into a success. It does not permit discarding
+        # the only copy of committed data, so it does not weaken the guard.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.assert_follower_drop_refused(session_follower, 'force=true')
+        self.assert_all_rows(session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_of_leader_only_data_is_allowed(self):
+        # Rows the follower only reads live in the checkpoint it picked up, not in its ingest
+        # constituent, so they never block the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_all_rows(session_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    #
+    # Follower drop tests where only the stable timestamp advances
+    #
+    # A follower's stable timestamp moves with the replication stream, independently of checkpoint
+    # pickup. Only a picked-up checkpoint accounts for the ingest constituent's content, so the
+    # stable timestamp must not shift the bound in either direction.
+    #
+
+    def test_drop_on_follower_after_stable_timestamp_only_is_refused(self):
+        # A stable timestamp past the follower's writes says the leader will not roll them back. It
+        # does not say any checkpoint holds them, so it must not unblock the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.set_follower_stable(conn_follower, 100)
+        self.assert_follower_drop_refused(session_follower)
+
+        # The refused drop left no partial state.
+        self.assert_all_rows(session_follower)
+        self.assertTrue(self.uri_in_local_metadata(conn_follower, self.uri))
+
+        # Picking up a covering checkpoint is still what releases the drop, even though the stable
+        # timestamp is already well past the writes.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_after_stable_timestamp_past_leader_checkpoint_is_refused(self):
+        # The leader has taken a covering checkpoint and the follower's stable timestamp has caught
+        # up with it, but the checkpoint itself has not been delivered. The two together must not
+        # substitute for the pickup.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.leader_write_and_checkpoint(3)
+        self.set_follower_stable(conn_follower, 3)
+        self.assert_follower_drop_refused(session_follower)
+
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_after_stable_timestamp_with_no_data_is_allowed(self):
+        # The reverse direction: advancing the stable timestamp on a follower that holds nothing
+        # must not invent a reason to refuse the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.set_follower_stable(conn_follower, 100)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_after_stable_timestamp_with_leader_only_data_is_allowed(self):
+        # Rows that arrived through a picked-up checkpoint stay accounted for when the stable
+        # timestamp then advances past them.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.set_follower_stable(conn_follower, 100)
+        self.assert_all_rows(session_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -459,6 +459,64 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assert_follower_drop_succeeds(conn_follower, session_follower)
         self.close_follower(conn_follower, session_follower)
 
+    def test_drop_ingest_constituent_directly_is_refused(self):
+        # Dropping the ingest constituent URI directly must hit the same guard as dropping the
+        # layered table: the protection lives in the final close path, not only in the layered
+        # drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        ingest_uri = 'file:' + self.test_name + '.wt_ingest'
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: session_follower.drop(ingest_uri))
+        err, sub, msg = session_follower.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
+        self.assertTrue('no checkpoint covers' in msg)
+
+        # The refused drop left no partial state.
+        self.assert_all_rows(session_follower)
+        self.assertTrue(self.uri_in_local_metadata(conn_follower, self.uri))
+
+        # A covering picked-up checkpoint releases the drop of the whole table as usual.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_waits_for_commit_then_requires_coverage(self):
+        # A transaction that closed its cursor but is still committing blocks the drop with
+        # WT_UNCOMMITTED_DATA; once it commits, the drop is refused with WT_DIRTY_DATA until a
+        # checkpoint covers the write.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        session_a = conn_follower.open_session('')
+        session_a.begin_transaction()
+        cursor = session_a.open_cursor(self.uri)
+        for i in range(1, self.nrows + 1):
+            cursor[i] = 'value'
+        cursor.close()
+
+        # The uncommitted transaction blocks the drop even though its cursor is closed.
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: session_follower.drop(self.uri))
+        err, sub, msg = session_follower.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_UNCOMMITTED_DATA)
+        self.assertTrue('uncommitted data' in msg)
+
+        # Once committed, the drop is refused because no picked-up checkpoint covers the write.
+        session_a.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+        session_a.close()
+        self.assert_follower_drop_refused(session_follower)
+        self.assert_all_rows(session_follower)
+
+        # A covering picked-up checkpoint releases the drop.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint(conn_follower)
+        self.disagg_wait_for_adoption(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
     #
     # Follower drop tests where only the stable timestamp advances
     #


### PR DESCRIPTION
WiredTiger depends on WT_SESSION::drop returning EBUSY when a table holds uncheckpointed data, so that drop and checkpoint schema epochs do not have to be carefully ordered to avoid asking WiredTiger to checkpoint previously uncheckpointed data for a table that no longer exists. WiredTiger already ensures that we return EBUSY on a leader; this PR adds a similar guardrail on the follower.