### PR TITLE
WT-18408 Refuse to advance a follower's stable cursor to a checkpoint that cannot serve the transaction's read timestamp

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -820,6 +820,24 @@ retry:
 
     WT_ERR(ret);
 
+    /*
+     * An adopted checkpoint discards all history below its oldest timestamp, so it cannot serve a
+     * read timestamp below it: reads silently lose keys whose newest visible version was removed as
+     * obsolete. Nothing prevents an adoption from passing an active reader's timestamp (new readers
+     * are bounded by the oldest timestamp, which the application advances to the adopted
+     * checkpoint's before the pickup), and a stale read is only possible through a bind, so refuse
+     * the bind here. Detection is the agreed response: such readers are expected to be rare, kept
+     * so by the application's history window.
+     */
+    WT_ASSERT_ALWAYS(session,
+      WT_SESSION_TXN_SHARED(session) == NULL ||
+        WT_SESSION_TXN_SHARED(session)->read_timestamp == WT_TS_NONE ||
+        WT_SESSION_TXN_SHARED(session)->read_timestamp >=
+          __wt_atomic_load_uint64_acquire(
+            &S2C(session)->disaggregated_storage.last_checkpoint_oldest_timestamp),
+      "binding the stable cursor to a checkpoint that cannot serve the transaction's read "
+      "timestamp");
+
 err:
     __wt_scr_free(session, &last_ckpt_uri);
     __wt_free(session, checkpoint_name);
@@ -916,23 +934,10 @@ __clayered_can_advance_stable(
         return (false);
 
     /*
-     * Don't advance while parked on the stable cursor, even under a read timestamp. A newer
-     * checkpoint may no longer hold the parked key once the leader's oldest timestamp has moved
-     * past the key's removal; reopening onto it loses the position and can skip stable keys, and
-     * the history store can't recover the value because the read is now older than that
-     * checkpoint's oldest timestamp. Check this before the read-timestamp fast path below.
-     *
-     * FIXME-WT-17968: This check is only needed here because a follower can adopt a checkpoint
-     * whose oldest timestamp exceeds a pinned reader's read timestamp. Once that is prevented, move
-     * the check back inside the no-read-timestamp branch below.
-     */
-    if (F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT) &&
-      clayered->current_cursor == clayered->stable_cursor)
-        return (false);
-
-    /*
-     * With a read timestamp set and the parked-on-stable case excluded above, it's safe to advance
-     * even during iteration: a timestamped read stays consistent across the checkpoint change.
+     * With a read timestamp set it's safe to advance even during iteration, including while parked
+     * on the stable cursor: an adopted checkpoint's oldest timestamp never passes an active read
+     * timestamp (the stable open refuses such a bind), so a version of any key visible to the read
+     * survives in the newer checkpoint or its history store and a parked position transfers.
      */
     txn_shared = WT_SESSION_TXN_SHARED(session);
     if (txn_shared != NULL && txn_shared->read_timestamp != WT_TS_NONE)
@@ -940,6 +945,14 @@ __clayered_can_advance_stable(
     else {
         /* if this is an iteration, we won't reopen the cursor, we're done. */
         if (iteration)
+            return (false);
+
+        /*
+         * Don't advance while parked on the stable cursor: without a read timestamp, a newer
+         * snapshot may not see the parked key in the newer checkpoint, losing the position.
+         */
+        if (F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT) &&
+          clayered->current_cursor == clayered->stable_cursor)
             return (false);
 
         /*

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -824,6 +824,13 @@ retry:
      * An adopted checkpoint discards all history below its oldest timestamp, so it cannot serve a
      * read timestamp below it: reads silently lose keys whose newest visible version was removed as
      * obsolete.
+     *
+     * The value read here is never older than the bound checkpoint's oldest timestamp: the pickup
+     * publishes it while holding the checkpoint lock, the first open of the checkpoint's stable
+     * dhandle takes that lock (see FIXME-WT-16477 in the dhandle open path), and every later use
+     * acquires the dhandle lock the opener released. A newer pickup completing mid-bind can only
+     * make the comparison stricter, against an oldest timestamp the reader must satisfy on its next
+     * advance anyway.
      */
     if (F_ISSET(session->txn, WT_TXN_SHARED_TS_READ)) {
         WT_ASSERT_ALWAYS(session,

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -823,20 +823,15 @@ retry:
     /*
      * An adopted checkpoint discards all history below its oldest timestamp, so it cannot serve a
      * read timestamp below it: reads silently lose keys whose newest visible version was removed as
-     * obsolete. Nothing prevents an adoption from passing an active reader's timestamp (new readers
-     * are bounded by the oldest timestamp, which the application advances to the adopted
-     * checkpoint's before the pickup), and a stale read is only possible through a bind, so refuse
-     * the bind here. Detection is the agreed response: such readers are expected to be rare, kept
-     * so by the application's history window.
+     * obsolete.
      */
-    WT_ASSERT_ALWAYS(session,
-      WT_SESSION_TXN_SHARED(session) == NULL ||
-        WT_SESSION_TXN_SHARED(session)->read_timestamp == WT_TS_NONE ||
-        WT_SESSION_TXN_SHARED(session)->read_timestamp >=
-          __wt_atomic_load_uint64_acquire(
-            &S2C(session)->disaggregated_storage.last_checkpoint_oldest_timestamp),
-      "binding the stable cursor to a checkpoint that cannot serve the transaction's read "
-      "timestamp");
+    if (F_ISSET(session->txn, WT_TXN_SHARED_TS_READ)) {
+        WT_ASSERT_ALWAYS(session,
+          WT_SESSION_TXN_SHARED(session)->read_timestamp >=
+            __wt_atomic_load_uint64_acquire(
+              &S2C(session)->disaggregated_storage.last_checkpoint_oldest_timestamp),
+          "advancing stable to a checkpoint that cannot serve the transaction's read timestamp");
+    }
 
 err:
     __wt_scr_free(session, &last_ckpt_uri);

--- a/test/suite/test_layered_cursor25.py
+++ b/test/suite/test_layered_cursor25.py
@@ -26,13 +26,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# A follower cursor may be positioned on a key that only exists in an older
-# checkpoint. When the follower moves to a newer checkpoint that no longer
-# contains that key, continuing to iterate under a read timestamp must proceed
-# safely rather than lose the cursor position. This holds whether or not the
-# follower has already locally applied the delete: a reader at an older read
-# timestamp does not see a newer delete, so it stays positioned on the stable
-# value regardless.
+# A follower cursor may be positioned on a key that a newer checkpoint removes
+# at a timestamp above the reader's. Moving to that checkpoint mid-iteration
+# must transfer the position and continue without skipping or duplicating keys.
+# This holds whether or not the follower has already locally applied the
+# delete: a reader at an older read timestamp does not see a newer delete, so
+# it stays positioned on the stable value regardless.
 
 import wiredtiger
 import wttest
@@ -82,15 +81,17 @@ class test_layered_cursor25(wttest.WiredTigerTestCase):
         self.assertEqual(cursor_r.next(), 0)
         self.assertEqual(cursor_r.get_key(), 1)
 
-        # The leader removes the positioned key and ages it out beyond the reader's
-        # timestamp, so the next checkpoint no longer contains it.
+        # The leader removes the positioned key above the reader's timestamp. Oldest stays at
+        # the reader's timestamp: advancing it past an active reader would make the follower
+        # refuse the adoption bind (WT-18408), and the newer checkpoint keeps the history the
+        # reader needs.
         self.session.begin_transaction()
         c.set_key(1)
         self.assertEqual(c.remove(), 0)
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(30))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20))
         self.session.checkpoint()
 
         # Reflecting the mongo ordering, the follower locally applies the delete before

--- a/test/suite/test_layered_follower06.py
+++ b/test/suite/test_layered_follower06.py
@@ -69,24 +69,27 @@ class test_layered_follower06(wttest.WiredTigerTestCase):
         # Advance to the latest checkpoint
         self.disagg_advance_checkpoint(conn_follow)
 
+        # The read timestamp must not fall behind the oldest timestamp of any checkpoint adopted
+        # while the transaction is active.
         cursor_follow = session_follow.open_cursor(self.uri, None, None)
-        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(2)}')
+        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(3)}')
         self.assertEqual(cursor_follow["1"], "value1")
 
-        # Update the value with timestamp 4
+        # Update both values with timestamp 4: the old version of "1" is now history the
+        # spanning reader depends on.
         self.session.begin_transaction()
+        cursor["1"] = "value1b"
         cursor["2"] = "value3"
         self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(4)}')
 
-        # Make the first version obsolete
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(4)}, oldest_timestamp={self.timestamp_str(3)}')
         self.session.checkpoint()
 
         # Advance to the latest checkpoint
         self.disagg_advance_checkpoint(conn_follow)
 
-        # Verify we can read the correct value from the history store
+        # Verify we can read the correct value from the history store: the new checkpoint's
+        # newest version of "1" is value1b, so the read at timestamp 3 is served from history.
         cursor_follow.reset()
-        # Cursor should still see the old value at timestamp 2 as it has the history store dhandle pinned
         self.assertEqual(cursor_follow["1"], "value1")
         session_follow.rollback_transaction()

--- a/test/suite/test_layered_follower09.py
+++ b/test/suite/test_layered_follower09.py
@@ -30,7 +30,10 @@ import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
 from wtscenario import make_scenarios
 
-# Test pinning the content in the ingest table
+# A long-lived timestamped scan starts before the follower adopts its first checkpoint and is
+# served from the ingest table. It must survive the mid-scan bind of the adopted stable table,
+# ingest eviction underneath it, and full key overlap between the constituents (every key has a
+# visible insert and an invisible newer tombstone in both), returning every key exactly once.
 @disagg_test_class
 class test_layered_follower09(wttest.WiredTigerTestCase):
     test_name = __qualname__
@@ -92,8 +95,9 @@ class test_layered_follower09(wttest.WiredTigerTestCase):
         oplog.apply(self, self.session, self.nitems, self.nitems)
         oplog.check(self, self.session, self.nitems, self.nitems)
 
-        # Make all the data obsolete
-        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())},oldest_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        # Advance oldest only to the reader's timestamp: the removals stay non-obsolete, so the
+        # new checkpoint keeps the history the pinned reader needs.
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())},oldest_timestamp={self.timestamp_str(ts)}')
 
         self.session.checkpoint()
 


### PR DESCRIPTION
Nothing prevents a follower from adopting a checkpoint whose oldest timestamp exceeds the read timestamp of an active transaction. The server intentionally does not synchronize checkpoint installation with ongoing reads. When it happens, the reader's data is unrecoverable by construction: the leader's reconciliation discards keys and history whose tombstones are globally visible at its oldest timestamp, so the new checkpoint holds neither the key nor a history store version the reader can use.

### Solution

Assert at the stable-cursor bind (`__clayered_open_stable_follower`) that the session's read timestamp is not below the adopted checkpoint's oldest timestamp. With that invariant enforced, move the positioned-on-stable check in `__clayered_can_advance_stable` back inside the no-read-timestamp branch (resolving the FIXME): under oldest <= read timestamp, a key visible to the reader cannot have its removal globally visible at the incoming oldest, so the position transfer in `__clayered_reopen_stable` always succeeds and timestamped readers can again advance mid-iteration, releasing the old checkpoint instead of pinning it.
