### PR TITLE
WT-18412 Harden test_bug018 and test_schema09 against a failure that never fires

### DIFF
--- a/test/suite/helpers/suite_subprocess.py
+++ b/test/suite/helpers/suite_subprocess.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
-import os, re, subprocess, sys
+import os, re, signal, subprocess, sys
 from run import wt_builddir
 from wttest import WiredTigerTestCase
 import wttest
@@ -217,6 +217,30 @@ class suite_subprocess:
         new_home_dir = os.path.join(directory,
             testparts[1] + '.0')
         return [ returncode, new_home_dir ]
+
+    # Assert that a subprocess was stopped by the given signal. WiredTiger raises the signal on
+    # POSIX and aborts on Windows, so the exit status is platform specific. Where the two are
+    # distinguishable, insist on the signal: any other one means the subprocess stopped somewhere
+    # it was not asked to, such as an assertion catching a crash point that was configured but
+    # never reached.
+    def assert_crashed(self, returncode, expected_signal):
+        if os.name == 'nt':
+            self.assertNotEqual(returncode, 0)
+        else:
+            self.assertEqual(returncode, -expected_signal)
+
+    # Run a method as a subprocess that is expected to crash, and return the WiredTiger home
+    # directory it left behind. The signal differs by how WiredTiger stops: __wt_debug_crash kills
+    # the process, an assertion or a panic aborts it.
+    def crash_in_subprocess(self, directory, funcname, expected_signal):
+        # Restrict the subprocess to this test's own scenario, so that each is crashed and asserted
+        # independently. Running the child over the whole list instead crashes it in the first
+        # scenario and never reaches the others. A test without scenarios has no attribute, and
+        # run_subprocess_function takes None to mean it should not restrict the child at all.
+        [ returncode, home ] = self.run_subprocess_function(directory, funcname, silent=True,
+            scenario=getattr(self, 'scenario_number', None))
+        self.assert_crashed(returncode, expected_signal)
+        return home
 
     # Merge a connection configuration string into a wt argument list, combining with an existing
     # -C value when present.

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -28,7 +28,7 @@
 
 from helper import copy_wiredtiger_home
 from suite_subprocess import suite_subprocess
-import os
+import os, signal
 import wiredtiger, wttest
 
 # JIRA WT-3590: if writing table data fails during close then tables
@@ -107,10 +107,10 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
         # Expect an error and messages, so turn off stderr checking.
         self.ignoreStdoutPattern('log_slot_destroy: failed to write slot')
         with self.expectedStderrPattern(''):
-            try:
-                self.close_conn()
-            except wiredtiger.WiredTigerError:
-                self.conn = None
+            # The simulated write failure has to reach the application. Without it this test
+            # verifies recovery of a database that closed cleanly.
+            self.assertRaises(wiredtiger.WiredTigerError, self.close_conn)
+            self.conn = None
 
     def test_bug018(self):
         '''Test closing multiple tables'''
@@ -123,8 +123,16 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
 
         self.close_conn()
         subdir = 'SUBPROCESS'
-        [ignore_result, new_home_dir] = self.run_subprocess_function(subdir,
-            f'{self.test_name}.{self.test_name}.subprocess_bug018')
+        [returncode, new_home_dir] = self.run_subprocess_function(subdir,
+            f'{self.test_name}.{self.test_name}.subprocess_bug018', silent=True)
+
+        # The failed write panics the connection, and a diagnostic build turns that into an abort.
+        # Elsewhere the panic comes back as an error from close, which the subprocess asserts on
+        # before exiting cleanly.
+        if wiredtiger.diagnostic_build():
+            self.assert_crashed(returncode, signal.SIGABRT)
+        else:
+            self.assertEqual(returncode, 0)
 
         # Make a backup for forensics in case something goes wrong.
         backup_dir = 'BACKUP'

--- a/test/suite/test_key_provider_disagg02.py
+++ b/test/suite/test_key_provider_disagg02.py
@@ -25,7 +25,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-import os, signal
+import signal
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from helper_key_provider import KeyProviderBase
 from suite_subprocess import suite_subprocess
@@ -75,26 +75,12 @@ class test_key_provider_disagg02(KeyProviderBase, suite_subprocess):
         self.rotate_key(2)
         self.session.checkpoint(f"debug=(checkpoint_crash_trigger_point={self.crash_point})") # Expected to fail
 
-    def assert_crashed(self, returncode):
-        # WiredTiger kills the process outright on POSIX and aborts on Windows, so the exit status
-        # is platform specific. Where the two are distinguishable, insist on the kill: an abort
-        # means we stopped somewhere we did not ask to.
-        if os.name == 'nt':
-            self.assertNotEqual(returncode, 0)
-        else:
-            self.assertEqual(returncode, -signal.SIGKILL)
-
     def test_key_provider_disagg02(self):
         self.conn.close()
 
-        # Restrict the subprocess to this scenario, otherwise it crashes in the first one and no
-        # other crash point is ever reached.
         subdir = 'SUBPROCESS'
-        [returncode, new_home_dir] = self.run_subprocess_function(subdir,
-            f'{self.test_name}.{self.test_name}.subprocess_func', silent=True,
-            scenario=self.scenario_number)
-
-        self.assert_crashed(returncode)
+        new_home_dir = self.crash_in_subprocess(subdir,
+            f'{self.test_name}.{self.test_name}.subprocess_func', signal.SIGKILL)
 
         # The subprocess wrote to new_home_dir; its turtle reference survived the crash intact.
         self.validate_turtle_page(home=new_home_dir)

--- a/test/suite/test_schema09.py
+++ b/test/suite/test_schema09.py
@@ -26,6 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import signal
 import wttest, wiredtiger
 from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
@@ -89,8 +90,9 @@ class test_schema09(wttest.WiredTigerTestCase, suite_subprocess):
 
         subdir = f'SUBPROCESS_crash_point_{self.crash_point}'
         func = f'{self.test_name}.{self.test_name}.subprocess_crash_point_{self.crash_point}'
-        [ignore_result, new_home_dir] = self.run_subprocess_function(
-            subdir, func, silent=True)
+        # Without asserting the crash the test only notices a crash point that never fired
+        # through the recovery message, which the drop scenarios do not need.
+        new_home_dir = self.crash_in_subprocess(subdir, func, signal.SIGABRT)
 
         with self.expectedStdoutPattern('removing incomplete table'):
             self.conn = self.setUpConnectionOpen(new_home_dir)


### PR DESCRIPTION
## Summary
- `test_bug018` discarded the subprocess exit status, and its only assertion held trivially if the simulated write failure never happened. The subprocess now asserts that close reports the failure, and the parent asserts the exit status.
- `test_schema09` asserts that its crash points abort the subprocess, instead of noticing a dead crash point only through a recovery message that two of its four scenarios do not need.
- Factors the assertion into `suite_subprocess`

🤖 Generated with [Claude Code](https://claude.com/claude-code)