### PR TITLE
WT-18433 Report the block header fields on a read checksum mismatch

### DIFF
--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -90,6 +90,66 @@ err:
 }
 
 /*
+ * __block_header_report --
+ *     Decode the headers of a block that failed its checksum into a diagnostic string. The size the
+ *     block declares for itself is the discriminator: a block agreeing with the address cookie is
+ *     the block we asked for with damaged bytes, while a block disagreeing with it is a
+ *     structurally valid block of a different size sitting at that offset, which implicates the
+ *     storage stack rather than the media and needs an entirely different remediation.
+ */
+static void
+__block_header_report(
+  const void *image, const WT_BLOCK_HEADER *blk, uint32_t size, char *dst, size_t dst_size)
+{
+    WT_PAGE_HEADER dsk;
+
+    /*
+     * The page header is only byte-swapped once a block passes its checksum, so decode a copy of
+     * it. The block header is the caller's byte-swapped copy: the one in the image may already have
+     * had its checksum cleared.
+     */
+    memcpy(&dsk, image, sizeof(dsk));
+    __wt_page_header_byteswap(&dsk);
+
+    /*
+     * None of these fields is trusted enough to size or index anything with, so every one of them
+     * is formatted as a fixed-width integer or a bounded string.
+     */
+    WT_IGNORE_RET(__wt_snprintf(dst, dst_size,
+      "%s%s: block header disk_size %" PRIu32 ", requested size %" PRIu32 ", flags %#" PRIx8
+      "; page header mem_size %" PRIu32 ", write_gen %" PRIu64 ", entries %" PRIu32 ", type %" PRIu8
+      " (%s), flags %#" PRIx8 ", version %" PRIu8,
+      blk->disk_size == size ? "HEADER_SIZE_MATCH" : "HEADER_SIZE_MISMATCH",
+      F_ISSET(&dsk, WT_PAGE_COMPRESSED) && dsk.mem_size <= blk->disk_size ?
+        " IMPLAUSIBLE_MEM_SIZE" :
+        "",
+      blk->disk_size, size, blk->flags, dsk.mem_size, dsk.write_gen, dsk.u.entries, dsk.type,
+      __wt_page_type_str(dsk.type), dsk.flags, dsk.version));
+}
+
+/*
+ * __block_checksum_bitflip_detect --
+ *     Check whether the checksum stored in the block header differs from the expected checksum by
+ *     exactly one bit. Scanning the block cannot answer this, because a scan assumes the stored
+ *     checksum is the one the write path computed.
+ */
+static bool
+__block_checksum_bitflip_detect(uint32_t stored, uint32_t expected, size_t *bit_position)
+{
+    size_t bit;
+    uint32_t diff;
+
+    diff = stored ^ expected;
+    if (diff == 0 || (diff & (diff - 1)) != 0)
+        return (false);
+
+    for (bit = 0; (diff & (1U << bit)) == 0; ++bit)
+        ;
+    *bit_position = bit;
+    return (true);
+}
+
+/*
  * __block_bitflip_detect --
  *     Check if flipping a single bit in the data would match the expected checksum. This helps
  *     diagnose single-bit memory corruption. Skip check for blocks larger than a defined size to
@@ -172,7 +232,7 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
   wt_off_t offset, uint32_t size, uint32_t checksum)
 {
     WT_BLOCK_HEADER *blk, swap;
-    size_t bufsize, check_size;
+    size_t bit_position, bufsize, check_size;
     uint64_t time_start, time_stop;
     bool full_checksum_mismatch;
 
@@ -231,6 +291,8 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
     }
 
     if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE)) {
+        char header_report[512];
+
         if (full_checksum_mismatch)
             __wt_errx_id(session, 1538000,
               "%s: potential hardware corruption, read checksum error for %" PRIu32
@@ -245,6 +307,16 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
               block->name, size, (uintmax_t)offset, swap.checksum, checksum);
 
         /*
+         * Report what the block says about itself. The classification this gives us is only
+         * available while the block is in hand: these events happen once and cannot be repeated,
+         * and the raw dump below is often unusable because it can hold user data.
+         */
+        __block_header_report(buf->mem, &swap, size, header_report, sizeof(header_report));
+        __wt_errx_id(session, 1843300,
+          "%s: read checksum error diagnostic for %" PRIu32 "B block at offset %" PRIuMAX ": %s",
+          block->name, size, (uintmax_t)offset, header_report);
+
+        /*
          * Dump the corrupted block for analysis prior to bitflip detection in case detection takes
          * too long.
          */
@@ -256,11 +328,13 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
         __fs_free_space_dump(session, block);
 
         /*
-         * Attempt to detect single-bit flips in the data. This can help diagnose memory corruption
-         * issues.
+         * Attempt to detect single-bit flips. On the full mismatch branch the stored checksum
+         * agreed with the cookie, so any flip has to be in the block itself; on the block header
+         * branch the stored checksum is what disagreed, so the only single-bit explanation is a
+         * flip in that field, which no scan of the block can find.
          */
+        bit_position = 0;
         if (full_checksum_mismatch) {
-            size_t bit_position = 0;
             if (__block_bitflip_detect(buf->mem, check_size, checksum, &bit_position))
                 __wt_errx(session,
                   "%s: single-bit flip detected at bit position %" WT_SIZET_FMT
@@ -270,6 +344,16 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
             else
                 __wt_errx(session, "%s: bitflip detection performed but no single-bit flip found",
                   block->name);
+        } else if (__block_checksum_bitflip_detect(swap.checksum, checksum, &bit_position)) {
+            __wt_errx(session,
+              "%s: single-bit flip detected in the stored block header checksum at bit "
+              "position %" WT_SIZET_FMT,
+              block->name, bit_position);
+        } else {
+            __wt_errx(session,
+              "%s: the stored block header checksum is not a single-bit flip of the expected "
+              "checksum",
+              block->name);
         }
     }
 
@@ -344,5 +428,18 @@ __ut_block_bitflip_detect(
   void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
 {
     return (__block_bitflip_detect(data, check_size, expected_checksum, bit_position));
+}
+
+void
+__ut_block_header_report(
+  const void *image, const WT_BLOCK_HEADER *blk, uint32_t size, char *dst, size_t dst_size)
+{
+    __block_header_report(image, blk, size, dst, dst_size);
+}
+
+bool
+__ut_block_checksum_bitflip_detect(uint32_t stored, uint32_t expected, size_t *bit_position)
+{
+    return (__block_checksum_bitflip_detect(stored, expected, bit_position));
 }
 #endif

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2763,6 +2763,8 @@ extern WT_EXT *__ut_block_off_srch_last(WT_EXT **head, WT_EXT ***stack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_bitflip_detect(void *data, size_t check_size, uint32_t expected_checksum,
   size_t *bit_position) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __ut_block_checksum_bitflip_detect(uint32_t stored, uint32_t expected,
+  size_t *bit_position) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_disagg_header_version_compatible(uint8_t compatible_version)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_first_srch(WT_SESSION_IMPL *session, WT_EXT **head, wt_off_t size,
@@ -2822,6 +2824,8 @@ extern int __ut_layered_derive_layered_uri(WT_SESSION_IMPL *session, const char 
 extern int __ut_verify_compare_page_id_lists(WT_SESSION_IMPL *session, uint64_t *btree_ids,
   size_t num_btree, const uint64_t *pali_ids, size_t num_pali)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __ut_block_header_report(
+  const void *image, const WT_BLOCK_HEADER *blk, uint32_t size, char *dst, size_t dst_size);
 extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bool skip_off);
 extern void __ut_block_off_srch_pair(
   WT_EXTLIST *el, wt_off_t off, WT_EXT **beforep, WT_EXT **afterp);

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
         block/unit/test_block_bitflip.cpp
         block/unit/test_block_ckpt.cpp
         block/unit/test_block_file.cpp
+        block/unit/test_block_header_report.cpp
         block/unit/test_block_other.cpp
         block/unit/test_block_session_bms.cpp
         block/unit/test_block_session_ext.cpp

--- a/test/catch2/block/unit/test_block_bitflip.cpp
+++ b/test/catch2/block/unit/test_block_bitflip.cpp
@@ -315,3 +315,45 @@ TEST_CASE("Block bitflip detection: data integrity", "[block_bitflip]")
         }
     }
 }
+
+TEST_CASE("Block bitflip detection: the stored checksum itself", "[block_bitflip]")
+{
+    size_t bit_position = 0;
+
+    SECTION("A stored checksum one bit away from the expected one is detected")
+    {
+        for (size_t bit = 0; bit < 32; ++bit) {
+            uint32_t expected = 0xdeadbeef;
+            uint32_t stored = expected ^ (UINT32_C(1) << bit);
+
+            bit_position = 0;
+            CHECK(__ut_block_checksum_bitflip_detect(stored, expected, &bit_position) == true);
+            CHECK(bit_position == bit);
+        }
+    }
+
+    SECTION("A stored checksum matching the expected one is not a flip")
+    {
+        CHECK(__ut_block_checksum_bitflip_detect(0xdeadbeef, 0xdeadbeef, &bit_position) == false);
+    }
+
+    SECTION("A stored checksum two bits away from the expected one is not a flip")
+    {
+        CHECK(
+          __ut_block_checksum_bitflip_detect(0xdeadbeef ^ 0x9, 0xdeadbeef, &bit_position) == false);
+    }
+
+    SECTION("An unrelated stored checksum is not a flip")
+    {
+        CHECK(__ut_block_checksum_bitflip_detect(0, 0xdeadbeef, &bit_position) == false);
+    }
+
+    SECTION("The highest and lowest bits are both reachable")
+    {
+        CHECK(__ut_block_checksum_bitflip_detect(0x1, 0x0, &bit_position) == true);
+        CHECK(bit_position == 0);
+
+        CHECK(__ut_block_checksum_bitflip_detect(0x80000000, 0x0, &bit_position) == true);
+        CHECK(bit_position == 31);
+    }
+}

--- a/test/catch2/block/unit/test_block_header_report.cpp
+++ b/test/catch2/block/unit/test_block_header_report.cpp
@@ -1,0 +1,170 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * [block_header_report]: block_read.c
+ * This file unit tests the diagnostic reported when a block fails its checksum. The classification
+ * that matters is whether the size the block declares for itself agrees with the size that was
+ * asked for: agreement means the expected block arrived damaged, disagreement means a different
+ * block arrived instead.
+ */
+
+#include <catch2/catch.hpp>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "wt_internal.h"
+
+namespace {
+
+/*
+ * Build a block image whose page header holds the supplied fields. The image is in on-disk order,
+ * which is what the reporting code is handed.
+ */
+std::vector<uint8_t>
+build_image(uint32_t mem_size, uint64_t write_gen, uint32_t entries, uint8_t type, uint8_t flags,
+  uint8_t version)
+{
+    std::vector<uint8_t> image(WT_BLOCK_HEADER_BYTE_SIZE, 0);
+    WT_PAGE_HEADER dsk;
+
+    memset(&dsk, 0, sizeof(dsk));
+    dsk.mem_size = mem_size;
+    dsk.write_gen = write_gen;
+    dsk.u.entries = entries;
+    dsk.type = type;
+    dsk.flags = flags;
+    dsk.version = version;
+
+    /* The byte-swap is its own inverse, so this converts host order to on-disk order. */
+    __wt_page_header_byteswap(&dsk);
+    memcpy(image.data(), &dsk, sizeof(dsk));
+
+    return image;
+}
+
+/* The block header reaches the reporting code already byte-swapped, so it needs no conversion. */
+std::string
+report(const std::vector<uint8_t> &image, uint32_t disk_size, uint8_t flags, uint32_t size,
+  size_t dst_size = 512)
+{
+    WT_BLOCK_HEADER blk;
+    std::vector<char> dst(dst_size, 'x');
+
+    memset(&blk, 0, sizeof(blk));
+    blk.disk_size = disk_size;
+    blk.flags = flags;
+
+    __ut_block_header_report(image.data(), &blk, size, dst.data(), dst.size());
+
+    /* The formatting is not allowed to run off the end of the buffer. */
+    REQUIRE(memchr(dst.data(), '\0', dst.size()) != nullptr);
+    return std::string(dst.data());
+}
+
+} // namespace
+
+TEST_CASE("Block header report: size classification", "[block_header_report]")
+{
+    SECTION("A block declaring the size that was asked for is the expected block, damaged")
+    {
+        auto image =
+          build_image(8192, 42, 71, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 4096);
+
+        CHECK(s.find("HEADER_SIZE_MATCH") == 0);
+        CHECK(s.find("HEADER_SIZE_MISMATCH") == std::string::npos);
+        CHECK(s.find("disk_size 4096") != std::string::npos);
+        CHECK(s.find("requested size 4096") != std::string::npos);
+    }
+
+    SECTION("A block declaring a different size is a different block")
+    {
+        auto image =
+          build_image(24576, 99, 130, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 12288);
+
+        CHECK(s.find("HEADER_SIZE_MISMATCH") == 0);
+        CHECK(s.find("disk_size 4096") != std::string::npos);
+        CHECK(s.find("requested size 12288") != std::string::npos);
+    }
+
+    SECTION("The decoded header fields are reported")
+    {
+        auto image =
+          build_image(8192, 42, 71, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 4096);
+
+        CHECK(s.find("mem_size 8192") != std::string::npos);
+        CHECK(s.find("write_gen 42") != std::string::npos);
+        CHECK(s.find("entries 71") != std::string::npos);
+        CHECK(s.find("WT_PAGE_ROW_LEAF") != std::string::npos);
+        CHECK(s.find("version 1") != std::string::npos);
+    }
+
+    SECTION("A page type outside the known set is named rather than dropped")
+    {
+        auto image = build_image(8192, 42, 71, 0xdb, 0, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 4096);
+
+        CHECK(s.find("type 219 (PAGE_TYPE_INVALID)") != std::string::npos);
+    }
+}
+
+TEST_CASE("Block header report: in-memory size plausibility", "[block_header_report]")
+{
+    SECTION("A compressed block no larger in memory than on disk is called out")
+    {
+        auto image =
+          build_image(4096, 42, 71, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 4096);
+
+        CHECK(s.find("IMPLAUSIBLE_MEM_SIZE") != std::string::npos);
+    }
+
+    SECTION("An uncompressed block no larger in memory than on disk is not called out")
+    {
+        auto image = build_image(4096, 42, 71, WT_PAGE_ROW_LEAF, 0, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 4096);
+
+        CHECK(s.find("IMPLAUSIBLE_MEM_SIZE") == std::string::npos);
+    }
+
+    SECTION("A compressed block larger in memory than on disk is not called out")
+    {
+        auto image =
+          build_image(8192, 42, 71, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 4096);
+
+        CHECK(s.find("IMPLAUSIBLE_MEM_SIZE") == std::string::npos);
+    }
+}
+
+TEST_CASE("Block header report: extreme values", "[block_header_report]")
+{
+    SECTION("Wild sizes are reported, not acted on")
+    {
+        auto image = build_image(
+          UINT32_MAX, UINT64_MAX, UINT32_MAX, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, 0xff);
+        std::string s = report(image, UINT32_MAX, 0xff, 4096);
+
+        CHECK(s.find("HEADER_SIZE_MISMATCH") == 0);
+        CHECK(s.find("mem_size 4294967295") != std::string::npos);
+        CHECK(s.find("write_gen 18446744073709551615") != std::string::npos);
+    }
+
+    SECTION("A buffer too small to hold the report is truncated, not overrun")
+    {
+        auto image =
+          build_image(8192, 42, 71, WT_PAGE_ROW_LEAF, WT_PAGE_COMPRESSED, WT_PAGE_VERSION_TS);
+        std::string s = report(image, 4096, WT_BLOCK_DATA_CKSUM, 12288, 8);
+
+        CHECK(s == "HEADER_");
+    }
+}

--- a/test/suite/test_corrupt03.py
+++ b/test/suite/test_corrupt03.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re, struct
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+# Offsets of the block header fields within a block, and the first byte past both headers. The
+# on-disk byte order is little-endian regardless of the host.
+DISK_SIZE_OFFSET = 28
+CHECKSUM_OFFSET = 32
+PAYLOAD_OFFSET = 40
+
+# A block that fails its checksum is reported along with the fields decoded from the header it just
+# read. Whether the size the block claims for itself agrees with the size that was asked for
+# separates damage to the expected block from a different block arriving in its place, and the two
+# need entirely different remediation.
+@wttest.skip_for_hook("tiered", "corrupts local block files not used by tiered storage")
+@wttest.skip_for_hook("disagg", "corrupts blocks which are not relevant for disagg")
+class test_corrupt03(wttest.WiredTigerTestCase, suite_subprocess):
+    test_name = __qualname__
+    uri = f'table:{test_name}'
+    tablename = f'{test_name}.wt'
+    conn_config = 'cache_size=50MB,debug_mode=(corruption_abort=false)'
+    table_config = 'key_format=i,value_format=S,allocation_size=512B,leaf_page_max=4KB'
+    num_kv = 5000
+
+    scenarios = make_scenarios([
+        ('payload', dict(corrupt='payload')),
+        ('disk_size', dict(corrupt='disk_size')),
+        ('checksum_bit', dict(corrupt='checksum_bit')),
+    ])
+
+    def leaf_block(self):
+        """
+        Return the on-disk (offset, size) of a leaf block, taken from the addresses the wt utility
+        prints for the checkpoint.
+        """
+        dump_file = 'dump_output.txt'
+        self.runWt(['verify', '-d', 'dump_address', self.uri], outfilename=dump_file,
+            closeconn=False)
+
+        with open(dump_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if 'row-store leaf' not in line:
+                    continue
+                # An address looks like "[0: 708608-737280, 28672, 2171724032]".
+                match = re.search(r'\[\d+: (\d+)-\d+, (\d+), \d+\]', line)
+                if match:
+                    return int(match.group(1)), int(match.group(2))
+
+        self.fail("no leaf block address found in the dump output")
+
+    def corrupt_block(self, offset, size):
+        """
+        Damage a leaf block in the way this scenario calls for.
+        """
+        with open(self.tablename, 'r+b') as f:
+            if self.corrupt == 'payload':
+                # Past both headers, but inside the first 64 bytes, which the checksum always
+                # covers whether or not it extends over the whole block.
+                f.seek(offset + PAYLOAD_OFFSET)
+                original = f.read(8)
+                f.seek(offset + PAYLOAD_OFFSET)
+                f.write(bytes(b ^ 0xff for b in original))
+            elif self.corrupt == 'disk_size':
+                # Leave the block otherwise intact, but have it claim a size the address cookie
+                # does not: that is what a valid block from a different offset looks like.
+                f.seek(offset + DISK_SIZE_OFFSET)
+                f.write(struct.pack('<I', size * 2))
+            else:
+                # A single bit in the stored checksum, which no scan of the block can find.
+                f.seek(offset + CHECKSUM_OFFSET)
+                original = f.read(1)
+                f.seek(offset + CHECKSUM_OFFSET)
+                f.write(bytes([original[0] ^ 0x04]))
+
+    def expected_messages(self, size):
+        if self.corrupt == 'payload':
+            return [
+                'calculated block checksum',
+                'HEADER_SIZE_MATCH',
+                f'disk_size {size}',
+                f'requested size {size}',
+            ]
+        if self.corrupt == 'disk_size':
+            return [
+                'HEADER_SIZE_MISMATCH',
+                f'disk_size {size * 2}',
+                f'requested size {size}',
+            ]
+        return [
+            'block header checksum',
+            'HEADER_SIZE_MATCH',
+            'single-bit flip detected in the stored block header checksum',
+        ]
+
+    def test_corrupt03(self):
+        self.session.create(self.uri, self.table_config)
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(self.num_kv):
+            cursor[i] = 'a' * 100
+        cursor.close()
+        self.session.checkpoint()
+        self.conn.close()
+
+        offset, size = self.leaf_block()
+        self.corrupt_block(offset, size)
+
+        corrupt_conn = None
+        try:
+            corrupt_conn = self.setUpConnectionOpen('.')
+            session = self.setUpSessionOpen(corrupt_conn)
+            cursor = session.open_cursor(self.uri)
+            while cursor.next() == 0:
+                continue
+            self.fail("reading the corrupt block should have failed")
+        except wiredtiger.WiredTigerError:
+            pass
+        finally:
+            if corrupt_conn is not None:
+                self.assertRaises(
+                    wiredtiger.WiredTigerError, lambda: corrupt_conn.close())
+
+        stderr = self.readStderr(maxchars=1000000)
+        for message in self.expected_messages(size):
+            self.assertTrue(message in stderr,
+                f'"{message}" missing from the corrupt-block report')
+
+        self.ignoreStdoutPatternIfExists('extent list')
+        self.ignoreStderrPatternIfExists('checksum error')


### PR DESCRIPTION
When a block read fails its checksum, `__wti_block_read_off()` reported the two checksums and dumped the raw block, but never the fields already sitting in the header it had just read — in particular it never compared the header's `disk_size` against the size in the address cookie. That one comparison separates the right block with damaged bytes (bit rot; the existing flip scan is the right next step) from a structurally valid block of a different size at that offset (a stale, misdirected or lost read/write, where flip analysis is meaningless). Both previously printed the same line, so telling them apart took a manual hex decode of a dump that can contain user data.

Adds a separate `__wt_errx_id(session, 1843300, ...)` line carrying the decoded headers and a greppable verdict:

```
HEADER_SIZE_MISMATCH: block header disk_size 7168, requested size 3584, flags 0x1;
page header mem_size 3505, write_gen 2, entries 66, type 7 (WT_PAGE_ROW_LEAF), flags 0x4, version 1
```

On the block header checksum branch, where no scan runs today, the stored checksum is also tested for being one bit off the expected one — no scan can find that flip, because a scan assumes the stored checksum is the one the write path computed.

Diagnostic output only: the read still fails and still panics.