### PR TITLE
WT-18374 Wait for checkpoint adoption in test_layered_checkpoint02

### DIFF
--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -254,6 +254,13 @@ class DisaggConfigMixin:
         finally:
             session.close()
 
+    # Deliver the newest checkpoint to the follower and wait until it is adopted. Use this wherever
+    # the test reads data the new checkpoint carries; the reader's own snapshot does not force the
+    # adoption. Any snapshot that predates the delivery blocks it, so end them first.
+    def disagg_advance_checkpoint_and_wait(self, conn_follower, conn_leader=None, timeout=60):
+        self.disagg_advance_checkpoint(conn_follower, conn_leader)
+        self.disagg_wait_for_adoption(conn_follower, timeout)
+
     # Switch the leader and the follower
     def disagg_switch_follower_and_leader(self, conn_follower, conn_leader=None):
         if conn_leader is None:

--- a/test/suite/test_layered_checkpoint02.py
+++ b/test/suite/test_layered_checkpoint02.py
@@ -146,8 +146,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Check data in the follower
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
         cursors = self.check_data_follower(value_prefix0)
         self.close_cursors(cursors)
 
@@ -162,8 +161,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Check data in the follower
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
         follower_cursors = self.check_data_follower(value_prefix1)
         # keep the follower cursors
 
@@ -179,8 +177,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
 
         # Check data in the follower
         self.close_cursors(follower_cursors)
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
         follower_cursors = self.check_data_follower(value_prefix2)
         # keep the follower cursors
 
@@ -197,8 +194,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         # Check data in the follower after a reset. Reset first: the positioned cursors' snapshots
         # would defer the adoption.
         self.reset_cursors(follower_cursors)
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
         follower_cursors = self.check_data_follower(value_prefix3, cursors=follower_cursors)
 
         #
@@ -234,8 +230,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         # With the snapshots gone, the delivery is no longer blocked, but it may still be picked up
         # by the pickup server rather than inline, so wait for the adoption before reading.
         self.session.checkpoint()
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
         follower_cursors = self.scan_data_follower(value_prefix4, uris=self.layered_uris)
 
         #
@@ -253,8 +248,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         # their snapshots would defer the adoption we are about to wait for.
         self.reset_cursors(follower_cursors)
 
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
 
         # At this point, we have two connections, our old leader and the follower that is
         # becoming the new leader. Close the old leader first so there's no confusion within this test.

--- a/test/suite/test_layered_checkpoint02.py
+++ b/test/suite/test_layered_checkpoint02.py
@@ -147,6 +147,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
 
         # Check data in the follower
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         cursors = self.check_data_follower(value_prefix0)
         self.close_cursors(cursors)
 
@@ -162,6 +163,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
 
         # Check data in the follower
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         follower_cursors = self.check_data_follower(value_prefix1)
         # keep the follower cursors
 
@@ -178,6 +180,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         # Check data in the follower
         self.close_cursors(follower_cursors)
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         follower_cursors = self.check_data_follower(value_prefix2)
         # keep the follower cursors
 
@@ -195,6 +198,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         # would defer the adoption.
         self.reset_cursors(follower_cursors)
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         follower_cursors = self.check_data_follower(value_prefix3, cursors=follower_cursors)
 
         #
@@ -214,6 +218,7 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         self.put_data(value_prefix4)
 
         self.session.checkpoint()
+        # No wait for adoption here: the positioned cursors' snapshots defer it, which is the point.
         self.disagg_advance_checkpoint(conn_follow)
 
         # Check the continuation of each scan in the follower. Pure cursor scans should be insulated from state changes.
@@ -226,9 +231,11 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         # Now check that after closing, we get the new value; closing the cursors ends the
         # snapshots deferring the adoption.
         self.close_cursors(follower_cursors)
-        # With the snapshots gone, a freshly delivered checkpoint is adopted synchronously.
+        # With the snapshots gone, the delivery is no longer blocked, but it may still be picked up
+        # by the pickup server rather than inline, so wait for the adoption before reading.
         self.session.checkpoint()
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         follower_cursors = self.scan_data_follower(value_prefix4, uris=self.layered_uris)
 
         #
@@ -241,10 +248,13 @@ class test_layered_checkpoint02(wttest.WiredTigerTestCase):
         self.put_data(value_prefix5)
 
         self.session.checkpoint()
-        self.disagg_advance_checkpoint(conn_follow)
 
-        # Reset cursors before stepping up -- positioned cursors across a role change are illegal.
+        # Reset cursors before delivering: positioned cursors across a role change are illegal, and
+        # their snapshots would defer the adoption we are about to wait for.
         self.reset_cursors(follower_cursors)
+
+        self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         # At this point, we have two connections, our old leader and the follower that is
         # becoming the new leader. Close the old leader first so there's no confusion within this test.

--- a/test/suite/test_layered_follower10.py
+++ b/test/suite/test_layered_follower10.py
@@ -142,8 +142,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         # Now eviction should remove all the items from the ingest table, but it can't
         # until we pick up another checkpoint.
         self.session.checkpoint()
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
 
         self.evict_ingest(session_follow, ts)
         count = self.count_ingest(session_follow)
@@ -240,8 +239,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
 
         # Trigger advance checkpoint code again to set the prune timestamp to the last
         # checkpoint timestamp. We couldn't do that because there was a cursor holding the old content.
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
 
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
@@ -296,8 +294,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Pickup the last checkpoint and perform the final garbage collection
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
 
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
@@ -328,8 +325,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         oplog.check(self, session_follow, 0, self.nitems)
 
         # Take a checkpoint and advance it, make sure everything is garbage collected
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
         oplog.check(self, session_follow, 0, self.nitems)
 
         # Now eviction should remove all the items from the ingest table.

--- a/test/suite/test_layered_follower21.py
+++ b/test/suite/test_layered_follower21.py
@@ -783,8 +783,7 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         # snapshot the node happens to hold, including the ones the adoption itself takes, defers
         # the delivery to the server, so wait for it before reading.
         self.session.checkpoint()
-        self.disagg_advance_checkpoint(conn_follow)
-        self.disagg_wait_for_adoption(conn_follow)
+        self.disagg_advance_checkpoint_and_wait(conn_follow)
 
         session = conn_follow.open_session('')
         session.begin_transaction()


### PR DESCRIPTION
`test_layered_checkpoint02` assumed that a checkpoint delivered to a disaggregated follower is adopted inline. Since WT-18156 that no longer holds: the delivery is deferred to the pickup server whenever any session pins the checkpoint generation, including the internal metadata transactions the adoption itself runs. Reading straight after the delivering reconfigure can therefore bind the reader's snapshot to the previously adopted checkpoint and see the old values, which is the `'ccc0' != 'ddd0'` failure on the ticket.

This waits with the existing `disagg_wait_for_adoption()` helper before each read that depends on an adoption, and moves the cursor reset in part 5 ahead of the delivery so the wait cannot block on those cursors' snapshots. The part 4 delivery that the positioned cursors are supposed to defer is deliberately left without a wait -- that deferral is what the following scan tests.