### PR TITLE
WT-18198 Stop a random cursor dividing by an empty leaf page's entry count

### DIFF
--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -236,6 +236,17 @@ __random_leaf_disk(WT_CURSOR_BTREE *cbt, bool *validp)
     session = CUR2S(cbt);
     entries = cbt->ref->page->entries;
 
+    /*
+     * Merging deltas into a base image drops keys whose deletes are globally visible, so a
+     * materialized row-store leaf image can legitimately have no entries. Images read off a block
+     * device always have entries.
+     */
+    if (entries == 0) {
+        WT_ASSERT(
+          session, page->disagg_info != NULL && page->disagg_info->block_meta.delta_count > 0);
+        return (0);
+    }
+
     /* This is a relatively cheap test, so try several times. */
     for (retry = 0; retry < WT_RANDOM_DISK_RETRY; ++retry) {
         slot = __wt_random(&cbt->rnd) % entries;

--- a/test/suite/test_layered_delta17.py
+++ b/test/suite/test_layered_delta17.py
@@ -39,13 +39,15 @@ from wtscenario import make_scenarios
 # checkpoint all tolerate that empty reconstructed page (rather than tripping the
 # mutually-exclusive empty-value page flags during verification), both for a
 # single-leaf tree and for one where the empty page is the leftmost of several
-# children.
+# children. A random cursor is checked separately: it sizes its choice of slot
+# by the entry count, so no entries used to mean a divide by zero.
 @disagg_test_class
 class test_layered_delta17(wttest.WiredTigerTestCase):
     test_name = __qualname__
     uri = test_name
     conn_base_config = ('statistics=(all),transaction_sync=(enabled,method=fsync),'
-                        'page_delta=(delta_pct=100,leaf_page_delta=true),precise_checkpoint=true,')
+                        'page_delta=(delta_pct=100,delete_pct=100,leaf_page_delta=true),'
+                        'precise_checkpoint=true,')
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
@@ -57,7 +59,7 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
     split_keep = 20
 
     def conn_config(self):
-        return self.conn_base_config + 'disaggregated=(role="leader")'
+        return self.conn_base_config + 'disaggregated=(role="leader"),'
 
     def rstat(self, key, uri):
         with wttest.open_cursor(self.session, "statistics:" + uri) as c:
@@ -75,8 +77,11 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         s.rollback_transaction()
         s.close()
 
-    def test_empty_reconstructed_page(self):
-        uri = 'table:' + self.uri
+    def build_empty_reconstructed_page(self, uri):
+        # Leave the tree with a single leaf that is only reachable by merging a
+        # base image full of tombstones with leaf deltas, once every delete is
+        # globally visible. On return the page is out of cache, so the next
+        # access runs the merge and lands on an image with no entries.
         self.session.create(uri, "key_format=S,value_format=S,block_manager=disagg")
         value = "a" * 20
 
@@ -121,8 +126,12 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         # merge yields an empty leaf.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20) +
                                 ',stable_timestamp=' + self.timestamp_str(20))
-
         cursor.close()
+
+    def test_empty_reconstructed_page(self):
+        uri = 'table:' + self.uri
+        self.build_empty_reconstructed_page(uri)
+
         cursor = self.session.open_cursor(uri, None, None)
 
         # Forward and backward scans see nothing.
@@ -138,6 +147,28 @@ class test_layered_delta17(wttest.WiredTigerTestCase):
         # The empty reconstructed page verifies and checkpoints cleanly.
         self.session.verify(uri, None)
         self.session.checkpoint()
+
+    def test_empty_reconstructed_page_random_cursor(self):
+        # A random cursor picks a slot by taking the remainder of a random
+        # number over the page's entry count, so an empty reconstructed page
+        # divides by zero. The page has to be selected straight off its disk
+        # image: with no entries there is no insert list to fall back to, and
+        # the page is clean, which is the combination that sends the random
+        # cursor at the disk entries a second time.
+        uri = 'table:' + self.uri
+        self.build_empty_reconstructed_page(uri)
+
+        # Drop the cache so the page has to be rebuilt from the page service:
+        # evicting on its own leaves the newest image a full page write. The
+        # restart resets the oldest timestamp, so push it past the deletes
+        # again before reading.
+        self.reopen_disagg_conn(self.conn_config())
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20) +
+                                ',stable_timestamp=' + self.timestamp_str(20))
+
+        cursor = self.session.open_cursor(uri, None, "next_random=true")
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
+        cursor.close()
 
     def test_empty_reconstructed_leftmost_page(self):
         # Same empty reconstructed leaf, reached from a tree deep enough for the


### PR DESCRIPTION
A random cursor sizes its choice of slot by taking a remainder over the leaf page's entry count. Before disaggregated storage a page with a disk image always had entries, so that count was never zero. Merging deltas into a base image breaks the implication: the merge drops every key whose delete is globally visible, and when that is all of them the materialized image legitimately has none. The cursor then divides by zero, and the reason it gets there at all is that a page with no entries also has no insert list to fall back to and is clean, which is the combination that sends it at the disk entries a second time.

The fix returns without a selection when the image is empty. Diagnostic builds also assert that an empty image only ever arrives from a delta merge, so a zero-entry image read off a block device is still caught rather than silently ignored.

The regression test joins test_layered_delta17, which already builds this page; its setup is now shared between the cases. Two extra things were needed to hit the crash: a delete percentage that keeps reconciliation writing deltas rather than a full page, and dropping the whole cache instead of evicting, because evicting a dirty page reconciles it and leaves a full image behind, so the re-read never runs the merge. Without the fix the test crashes in __random_leaf_disk with the frames from the ticket, on aarch64 as a null dereference of the row array rather than the reported SIGFPE, since integer division by zero does not trap there.