### PR TITLE
WT-18411 Assert the key rotation crash points fire in test_key_provider_disagg02

### DIFF
--- a/test/suite/test_key_provider_disagg02.py
+++ b/test/suite/test_key_provider_disagg02.py
@@ -25,6 +25,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+import os, signal
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from helper_key_provider import KeyProviderBase
 from suite_subprocess import suite_subprocess
@@ -74,12 +75,26 @@ class test_key_provider_disagg02(KeyProviderBase, suite_subprocess):
         self.rotate_key(2)
         self.session.checkpoint(f"debug=(checkpoint_crash_trigger_point={self.crash_point})") # Expected to fail
 
+    def assert_crashed(self, returncode):
+        # WiredTiger kills the process outright on POSIX and aborts on Windows, so the exit status
+        # is platform specific. Where the two are distinguishable, insist on the kill: an abort
+        # means we stopped somewhere we did not ask to.
+        if os.name == 'nt':
+            self.assertNotEqual(returncode, 0)
+        else:
+            self.assertEqual(returncode, -signal.SIGKILL)
+
     def test_key_provider_disagg02(self):
         self.conn.close()
 
+        # Restrict the subprocess to this scenario, otherwise it crashes in the first one and no
+        # other crash point is ever reached.
         subdir = 'SUBPROCESS'
-        [ignore_result, new_home_dir] = self.run_subprocess_function(subdir,
-            f'{self.test_name}.{self.test_name}.subprocess_func', silent=True)
+        [returncode, new_home_dir] = self.run_subprocess_function(subdir,
+            f'{self.test_name}.{self.test_name}.subprocess_func', silent=True,
+            scenario=self.scenario_number)
+
+        self.assert_crashed(returncode)
 
         # The subprocess wrote to new_home_dir; its turtle reference survived the crash intact.
         self.validate_turtle_page(home=new_home_dir)


### PR DESCRIPTION
## Summary
- The test discarded the subprocess exit status, so a crash point that never fired still left it passing. Assert the subprocess was killed, reusing the portable `assert_crashed` helper from `test_checkpoint_crash01`: `-SIGKILL` on POSIX, merely non-zero on Windows, since `__wt_debug_crash` kills on POSIX and aborts on Windows.
- Pass `scenario=self.scenario_number` to `run_subprocess_function`. Without it the child ran the whole scenario list and died in the first one, so all six parent scenarios exercised `pull/before_key_rotation` and the other two crash points were never reached.

## Testing
`test_key_provider_disagg02.py`, 6/6 passing. Verified by mutation, replacing the trigger comparisons in `src/conn/conn_layered_page_log.c` with one that never matches:

| Source state | Result |
|---|---|
| unmodified | 6/6 pass |
| all three crash points neutralised | 6/6 fail |
| only `after_key_rotation` neutralised | exactly the 2 `crash_after_key_rotation` scenarios fail |
| only `after_key_rotation` neutralised, `scenario=` removed | 6/6 pass |

Note that with a crash point neutralised the child exits `-6` rather than `0`, because the checkpoint teardown assertion catches the unconsumed trigger point. The Windows arm therefore only discriminates in a release build, where `WT_ASSERT` compiles out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)