### PR TITLE
WT-18147 Fix wt tool's pretty-print support for zero-length "u" data

### DIFF
--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -173,8 +173,15 @@ __wt_buf_set_printable_format(WT_SESSION_IMPL *session, const void *buffer, size
             break;
         case 'U':
         case 'u':
-            if (pv.u.item.size == 0)
+            if (pv.u.item.size == 0) {
+                /*
+                 * The buffer is reused across records; without writing anything here, buf->data
+                 * would still reference the previous record's formatted string instead of an empty
+                 * one.
+                 */
+                WT_ERR(__wt_buf_catfmt(session, buf, "%s", sep));
                 break;
+            }
 
             if (tmp == NULL)
                 WT_ERR(__wt_scr_alloc(session, 0, &tmp));

--- a/test/suite/fail_lists/hook_disagg.fail
+++ b/test/suite/fail_lists/hook_disagg.fail
@@ -13,6 +13,7 @@ test_dump02.py
 test_dump03.py
 test_dump04.py
 test_dump05.py
+test_dump06.py
 test_dupc.py
 test_durable_ts03.py
 test_empty.py

--- a/test/suite/test_dump06.py
+++ b/test/suite/test_dump06.py
@@ -40,14 +40,6 @@ class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
     hex_file = 'dump_hex.out'
     json_file = 'dump_json.out'
 
-    def populate_table(self):
-        cursor = self.session.open_cursor(self.uri, None, None)
-        cursor[2] = b'A'
-        cursor[3] = b''
-        cursor[5] = b'B'
-        cursor[6] = b'C'
-        cursor.close()
-
     def dump_value_lines(self, filename):
         lines = open(filename).readlines()
         start = lines.index('Data\n') + 1
@@ -56,7 +48,13 @@ class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_dump_pretty_empty_value(self):
         self.session.create(self.uri, self.table_format)
-        self.populate_table()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor[1] = b''
+        cursor[2] = b'A'
+        cursor[3] = b''
+        cursor[5] = b'B'
+        cursor[6] = b'C'
+        cursor.close()
 
         self.runWt(['dump', '-p', self.uri], outfilename=self.pretty_file)
         self.runWt(['dump', '-x', self.uri], outfilename=self.hex_file)
@@ -65,46 +63,11 @@ class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
         pretty = self.dump_value_lines(self.pretty_file)
         hexvals = self.dump_value_lines(self.hex_file)
 
-        self.assertEqual(pretty, ['A', '', 'B', 'C'])
-        self.assertEqual(hexvals[1], '')
+        self.assertEqual(pretty, ['', 'A', '', 'B', 'C'])
+        self.assertEqual(hexvals[0], '')
+        self.assertEqual(hexvals[2], '')
+        self.check_file_contains(self.json_file, '"key0" : 1,\n"value0" : ""\n')
         self.check_file_contains(self.json_file, '"key0" : 3,\n"value0" : ""\n')
-
-    def test_dump_pretty_empty_value_first_record(self):
-        self.session.create(self.uri, self.table_format)
-        cursor = self.session.open_cursor(self.uri, None, None)
-        cursor[1] = b''
-        cursor[2] = b'A'
-        cursor.close()
-
-        self.runWt(['dump', '-p', self.uri], outfilename=self.pretty_file)
-        pretty = self.dump_value_lines(self.pretty_file)
-        self.assertEqual(pretty, ['', 'A'])
-
-    def test_dump_pretty_composite_format_with_empty_u(self):
-        uri_qu = 'table:test_dump06_qu'
-        uri_uq = 'table:test_dump06_uq'
-
-        self.session.create(uri_qu, 'key_format=q,value_format=qu')
-        cursor = self.session.open_cursor(uri_qu, None, None)
-        cursor[1] = (10, b'X')
-        cursor[2] = (20, b'')
-        cursor[3] = (30, b'Y')
-        cursor.close()
-
-        self.session.create(uri_uq, 'key_format=q,value_format=uq')
-        cursor = self.session.open_cursor(uri_uq, None, None)
-        cursor[1] = (b'X', 100)
-        cursor[2] = (b'', 200)
-        cursor[3] = (b'Y', 300)
-        cursor.close()
-
-        self.runWt(['dump', '-p', uri_qu], outfilename=self.pretty_file)
-        qu = self.dump_value_lines(self.pretty_file)
-        self.assertEqual(qu, ['10,X', '20,', '30,Y'])
-
-        self.runWt(['dump', '-p', uri_uq], outfilename=self.pretty_file)
-        uq = self.dump_value_lines(self.pretty_file)
-        self.assertEqual(uq, ['X100', '200', 'Y300'])
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_dump06.py
+++ b/test/suite/test_dump06.py
@@ -40,12 +40,6 @@ class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
     hex_file = 'dump_hex.out'
     json_file = 'dump_json.out'
 
-    def dump_value_lines(self, filename):
-        lines = open(filename).readlines()
-        start = lines.index('Data\n') + 1
-        pairs = lines[start:]
-        return [pairs[i + 1].rstrip('\n') for i in range(0, len(pairs), 2)]
-
     def test_dump_pretty_empty_value(self):
         self.session.create(self.uri, self.table_format)
         cursor = self.session.open_cursor(self.uri, None, None)
@@ -60,12 +54,8 @@ class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(['dump', '-x', self.uri], outfilename=self.hex_file)
         self.runWt(['dump', '-j', self.uri], outfilename=self.json_file)
 
-        pretty = self.dump_value_lines(self.pretty_file)
-        hexvals = self.dump_value_lines(self.hex_file)
-
-        self.assertEqual(pretty, ['', 'A', '', 'B', 'C'])
-        self.assertEqual(hexvals[0], '')
-        self.assertEqual(hexvals[2], '')
+        self.check_file_contains(self.pretty_file, 'Data\n1\n\n2\nA\n3\n\n5\nB\n6\nC\n')
+        self.check_file_contains(self.hex_file, 'Data\n81\n\n82\n41\n83\n\n85\n42\n86\n43\n')
         self.check_file_contains(self.json_file, '"key0" : 1,\n"value0" : ""\n')
         self.check_file_contains(self.json_file, '"key0" : 3,\n"value0" : ""\n')
 

--- a/test/suite/test_dump06.py
+++ b/test/suite/test_dump06.py
@@ -40,22 +40,36 @@ class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
     hex_file = 'dump_hex.out'
     json_file = 'dump_json.out'
 
+    k_v_pairs = [(1, b''), (2, b'A'), (3, b''), (5, b'B'), (6, b'C')]
+
     def test_dump_pretty_empty_value(self):
         self.session.create(self.uri, self.table_format)
         cursor = self.session.open_cursor(self.uri, None, None)
-        cursor[1] = b''
-        cursor[2] = b'A'
-        cursor[3] = b''
-        cursor[5] = b'B'
-        cursor[6] = b'C'
+        for k, v in self.k_v_pairs:
+            cursor[k] = v
         cursor.close()
 
         self.runWt(['dump', '-p', self.uri], outfilename=self.pretty_file)
         self.runWt(['dump', '-x', self.uri], outfilename=self.hex_file)
         self.runWt(['dump', '-j', self.uri], outfilename=self.json_file)
 
-        self.check_file_contains(self.pretty_file, 'Data\n1\n\n2\nA\n3\n\n5\nB\n6\nC\n')
-        self.check_file_contains(self.hex_file, 'Data\n81\n\n82\n41\n83\n\n85\n42\n86\n43\n')
+        # Pretty-print format
+        pretty_expected = []
+        for k, v in self.k_v_pairs:
+            pretty_expected.append(f'{k}')
+            pretty_expected.append(v.decode())
+        pretty_expected = 'Data\n' + '\n'.join(pretty_expected)
+        self.check_file_contains(self.pretty_file, pretty_expected)
+
+        # Hex format
+        hex_expected = []
+        for k, v in self.k_v_pairs:
+            hex_expected.append(f'{k + 0x80:x}')
+            hex_expected.append(v.hex())
+        hex_expected = 'Data\n' + '\n'.join(hex_expected)
+        self.check_file_contains(self.hex_file, hex_expected)
+
+        # JSON format
         self.check_file_contains(self.json_file, '"key0" : 1,\n"value0" : ""\n')
         self.check_file_contains(self.json_file, '"key0" : 3,\n"value0" : ""\n')
 

--- a/test/suite/test_dump06.py
+++ b/test/suite/test_dump06.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from suite_subprocess import suite_subprocess
+
+# Test that a zero-length 'u' formatted value is dumped correctly with
+# the pretty-print (-p) option, rather than showing the previous
+# record's value.
+class test_dump06(wttest.WiredTigerTestCase, suite_subprocess):
+    uri = 'table:test_dump06'
+    table_format = 'key_format=q,value_format=u'
+
+    pretty_file = 'dump_pretty.out'
+    hex_file = 'dump_hex.out'
+    json_file = 'dump_json.out'
+
+    def populate_table(self):
+        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor[2] = b'A'
+        cursor[3] = b''
+        cursor[5] = b'B'
+        cursor[6] = b'C'
+        cursor.close()
+
+    def dump_value_lines(self, filename):
+        lines = open(filename).readlines()
+        start = lines.index('Data\n') + 1
+        pairs = lines[start:]
+        return [pairs[i + 1].rstrip('\n') for i in range(0, len(pairs), 2)]
+
+    def test_dump_pretty_empty_value(self):
+        self.session.create(self.uri, self.table_format)
+        self.populate_table()
+
+        self.runWt(['dump', '-p', self.uri], outfilename=self.pretty_file)
+        self.runWt(['dump', '-x', self.uri], outfilename=self.hex_file)
+        self.runWt(['dump', '-j', self.uri], outfilename=self.json_file)
+
+        pretty = self.dump_value_lines(self.pretty_file)
+        hexvals = self.dump_value_lines(self.hex_file)
+
+        self.assertEqual(pretty, ['A', '', 'B', 'C'])
+        self.assertEqual(hexvals[1], '')
+        self.check_file_contains(self.json_file, '"key0" : 3,\n"value0" : ""\n')
+
+    def test_dump_pretty_empty_value_first_record(self):
+        self.session.create(self.uri, self.table_format)
+        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor[1] = b''
+        cursor[2] = b'A'
+        cursor.close()
+
+        self.runWt(['dump', '-p', self.uri], outfilename=self.pretty_file)
+        pretty = self.dump_value_lines(self.pretty_file)
+        self.assertEqual(pretty, ['', 'A'])
+
+    def test_dump_pretty_composite_format_with_empty_u(self):
+        uri_qu = 'table:test_dump06_qu'
+        uri_uq = 'table:test_dump06_uq'
+
+        self.session.create(uri_qu, 'key_format=q,value_format=qu')
+        cursor = self.session.open_cursor(uri_qu, None, None)
+        cursor[1] = (10, b'X')
+        cursor[2] = (20, b'')
+        cursor[3] = (30, b'Y')
+        cursor.close()
+
+        self.session.create(uri_uq, 'key_format=q,value_format=uq')
+        cursor = self.session.open_cursor(uri_uq, None, None)
+        cursor[1] = (b'X', 100)
+        cursor[2] = (b'', 200)
+        cursor[3] = (b'Y', 300)
+        cursor.close()
+
+        self.runWt(['dump', '-p', uri_qu], outfilename=self.pretty_file)
+        qu = self.dump_value_lines(self.pretty_file)
+        self.assertEqual(qu, ['10,X', '20,', '30,Y'])
+
+        self.runWt(['dump', '-p', uri_uq], outfilename=self.pretty_file)
+        uq = self.dump_value_lines(self.pretty_file)
+        self.assertEqual(uq, ['X100', '200', 'Y300'])
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
`wt dump -p` printed a record's **previous** value instead of a blank value for a zero-length `u`/`U`-format field, because `__wt_buf_set_printable_format()` reused an output buffer and returned early without writing (or NUL-terminating) anything for the zero-length case.

`src/support/scratch.c`: the zero-length `'U'`/`'u'` case now writes the field separator (still nothing else) so the buffer is refreshed instead of left stale. Output is blank, matching `-x`, `-j`.

`test/suite/test_dump06.py` asserts the pretty dump shows blank (not stale/previous data).