### PR TITLE
WT-18429 schema-disagg-abort: Run schema ops during stepdown in single-node

### DIFF
--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -34,35 +34,6 @@ ckpt_latest(WORKLOAD_STATE *state, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *arg
 
     return (ret != WT_NOTFOUND);
 }
-
-/*
- * ckpt_pick_up --
- *     Pick up the latest complete checkpoint onto this connection. Returns true if a checkpoint was
- *     adopted, false if the page log has no new checkpoint.
- */
-static bool
-ckpt_pick_up(WORKLOAD_STATE *state, WT_SESSION *session)
-{
-    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
-
-    if (!ckpt_latest(state, &ckpt_args))
-        return (false);
-
-    if (ckpt_args.checkpoint_lsn == state->adopted_ckpt_lsn) {
-        free(ckpt_args.checkpoint_metadata.mem);
-        return (false);
-    }
-
-    WT_CONNECTION *conn = session->connection;
-    char meta_config[4096];
-    testutil_snprintf(meta_config, sizeof(meta_config), "disaggregated=(checkpoint_meta=\"%.*s\")",
-      (int)ckpt_args.checkpoint_metadata.size, (const char *)ckpt_args.checkpoint_metadata.data);
-    testutil_check(conn->reconfigure(conn, meta_config));
-    free(ckpt_args.checkpoint_metadata.mem);
-    state->adopted_ckpt_lsn = ckpt_args.checkpoint_lsn;
-    return (true);
-}
-
 /*
  * ckpt_lsn_stat --
  *     Return one of the connection's checkpoint metadata LSN statistics.
@@ -84,25 +55,35 @@ ckpt_lsn_stat(WT_SESSION *session, int stat_key)
 }
 
 /*
- * ckpt_adopt_latest --
- *     Adopt the latest checkpoint before stepping up. A pick-up can be deferred, and stepping up
- *     discards a pending deferral, so wait for the adopted LSN to catch up with the delivered one.
+ * ckpt_pick_up --
+ *     Pick up and adopt the latest complete checkpoint onto this connection. Returns true once a
+ *     new checkpoint is adopted, false if the page log has no new checkpoint.
  */
-void
-ckpt_adopt_latest(WORKLOAD_STATE *state)
+static bool
+ckpt_pick_up(WORKLOAD_STATE *state, WT_SESSION *session)
 {
-    WT_CONNECTION *conn = state->conn;
+    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
 
-    WT_SESSION *session;
-    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    if (!ckpt_latest(state, &ckpt_args))
+        return (false);
+
+    if (ckpt_args.checkpoint_lsn == state->adopted_ckpt_lsn) {
+        free(ckpt_args.checkpoint_metadata.mem);
+        return (false);
+    }
 
     struct timespec start;
     __wt_epoch(NULL, &start);
-    for (;;) {
-        (void)ckpt_pick_up(state, session);
 
-        const uint64_t delivered =
-          ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN);
+    WT_CONNECTION *conn = session->connection;
+    char meta_config[4096];
+    testutil_snprintf(meta_config, sizeof(meta_config), "disaggregated=(checkpoint_meta=\"%.*s\")",
+      (int)ckpt_args.checkpoint_metadata.size, (const char *)ckpt_args.checkpoint_metadata.data);
+    testutil_check(conn->reconfigure(conn, meta_config));
+    free(ckpt_args.checkpoint_metadata.mem);
+
+    const uint64_t delivered = ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN);
+    for (;;) {
         const uint64_t adopted = ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN);
         if (adopted >= delivered)
             break;
@@ -117,9 +98,24 @@ ckpt_adopt_latest(WORKLOAD_STATE *state)
         __wt_sleep(0, 10 * WT_THOUSAND);
     }
 
-    testutil_check(session->close(session, NULL));
+    state->adopted_ckpt_lsn = ckpt_args.checkpoint_lsn;
+    return (true);
+}
 
-    println("Node %" PRIu32 ": adopted the latest checkpoint before step-up", state->cfg->node_id);
+/*
+ * ckpt_adopt_latest --
+ *     Adopt the latest checkpoint before stepping up.
+ */
+void
+ckpt_adopt_latest(WORKLOAD_STATE *state)
+{
+    WT_SESSION *session;
+    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
+    const bool adopted = ckpt_pick_up(state, session);
+    testutil_check(session->close(session, NULL));
+    if (adopted)
+        println(
+          "Node %" PRIu32 ": adopted the latest checkpoint before step-up", state->cfg->node_id);
 }
 
 /*
@@ -142,7 +138,7 @@ thread_ckpt_run(void *arg)
     /* The cadence draws from the stream one past the generator's per-worker streams. */
     WT_RAND_STATE *rnd = &state->gen_rnd[state->nth_workers];
     struct timespec last = ckpt.phase_start;
-    uint64_t wait = __wt_random(rnd) % MAX_CKPT_INVL;
+    uint64_t wait = 1 + __wt_random(rnd) % MAX_CKPT_INVL;
 
     while (workload_active(state, STAGE_CKPT)) {
         struct timespec now;
@@ -155,7 +151,7 @@ thread_ckpt_run(void *arg)
         node_role(state->leads)->checkpoint(state, session, &ckpt);
 
         __wt_epoch(NULL, &last);
-        wait = __wt_random(rnd) % MAX_CKPT_INVL;
+        wait = 1 + __wt_random(rnd) % MAX_CKPT_INVL;
     }
 
     testutil_check(session->close(session, NULL));
@@ -205,9 +201,9 @@ thread_ts_run(void *arg)
              */
             const uint64_t frontier = workers_min(state);
             if (frontier != 0) {
-                const uint64_t cur_stable = query_ts(state->conn, "stable_timestamp");
+                const uint64_t cur_stable = query_ts(state->conn, TS_STABLE);
                 if (frontier >= cur_stable)
-                    set_frontier(state->conn, frontier);
+                    set_ts(state->conn, TS_FRONTIER, frontier);
             }
         }
         __wt_atomic_store_bool(&state->ts_busy, false);
@@ -230,7 +226,7 @@ leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
         return;
 
     /* Skip the checkpoint if there is no stable timestamp yet. */
-    const uint64_t stable_ts = query_ts(state->conn, "stable_timestamp");
+    const uint64_t stable_ts = query_ts(state->conn, TS_STABLE);
     if (stable_ts == 0) {
         struct timespec now;
         __wt_epoch(NULL, &now);

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -7,7 +7,7 @@
  */
 
 /*
- * The generator stage: the node's command stream - workload, the step-down marker, and the switch
+ * The generator stage: the node's command stream - workload, the step-down event, and the switch
  * event that ends a term - written into the self-pipe. Started only for a phase that produces its
  * own stream: a leader always does, and so does a follower with no peer.
  */
@@ -19,7 +19,7 @@ typedef enum {
     GEN_NORMAL,          /* the term's workload */
     GEN_FLUSH_PUBLISHES, /* one-shot: emit the publishes a term must not end holding */
     GEN_BEGIN_STEPDOWN,  /* one-shot: emit the step-down timestamp */
-    GEN_STEPDOWN,        /* the step-down window: limited workload */
+    GEN_STEPDOWN,        /* the step-down: limited workload */
     GEN_SWITCH,          /* one-shot: emit the switch event that ends the stream */
     GEN_STOP             /* terminal: the phase stopped, or the stream ended */
 } GENERATOR_PHASE;
@@ -83,11 +83,11 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         break;
     case TABLE_PUBLISHED:
         /* Take (more) data, drop the table, or linger. */
-        if (__wt_random(rnd) % INSERT_ODDS == 0) {
+        if (__wt_random(rnd) % GEN_INSERT_ODDS == 0) {
             ev.type = EVENT_INSERT;
             if (stepping_down)
                 *stepdown_insert = true;
-        } else if (__wt_random(rnd) % DROP_ODDS == 0 && (!stepping_down || !*stepdown_insert)) {
+        } else if (__wt_random(rnd) % GEN_DROP_ODDS == 0 && (!stepping_down || !*stepdown_insert)) {
             /* Such a drop would wait on a checkpoint the step-down cannot take. */
             ev.type = EVENT_DROP;
             *slot_state = TABLE_DROPPED;
@@ -139,13 +139,13 @@ generator_round(WORKLOAD_STATE *state, uint64_t lead_max, GENERATOR_PHASE phase)
     return (emitted);
 }
 
-/*
- * A leading generator's pacing state: the sentinel poll throttle, and the lead it may build over
- * its workers.
- */
+/* A leading generator's pacing state. */
 typedef struct {
-    struct timespec last_poll;
     uint64_t lead_max; /* events that may be in flight; UINT64_MAX when nothing bounds it */
+    struct timespec last_poll;
+
+    uint64_t stepdown_emitted;      /* events emitted since the step-down started */
+    struct timespec stepdown_start; /* when the step-down event is emitted */
 } GENERATOR_PACING;
 
 /*
@@ -155,11 +155,16 @@ typedef struct {
 static void
 generator_pacing_init(GENERATOR_PACING *pacing, const TEST_CONFIG *cfg)
 {
+    WT_CLEAR(*pacing);
     __wt_epoch(NULL, &pacing->last_poll);
-    /* Bound the lead so a hand-over drains inside one switch period; no switches, no bound. */
+    /*-
+     * How much lead the generator may have over the workers:
+     *   - no roles switching: no limit, the event pipe will be always full,
+     *   - otherwise: throttle the generator, so role switch happens within reasonable time.
+     */
     pacing->lead_max = cfg->switch_interval == 0 ?
       UINT64_MAX :
-      WT_MAX(cfg->switch_interval * GEN_APPLY_RATE_FLOOR, GEN_LEAD_MIN);
+      WT_MAX(cfg->switch_interval * GEN_APPLY_RATE_FLOOR, GEN_MIN_LEAD);
 }
 
 /*
@@ -181,6 +186,8 @@ generator_switch_requested(GENERATOR_PACING *pacing)
 /*
  * generator_flush_publishes --
  *     Emit the pending publish for every slot in an unpublished state, before the role transition.
+ *     FIXME-WT-18272 FIXME-WT-18284: Remove this function once these tickets are resolved.
+ *     Corresponding generator state GEN_FLUSH_PUBLISHES won't be needed anymore, as well.
  */
 static void
 generator_flush_publishes(WORKLOAD_STATE *state)
@@ -205,39 +212,51 @@ generator_flush_publishes(WORKLOAD_STATE *state)
 
 /*
  * generator_stepdown_ended --
- *     Whether the step-down may complete: the peer adopted the step-down checkpoint, or died.
+ *     Whether the step-down may complete: the peer adopted the step-down checkpoint or died, or a
+ *     lone node emitted its share of events.
  */
 static bool
-generator_stepdown_ended(
-  WORKLOAD_STATE *state, GENERATOR_PACING *pacing, const struct timespec *start)
+generator_stepdown_ended(WORKLOAD_STATE *state, GENERATOR_PACING *pacing)
 {
     /* Zero until the reader's step-down work completes. */
     const uint64_t ckpt_lsn = __wt_atomic_load_uint64(&state->stepdown_ckpt_lsn);
+    const bool lone = node_is_lone(state->cfg);
 
-    /* The peer died mid-window: nothing left to wait for, and no next leader to carry it. */
-    if (ckpt_lsn != 0 && !state->cfg->peer_alive)
+    /* A dead peer cannot adopt the checkpoint. */
+    if (ckpt_lsn != 0 && !lone && !state->cfg->peer_alive)
         return (true);
 
     struct timespec now;
     __wt_epoch(NULL, &now);
     if (WT_TIMEDIFF_SEC(now, pacing->last_poll) < 1)
-        return (false);
+        return (false); /* Too early, come back later. */
     pacing->last_poll = now;
 
-    if (ckpt_lsn != 0 && adopted_lsn_read() >= ckpt_lsn)
+    const uint64_t stepdown_events = state->emitted - pacing->stepdown_emitted;
+    /* Lone node exhausted step-down events or peer adopted the checkpoint. */
+    const bool ended = ckpt_lsn != 0 &&
+      (lone ? stepdown_events >= GEN_STEPDOWN_MIN_EVENTS : adopted_lsn_read() >= ckpt_lsn);
+
+    if (ended)
         return (true);
 
-    /* Which side stalled: our own step-down work, or the peer's adoption of it. */
-    if (WT_TIMEDIFF_SEC(now, *start) > MAX_OP_WAIT) {
+    /* Report which part of the step-down stalled. */
+    if (WT_TIMEDIFF_SEC(now, pacing->stepdown_start) > MAX_OP_WAIT) {
         if (ckpt_lsn == 0)
             testutil_die(ETIMEDOUT,
               "Node %" PRIu32 ": the step-down checkpoint did not complete in %d seconds",
               state->cfg->node_id, MAX_OP_WAIT);
-        testutil_die(ETIMEDOUT,
-          "Node %" PRIu32 ": peer did not adopt the step-down checkpoint (lsn %" PRIu64
-          ") in %d seconds",
-          state->cfg->node_id, ckpt_lsn, MAX_OP_WAIT);
+        else if (lone)
+            testutil_die(ETIMEDOUT,
+              "Node %" PRIu32 ": the step-down emitted %" PRIu64 " of %d events in %d seconds",
+              state->cfg->node_id, stepdown_events, GEN_STEPDOWN_MIN_EVENTS, MAX_OP_WAIT);
+        else
+            testutil_die(ETIMEDOUT,
+              "Node %" PRIu32 ": peer did not adopt the step-down checkpoint (lsn %" PRIu64
+              ") in %d seconds",
+              state->cfg->node_id, ckpt_lsn, MAX_OP_WAIT);
     }
+
     return (false);
 }
 
@@ -266,7 +285,6 @@ thread_generator_run(void *arg)
     GENERATOR_PACING pacing;
     generator_pacing_init(&pacing, state->cfg);
 
-    struct timespec start = {0};
     GENERATOR_PHASE phase = GEN_NORMAL;
 
     while (phase != GEN_STOP && workload_active(state, STAGE_GENERATOR)) {
@@ -287,18 +305,23 @@ thread_generator_run(void *arg)
             break;
         case GEN_BEGIN_STEPDOWN:
             /*
-             * Tell the reader to start the step-down work. If the peer exists, then generate a
-             * limited workload until the peer adopts the step-down checkpoint.
+             * Tell the reader to start the step-down work, then generate a limited workload until
+             * the step-down ends.
              */
             generator_transition_emit(state, EVENT_STEPDOWN);
-            __wt_epoch(NULL, &start);
-            phase = state->cfg->peer_alive ? GEN_STEPDOWN : GEN_SWITCH;
+            __wt_epoch(NULL, &pacing.stepdown_start);
+            pacing.stepdown_emitted = state->emitted;
+            phase = GEN_STEPDOWN;
             break;
         case GEN_STEPDOWN:
-            /* Stop adding operations the moment the peer is gone. */
-            progressed =
-              state->cfg->peer_alive && generator_round(state, pacing.lead_max, GEN_STEPDOWN);
-            phase = generator_stepdown_ended(state, &pacing, &start) ? GEN_SWITCH : GEN_STEPDOWN;
+            /* A dead peer cannot carry the operations, so stop adding them. */
+            progressed = (node_is_lone(state->cfg) || state->cfg->peer_alive) &&
+              generator_round(state, pacing.lead_max, GEN_STEPDOWN);
+            if (generator_stepdown_ended(state, &pacing)) {
+                println("Node %" PRIu32 ": step-down emitted %" PRIu64 " events",
+                  state->cfg->node_id, state->emitted - pacing.stepdown_emitted);
+                phase = GEN_SWITCH;
+            }
             break;
         case GEN_SWITCH:
             /* The stream's last event, carrying the counter the next leader continues from. */

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -38,15 +38,42 @@ println(const char *fmt, ...)
 }
 
 /*
+ * timestamp_name --
+ *     Return the configuration name for a timestamp bit.
+ */
+static const char *
+timestamp_name(uint8_t bit)
+{
+    switch (bit) {
+    case TS_OLDEST:
+        return ("oldest_timestamp");
+    case TS_STABLE:
+        return ("stable_timestamp");
+    case TS_STABLE_SCHEMA_EPOCH:
+        return ("stable_disaggregated_schema_epoch");
+    case TS_STEPDOWN_TIMESTAMP:
+        return ("step_down_timestamp");
+    case TS_STEPDOWN_SCHEMA_EPOCH:
+        return ("step_down_disaggregated_schema_epoch");
+    case TS_LAST_SCHEMA_EPOCH:
+        return ("last_disaggregated_schema_epoch");
+    case TS_LAST_CHECKPOINT:
+        return ("last_checkpoint");
+    default:
+        testutil_die(EINVAL, "unknown timestamp bit: %#" PRIx8, bit);
+    }
+}
+
+/*
  * query_ts --
  *     Return one of the connection's timestamps as an integer. A timestamp that was never set reads
- *     as zero; an unknown name is a coding error and fails the test.
+ *     as zero.
  */
 uint64_t
-query_ts(WT_CONNECTION *conn, const char *name)
+query_ts(WT_CONNECTION *conn, uint8_t bit)
 {
     char config[64], hex_ts[64];
-    testutil_snprintf(config, sizeof(config), "get=%s", name);
+    testutil_snprintf(config, sizeof(config), "get=%s", timestamp_name(bit));
     testutil_check(conn->query_timestamp(conn, hex_ts, config));
 
     uint64_t ts = 0;
@@ -55,32 +82,22 @@ query_ts(WT_CONNECTION *conn, const char *name)
 }
 
 /*
- * set_stepdown_ts --
- *     Set connection's step-down timestamps.
+ * set_ts --
+ *     Set the selected connection timestamps to given value.
  */
 void
-set_stepdown_ts(WT_CONNECTION *conn, uint64_t ts)
+set_ts(WT_CONNECTION *conn, uint8_t mask, uint64_t ts)
 {
-    char config[128];
-    testutil_snprintf(config, sizeof(config),
-      "step_down_timestamp=%" PRIx64 ",step_down_disaggregated_schema_epoch=%" PRIx64, ts, ts);
-    testutil_check(conn->set_timestamp(conn, config));
-}
+    char config[256];
+    size_t len = 0;
 
-/*
- * set_frontier --
- *     Move the connection's frontier - the oldest and stable timestamps and the stable schema epoch
- *     - to one timestamp. The three always advance together, so everything at or below that
- *     timestamp is committed and published.
- */
-void
-set_frontier(WT_CONNECTION *conn, uint64_t ts)
-{
-    char config[128];
-    testutil_snprintf(config, sizeof(config),
-      "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64
-      ",stable_disaggregated_schema_epoch=%" PRIx64,
-      ts, ts, ts);
+    testutil_assert(mask != 0);
+    for (uint8_t bit = 1; bit != 0; bit = (uint8_t)(bit << 1)) {
+        if ((mask & bit) == 0)
+            continue;
+        testutil_snprintf_len_incr(
+          config + len, sizeof(config) - len, &len, "%s=%" PRIx64 ",", timestamp_name(bit), ts);
+    }
     testutil_check(conn->set_timestamp(conn, config));
 }
 

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -71,6 +71,18 @@ workload_active(WORKLOAD_STATE *state, uint32_t stage)
 }
 
 /*
+ * node_is_lone --
+ *     Whether this node runs without a peer at all, as opposed to having outlived one: a peered
+ *     node keeps its pipes for the process's life, so the read end tells the two apart even after
+ *     peer_alive is cleared.
+ */
+bool
+node_is_lone(const TEST_CONFIG *cfg)
+{
+    return (cfg->pipe_read_fd < 0);
+}
+
+/*
  * disagg_opts_init --
  *     Point the test options at the shared PALite page log: the single source of truth for the
  *     disaggregated configuration, used by the nodes and by the parent's recovery opens.
@@ -325,7 +337,7 @@ node_step_up(WORKLOAD_STATE *state, uint64_t final_ts)
 
     /* Restore the timestamps on the new leader's connection. */
     if (final_ts != 0)
-        set_frontier(state->conn, final_ts);
+        set_ts(state->conn, TS_FRONTIER, final_ts);
 }
 
 /*
@@ -419,7 +431,7 @@ node_main(TEST_CONFIG *cfg)
      * event's epoch is above the stable one.
      */
     workload_seed_counter(state, SCHEMA_EPOCH_BOOTSTRAP);
-    set_frontier(state->conn, SCHEMA_EPOCH_BOOTSTRAP);
+    set_ts(state->conn, TS_FRONTIER, SCHEMA_EPOCH_BOOTSTRAP);
     println("Node %" PRIu32 ": starting as %s", cfg->node_id, role->name);
 
     return (node_run(cfg, state, role));

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -43,8 +43,8 @@ reader_step_down(WORKLOAD_STATE *state, uint64_t ts)
     while (__wt_atomic_load_bool(&state->ts_busy))
         __wt_sleep(0, WT_THOUSAND);
 
-    set_stepdown_ts(conn, ts);
-    set_frontier(conn, ts);
+    set_ts(conn, TS_STEPDOWN, ts);
+    set_ts(conn, TS_FRONTIER, ts);
 
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -45,16 +45,17 @@
 #include "test_util.h"
 
 /* Tunables. */
-#define MAX_CKPT_INVL 4 /* checkpoint thread: upper bound on the interval, in seconds */
-#define INSERT_ODDS 64  /* generate an insert: 1 in N visits to a published slot */
+
 /*
- * Generate a drop: 1 in N visits to a published slot. It is the dwell in the published state, so it
- * governs how much data a table accumulates before it is dropped - keep it well above INSERT_ODDS
- * or tables are dropped empty and the verifier has nothing to check.
+ * Generator parameters.
  */
-#define DROP_ODDS 48
-#define GEN_APPLY_RATE_FLOOR 30 /* generator: applied values/second, the multi-node worst case */
-#define GEN_LEAD_MIN 64         /* generator: lead floor, so the workers stay fed */
+#define GEN_INSERT_ODDS 64         /* an insert: 1 in N visits to a published slot */
+#define GEN_DROP_ODDS 48           /* a drop: 1 in N visits to a published slot */
+#define GEN_APPLY_RATE_FLOOR 30    /* applied values/second, the multi-node worst case */
+#define GEN_MIN_LEAD 64            /* lead floor, so the workers stay fed */
+#define GEN_STEPDOWN_MIN_EVENTS 64 /* minimum events a lone node emits during stepdown */
+
+#define MAX_CKPT_INVL 4 /* checkpoint thread: upper bound on the interval, in seconds */
 #define SCHEMA_EPOCH_BOOTSTRAP 1
 #define MAX_NODES 2
 /*
@@ -106,6 +107,17 @@
 
 /* Connection config. */
 #define ENV_CONFIG_DEF "create,statistics=(all),statistics_log=(json,on_close,wait=1)"
+
+/* Timestamp fields accepted by query_ts and set_ts. */
+#define TS_OLDEST 0x01u
+#define TS_STABLE 0x02u
+#define TS_STABLE_SCHEMA_EPOCH 0x04u
+#define TS_STEPDOWN_TIMESTAMP 0x08u
+#define TS_STEPDOWN_SCHEMA_EPOCH 0x10u
+#define TS_LAST_SCHEMA_EPOCH 0x20u
+#define TS_LAST_CHECKPOINT 0x40u
+#define TS_FRONTIER (TS_OLDEST | TS_STABLE | TS_STABLE_SCHEMA_EPOCH)
+#define TS_STEPDOWN (TS_STEPDOWN_TIMESTAMP | TS_STEPDOWN_SCHEMA_EPOCH)
 
 /* Which process this instance of the binary is. */
 typedef enum { ROLE_PARENT = 0, ROLE_NODE } TEST_ROLE;
@@ -279,9 +291,8 @@ typedef struct {
 
 /* main.c */
 void println(const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 1, 2)));
-uint64_t query_ts(WT_CONNECTION *conn, const char *name);
-void set_stepdown_ts(WT_CONNECTION *conn, uint64_t ts);
-void set_frontier(WT_CONNECTION *conn, uint64_t ts);
+uint64_t query_ts(WT_CONNECTION *conn, uint8_t bit);
+void set_ts(WT_CONNECTION *conn, uint8_t mask, uint64_t ts);
 void adopted_lsn_publish(uint32_t node_id, uint64_t lsn);
 uint64_t adopted_lsn_read(void);
 
@@ -294,6 +305,7 @@ void parent_main(TEST_CONFIG *cfg, const char *self_path);
  */
 int node_main(TEST_CONFIG *cfg);
 const NODE_ROLE *node_role(bool leads);
+bool node_is_lone(const TEST_CONFIG *cfg);
 void disagg_opts_init(const TEST_CONFIG *cfg);
 bool node_switch_request_consume(void);
 bool workload_active(WORKLOAD_STATE *state, uint32_t stage);

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -206,7 +206,7 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
 void
 verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
 {
-    const uint64_t durable_epoch = query_ts(conn, "last_disaggregated_schema_epoch");
+    const uint64_t durable_epoch = query_ts(conn, TS_LAST_SCHEMA_EPOCH);
     println("Schema verify: last_disaggregated_schema_epoch = %" PRIu64, durable_epoch);
     /* Nothing durable means no record is below the cutoff, so there is nothing to check. */
     if (durable_epoch == 0) {
@@ -214,7 +214,7 @@ verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
         return;
     }
 
-    const uint64_t last_ckpt_ts = query_ts(conn, "last_checkpoint");
+    const uint64_t last_ckpt_ts = query_ts(conn, TS_LAST_CHECKPOINT);
     println("Schema verify: last_checkpoint_timestamp = %" PRIu64, last_ckpt_ts);
 
     WT_SESSION *session;


### PR DESCRIPTION
- lone nodes: enable schema ops during step-down interval
- small refactoring