### PR TITLE
WT-17996 Perform a schema drop of a layered table without reopening a closed btree.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -479,39 +479,6 @@ __wt_btree_config_encryptor(
 }
 
 /*
- * __btree_setup_page_log --
- *     Configure a WT_BTREE page log.
- */
-static int
-__btree_setup_page_log(WT_SESSION_IMPL *session, WT_BTREE *btree)
-{
-    WT_CONFIG_ITEM page_log_item;
-    WT_DECL_RET;
-    WT_NAMED_PAGE_LOG *npage_log;
-    const char **cfg;
-
-    cfg = btree->dhandle->cfg;
-
-    /* Setup any configured page log on the data handle */
-    ret = __wt_config_gets(session, cfg, "disaggregated.page_log", &page_log_item);
-    WT_RET_NOTFOUND_OK(ret);
-    if (ret == WT_NOTFOUND || page_log_item.len == 0) {
-        npage_log = S2C(session)->disaggregated_storage.npage_log;
-        if (npage_log != NULL)
-            btree->page_log = npage_log->page_log;
-        return (0);
-    }
-
-    WT_RET(__wt_schema_open_page_log(session, &page_log_item, &npage_log));
-    if (npage_log == NULL)
-        return (0);
-
-    btree->page_log = npage_log->page_log;
-
-    return (0);
-}
-
-/*
  * __btree_conf --
  *     Configure a WT_BTREE structure.
  */
@@ -638,7 +605,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
                   "a live stable table cannot be opened on a follower");
             }
 
-            WT_RET(__btree_setup_page_log(session, btree));
+            WT_RET(
+              __wt_schema_page_log_from_config(session, btree->dhandle->cfg, &btree->page_log));
 
             /* A page log service and a storage source cannot both be enabled. */
             WT_ASSERT(session, btree->page_log == NULL || btree->bstorage == NULL);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1008,6 +1008,8 @@ extern int __wt_schema_open_storage_source(WT_SESSION_IMPL *session, WT_CONFIG_I
   WT_NAMED_STORAGE_SOURCE **nstoragep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_open_table(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_schema_page_log_from_config(WT_SESSION_IMPL *session, const char *cfg[],
+  WT_PAGE_LOG **page_logp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_project_in(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *proj_arg,
   va_list ap) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_project_merge(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *proj_arg,

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -134,30 +134,62 @@ __drop_index(
 static int
 __drop_issue_trim(WT_SESSION_IMPL *session, const char *uri)
 {
+    WT_BTREE *btree;
+    WT_CONFIG_ITEM cval;
     WT_DECL_RET;
+    WT_PAGE_LOG *page_log;
+    uint32_t btree_id;
+    char *config;
+    const char *cfg[2];
 
-    /* Get the layered data handle. */
-    ret = __wt_session_get_dhandle(session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE);
+    config = NULL;
+
+    /* Lock the handle without opening it to avoid any storage accesses. */
+    ret = __wt_session_get_dhandle(
+      session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_LOCK_ONLY);
     if (ret == EBUSY)
         WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_RET(ret);
 
-    WT_BTREE *btree = S2BT(session);
-
     /*
-     * A table awaiting publication has never been checkpointed, so closing its handle loses any
-     * committed data it holds. Refuse the drop until a checkpoint has persisted the data, so this
-     * table behaves like a regular table, which returns EBUSY when it holds uncheckpointed data.
+     * A handle that was never opened carries no configuration, so read the metadata directly. The
+     * caller expects ENOENT for an unknown table.
      */
-    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_AWAITS_PUBLISH) &&
-      __wt_atomic_load_uint64_relaxed(&btree->min_unpublished_durable_ts) != WT_TS_NONE)
-        WT_ERR_SUB(session, EBUSY, WT_DIRTY_DATA,
-          "the table has unpublished data and must be checkpointed before it can be dropped");
+    if ((ret = __wt_metadata_search(session, uri, &config)) != 0) {
+        if (ret == WT_NOTFOUND)
+            ret = __wt_set_return(session, ENOENT);
+        WT_ERR(ret);
+    }
 
-    if (btree->page_log == NULL)
+    cfg[0] = config;
+    cfg[1] = NULL;
+
+    WT_ERR(__wt_config_getones(session, config, "id", &cval));
+    btree_id = (uint32_t)cval.val;
+    WT_ERR(__wt_schema_page_log_from_config(session, cfg, &page_log));
+
+    /* If the btree was already opened, the configuration we just got must agree. */
+    if (F_ISSET(session->dhandle, WT_DHANDLE_OPEN)) {
+        btree = S2BT(session);
+        WT_ASSERT(session, btree_id == btree->id && page_log == btree->page_log);
+
+        /*
+         * A table awaiting publication has never been checkpointed, so closing its handle loses any
+         * committed data it holds. Refuse the drop until a checkpoint has persisted the data, so
+         * this table behaves like a regular table, which returns EBUSY when it holds uncheckpointed
+         * data. Only an open handle can be awaiting publication: uncheckpointed data keeps sweep
+         * from closing it and does not survive a restart.
+         */
+        if (F_ISSET_ATOMIC_32(btree, WT_BTREE_AWAITS_PUBLISH) &&
+          __wt_atomic_load_uint64_relaxed(&btree->min_unpublished_durable_ts) != WT_TS_NONE)
+            WT_ERR_SUB(session, EBUSY, WT_DIRTY_DATA,
+              "the table has unpublished data and must be checkpointed before it can be dropped");
+    }
+
+    if (page_log == NULL)
         WT_ERR(ENOTSUP);
 
-    if (btree->page_log->pl_trim_table == NULL) {
+    if (page_log->pl_trim_table == NULL) {
         __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE, "%s",
           "Trim table is not supported by the current PALI implementation");
         ret = 0;
@@ -170,9 +202,10 @@ __drop_issue_trim(WT_SESSION_IMPL *session, const char *uri)
      *
      * FIXME-WT-16527: Set start LSN once implemented.
      */
-    WT_ERR(btree->page_log->pl_trim_table(btree->page_log, &session->iface, btree->id, 0, NULL));
+    WT_ERR(page_log->pl_trim_table(page_log, &session->iface, btree_id, 0, NULL));
 
 err:
+    __wt_free(session, config);
     WT_TRET(__wt_session_release_dhandle(session));
     return (ret);
 }

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -415,6 +415,34 @@ __wt_schema_open_page_log(
 }
 
 /*
+ * __wt_schema_page_log_from_config --
+ *     Return the page log named by a table's configuration, or the connection's page log if the
+ *     table does not name one.
+ */
+int
+__wt_schema_page_log_from_config(
+  WT_SESSION_IMPL *session, const char *cfg[], WT_PAGE_LOG **page_logp)
+{
+    WT_CONFIG_ITEM cval;
+    WT_DECL_RET;
+    WT_NAMED_PAGE_LOG *npage_log;
+
+    *page_logp = NULL;
+
+    ret = __wt_config_gets(session, cfg, "disaggregated.page_log", &cval);
+    WT_RET_NOTFOUND_OK(ret);
+    if (ret == WT_NOTFOUND || cval.len == 0)
+        npage_log = S2C(session)->disaggregated_storage.npage_log;
+    else
+        WT_RET(__wt_schema_open_page_log(session, &cval, &npage_log));
+
+    if (npage_log != NULL)
+        *page_logp = npage_log->page_log;
+
+    return (0);
+}
+
+/*
  * __wt_schema_open_storage_source --
  *     Return a storage source if configured. This doesn't really belong here, but it's shared
  *     between btree and tiered handle configuration, so I could not think of somewhere better.

--- a/test/suite/test_layered_drop01.py
+++ b/test/suite/test_layered_drop01.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_drop01.py
+# Dropping a layered table on a leader must not read from the page log.
+#
+# A replicated drop holds an oplog slot for the duration of the call, so any
+# synchronous page-log read it performs shows up as replication lag. When the
+# table's data handle is not currently open, the drop has to open it, and
+# opening the stable btree fetches its root page.
+
+import time
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+@disagg_test_class
+class test_layered_drop01(wttest.WiredTigerTestCase):
+    nitems = 5000
+    uri = 'layered:drop01'
+
+    conn_base_config = 'statistics=(all),' + \
+        'file_manager=(close_idle_time=1,close_scan_interval=1,close_handle_minimum=0),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def populate_and_checkpoint(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            cursor['key ' + str(i)] = 'value ' + str(i)
+        cursor.close()
+
+        self.session.checkpoint()
+
+    # The number of page-log reads a drop performs, measured with nothing else
+    # running against the table.
+    def reads_during_drop(self):
+        before = self.get_stat(stat.conn.disagg_block_get)
+        self.session.drop(self.uri, None)
+        after = self.get_stat(stat.conn.disagg_block_get)
+
+        with self.assertRaises(wiredtiger.WiredTigerError):
+            self.session.open_cursor(self.uri, None, None)
+
+        return after - before
+
+    def test_drop_after_conn_reopen(self):
+        self.populate_and_checkpoint()
+
+        # Reopening the connection leaves the table's data handles closed, the
+        # state the drop must not have to read its way out of.
+        self.reopen_conn()
+
+        self.assertEqual(self.reads_during_drop(), 0,
+            'dropping a layered table with a closed data handle read from the page log')
+
+    def test_drop_after_sweep(self):
+        self.populate_and_checkpoint()
+
+        # Wait for the sweep server to close the idle data handles. Everything
+        # created above is clean and unreferenced once the cursor is closed and
+        # the checkpoint has run, so the handle count returns to what the
+        # connection needs for its own metadata.
+        baseline = self.get_stat(stat.conn.dh_conn_handle_count)
+        deadline = time.time() + 30
+        while True:
+            self.session.reset()
+            count = self.get_stat(stat.conn.dh_conn_handle_count)
+            if self.get_stat(stat.conn.dh_sweep_expired_close) > 0 and count < baseline:
+                break
+            self.assertLess(time.time(), deadline,
+                'timed out waiting for sweep to close idle data handles')
+            time.sleep(0.5)
+
+        self.assertEqual(self.reads_during_drop(), 0,
+            'dropping a layered table with a swept data handle read from the page log')
+
+    def test_drop_with_open_handle(self):
+        # A control for the two cases above: with the data handle still open the
+        # drop reads nothing, so a read there is attributable to the reopen.
+        self.populate_and_checkpoint()
+
+        self.assertEqual(self.reads_during_drop(), 0,
+            'dropping a layered table with an open data handle read from the page log')

--- a/test/suite/test_layered_drop01.py
+++ b/test/suite/test_layered_drop01.py
@@ -27,12 +27,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # test_layered_drop01.py
-# Dropping a layered table on a leader must not read from the page log.
-#
-# A replicated drop holds an oplog slot for the duration of the call, so any
-# synchronous page-log read it performs shows up as replication lag. When the
-# table's data handle is not currently open, the drop has to open it, and
-# opening the stable btree fetches its root page.
+# Dropping a layered table must not read from the page log.
+# If an existing table has been closed by the connection sweep, we want to make
+# sure that a drop does not reopen the table while getting exclusive access to it.
 
 import time
 import wiredtiger, wttest
@@ -62,13 +59,14 @@ class test_layered_drop01(wttest.WiredTigerTestCase):
 
         self.session.checkpoint()
 
-    # The number of page-log reads a drop performs, measured with nothing else
-    # running against the table.
+    # Returns the number of block reads a drop performs
     def reads_during_drop(self):
         before = self.get_stat(stat.conn.disagg_block_get)
         self.session.drop(self.uri, None)
         after = self.get_stat(stat.conn.disagg_block_get)
 
+        # Ensure that the table has really been dropped,
+        # expect an error on reopen.
         with self.assertRaises(wiredtiger.WiredTigerError):
             self.session.open_cursor(self.uri, None, None)
 
@@ -77,8 +75,7 @@ class test_layered_drop01(wttest.WiredTigerTestCase):
     def test_drop_after_conn_reopen(self):
         self.populate_and_checkpoint()
 
-        # Reopening the connection leaves the table's data handles closed, the
-        # state the drop must not have to read its way out of.
+        # Reopening the connection leaves the table's data handles closed.
         self.reopen_conn()
 
         self.assertEqual(self.reads_during_drop(), 0,
@@ -87,10 +84,8 @@ class test_layered_drop01(wttest.WiredTigerTestCase):
     def test_drop_after_sweep(self):
         self.populate_and_checkpoint()
 
-        # Wait for the sweep server to close the idle data handles. Everything
-        # created above is clean and unreferenced once the cursor is closed and
-        # the checkpoint has run, so the handle count returns to what the
-        # connection needs for its own metadata.
+        # Wait for the sweep server to close idle data handles.  The populated
+        # table has no cursors open, so it should be closed.
         baseline = self.get_stat(stat.conn.dh_conn_handle_count)
         deadline = time.time() + 30
         while True:
@@ -106,8 +101,7 @@ class test_layered_drop01(wttest.WiredTigerTestCase):
             'dropping a layered table with a swept data handle read from the page log')
 
     def test_drop_with_open_handle(self):
-        # A control for the two cases above: with the data handle still open the
-        # drop reads nothing, so a read there is attributable to the reopen.
+        # With the data handle still open we expect the drop to read nothing.
         self.populate_and_checkpoint()
 
         self.assertEqual(self.reads_during_drop(), 0,


### PR DESCRIPTION
Includes a new test that shows the (now fixed) problem.