### PR TITLE
WT-18414 Harden background compaction tests against polling races

### DIFF
--- a/test/suite/helpers/compact_util.py
+++ b/test/suite/helpers/compact_util.py
@@ -78,6 +78,15 @@ class compact_util(wttest.WiredTigerTestCase):
     def get_bg_compaction_files_skipped(self):
         return self.get_stat(stat.conn.background_compact_skipped)
 
+    def get_bg_compaction_fail(self):
+        return self.get_stat(stat.conn.background_compact_fail)
+
+    # The number of files the background compaction server has finished with, whether it compacted
+    # them or not. Unlike the running statistic, this is cumulative and outlives the server.
+    def get_bg_compaction_files_processed(self):
+        return self.get_bg_compaction_success() + self.get_bg_compaction_fail() + \
+            self.get_bg_compaction_files_skipped()
+
     # Return the size of the given file.
     def get_size(self, uri):
         # To allow this to work on systems without ftruncate,
@@ -97,9 +106,20 @@ class compact_util(wttest.WiredTigerTestCase):
                 c[k] = value
         c.close()
 
-    def turn_on_bg_compact(self, config = ''):
+    # Enable the background compaction server and wait until it has started. Configured with
+    # run_once, the server clears the running statistic as soon as it has walked the metadata once
+    # and never sets it again, so waiting on that statistic alone waits forever whenever the pass
+    # finishes before we get to look. A file the server has finished with is equally good proof
+    # that it started, so accept either.
+    def turn_on_bg_compact(self, config = '', timeout = 60):
+        files_processed = self.get_bg_compaction_files_processed()
         self.session.compact(None, f'background=true,{config}')
+        deadline = time.time() + timeout
         while not self.get_bg_compaction_running():
+            if self.get_bg_compaction_files_processed() > files_processed:
+                return
+            self.assertLess(time.time(), deadline,
+                f'background compaction did not start within {timeout} seconds')
             time.sleep(0.1)
 
     def turn_off_bg_compact(self):

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -79,9 +79,8 @@ class test_compact06(compact_util):
         # Background compaction should have skipped the HS file as it is less than 1MB.
         assert self.get_bg_compaction_files_skipped() == 1
 
-        # Enable background and configure it to run once. Don't use the helper function as the
-        # server may go to sleep before we have the time to check it is actually running.
-        self.session.compact(None, 'background=true,run_once=true')
+        # Enable background and configure it to run once.
+        self.turn_on_bg_compact('run_once=true')
 
         # Wait for background compaction to start and skip the HS file again.
         while self.get_bg_compaction_files_skipped() == 1:

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -76,27 +76,30 @@ class test_compact06(compact_util):
         # Disable the background compaction server.
         self.turn_off_bg_compact()
 
-        # Background compaction should have skipped the HS file as it is less than 1MB.
-        assert self.get_bg_compaction_files_skipped() == 1
+        # Background compaction should have skipped the HS file as it is less than 1MB. The server
+        # walks the metadata once every full_iteration_wait_time, so it may have skipped the file
+        # more than once before being disabled.
+        files_skipped = self.get_bg_compaction_files_skipped()
+        self.assertGreaterEqual(files_skipped, 1)
 
         # Enable background and configure it to run once.
         self.turn_on_bg_compact('run_once=true')
 
         # Wait for background compaction to start and skip the HS file again.
-        while self.get_bg_compaction_files_skipped() == 1:
+        while self.get_bg_compaction_files_skipped() == files_skipped:
             time.sleep(1)
 
         # Ensure background compaction stops by itself.
         while self.get_bg_compaction_running():
             time.sleep(1)
 
-        # Background compact should only skip the HS file once.
-        assert self.get_bg_compaction_files_skipped() == 2
+        # A single pass should only skip the HS file once.
+        self.assertEqual(self.get_bg_compaction_files_skipped(), files_skipped + 1)
 
         # Enable the server again but with default options, the HS should be skipped.
         self.turn_on_bg_compact()
 
-        while self.get_bg_compaction_files_skipped() == 2:
+        while self.get_bg_compaction_files_skipped() == files_skipped + 1:
             time.sleep(1)
 
         self.turn_off_bg_compact()

--- a/test/suite/test_compact07.py
+++ b/test/suite/test_compact07.py
@@ -103,10 +103,8 @@ class test_compact07(compact_util):
         # Enable background compaction with a threshold big enough so it does not process the first
         # table created but only the others with more empty space. We set run_once so we don't
         # conflict with foreground compaction. If the two are running in parallel, stats cannot be
-        # checked properly. Don't use the helper function as the server may go to sleep before we
-        # have the time to check it is actually running.
-        bg_compact_config = f'background=true,free_space_target={(free_space_20 + 1)}MB,run_once=true'
-        self.session.compact(None, bg_compact_config)
+        # checked properly.
+        self.turn_on_bg_compact(f'free_space_target={(free_space_20 + 1)}MB,run_once=true')
 
         # Background compaction should run through every file as listed in the metadata file.
         # Wait until all the eligible files have been compacted.

--- a/test/suite/test_compact09.py
+++ b/test/suite/test_compact09.py
@@ -74,10 +74,7 @@ class test_compact09(compact_util):
         # Enable background compaction and exclude the two tables. Use run once to be able to
         # track the stats easily.
         exclude_list = f'["{self.uri_prefix}_0.wt", "{self.uri_prefix}_1.wt"]'
-        config = f'background=true,free_space_target=1MB,exclude={exclude_list},run_once=true'
-        # Don't use the helper function as the server may go to sleep before we have the time to
-        # check it is actually running.
-        self.session.compact(None, config)
+        self.turn_on_bg_compact(f'free_space_target=1MB,exclude={exclude_list},run_once=true')
 
         # Background compaction should exclude all files.
         while self.get_bg_compaction_files_excluded() < self.n_tables:
@@ -92,8 +89,7 @@ class test_compact09(compact_util):
 
         # Enable background compaction and exclude only one table.
         exclude_list = f'["{self.uri_prefix}_0.wt"]'
-        config = f'background=true,free_space_target=1MB,exclude={exclude_list},run_once=true'
-        self.session.compact(None, config)
+        self.turn_on_bg_compact(f'free_space_target=1MB,exclude={exclude_list},run_once=true')
 
         # Background compaction should exclude only one file now. Since the stats are cumulative, we
         # need to take into account the previous check.

--- a/test/suite/test_compact13.py
+++ b/test/suite/test_compact13.py
@@ -59,7 +59,7 @@ class test_compact13(compact_util):
         self.session.checkpoint()
 
         # Enable background compaction.
-        bg_compact_config = 'background=true,free_space_target=1MB'
+        bg_compact_config = 'free_space_target=1MB'
         self.turn_on_bg_compact(bg_compact_config)
 
         # Nothing should be compacted.

--- a/test/suite/test_compact14.py
+++ b/test/suite/test_compact14.py
@@ -51,7 +51,7 @@ class test_compact14(compact_util):
         self.session.checkpoint()
 
         # Enable background compaction.
-        bg_compact_config = 'background=true,free_space_target=1MB'
+        bg_compact_config = 'free_space_target=1MB'
         self.turn_on_bg_compact(bg_compact_config)
 
         while self.get_bg_compaction_files_skipped() == 0:


### PR DESCRIPTION
## Summary

Three brittle patterns in the background compaction python tests, one commit each.

- `turn_on_bg_compact` waited only on `background_compact_running`, which a `run_once` server clears once its single pass ends and never sets again — so the wait could never finish. Accept a processed file as proof it started, and bound the wait.
- `test_compact06` asserted absolute values on a counter incremented once per metadata walk; assert deltas instead.
- `test_compact13`/`test_compact14` passed `background=true` to a helper that already supplies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)