### PR TITLE
WT-18432 Make the compressor stored-length check overflow-safe

### DIFF
--- a/ext/compressors/lz4/lz4_compress.c
+++ b/ext/compressors/lz4/lz4_compress.c
@@ -188,9 +188,8 @@ lz4_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *src, siz
 #endif
 
     /*
-     * The stored length is only as trustworthy as the bytes on disk, so bound it with a
-     * subtraction: where size_t is 32 bits, adding the prefix wraps for stored lengths close to
-     * UINT32_MAX.
+     * We avoid the risk of overflow by using subtraction in this check. The stored size comes from
+     * disk, and if it is corrupted it might be close to the maximum integer value.
      */
     if (prefix.compressed_len > src_len - sizeof(LZ4_PREFIX)) {
         (void)wt_api->err_printf(

--- a/ext/compressors/lz4/lz4_compress.c
+++ b/ext/compressors/lz4/lz4_compress.c
@@ -172,6 +172,12 @@ lz4_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *src, siz
 
     wt_api = ((LZ4_COMPRESSOR *)compressor)->wt_api;
 
+    if (src_len < sizeof(LZ4_PREFIX)) {
+        (void)wt_api->err_printf(
+          wt_api, session, "WT_COMPRESSOR.decompress: source size is smaller than the size prefix");
+        return (WT_ERROR);
+    }
+
     /*
      * Retrieve the true length of the compressed block and source and the decompressed bytes to
      * return from the start of the source buffer.
@@ -180,7 +186,13 @@ lz4_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *src, siz
 #ifdef WORDS_BIGENDIAN
     lz4_prefix_swap(&prefix);
 #endif
-    if (prefix.compressed_len + sizeof(LZ4_PREFIX) > src_len) {
+
+    /*
+     * The stored length is only as trustworthy as the bytes on disk, so bound it with a
+     * subtraction: where size_t is 32 bits, adding the prefix wraps for stored lengths close to
+     * UINT32_MAX.
+     */
+    if (prefix.compressed_len > src_len - sizeof(LZ4_PREFIX)) {
         (void)wt_api->err_printf(
           wt_api, session, "WT_COMPRESSOR.decompress: stored size exceeds source size");
         return (WT_ERROR);

--- a/ext/compressors/snappy/snappy_compress.c
+++ b/ext/compressors/snappy/snappy_compress.c
@@ -160,6 +160,12 @@ snappy_decompression(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *sr
 
     wt_api = ((SNAPPY_COMPRESSOR *)compressor)->wt_api;
 
+    if (src_len < SNAPPY_PREFIX) {
+        (void)wt_api->err_printf(
+          wt_api, session, "WT_COMPRESSOR.decompress: source size is smaller than the size prefix");
+        return (WT_ERROR);
+    }
+
     /*
      * Retrieve the saved length, handling little- to big-endian conversion as necessary.
      */
@@ -167,7 +173,13 @@ snappy_decompression(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *sr
 #ifdef WORDS_BIGENDIAN
     snaplen = snappy_bswap64(snaplen);
 #endif
-    if (snaplen + SNAPPY_PREFIX > src_len) {
+
+    /*
+     * The stored length is only as trustworthy as the bytes on disk, so bound it with a
+     * subtraction: adding the prefix wraps for stored lengths within SNAPPY_PREFIX of UINT64_MAX,
+     * which would hand the decompressor an input limit far beyond the end of the block.
+     */
+    if (snaplen > src_len - SNAPPY_PREFIX) {
         (void)wt_api->err_printf(
           wt_api, session, "WT_COMPRESSOR.decompress: stored size exceeds source size");
         return (WT_ERROR);

--- a/ext/compressors/snappy/snappy_compress.c
+++ b/ext/compressors/snappy/snappy_compress.c
@@ -175,9 +175,8 @@ snappy_decompression(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *sr
 #endif
 
     /*
-     * The stored length is only as trustworthy as the bytes on disk, so bound it with a
-     * subtraction: adding the prefix wraps for stored lengths within SNAPPY_PREFIX of UINT64_MAX,
-     * which would hand the decompressor an input limit far beyond the end of the block.
+     * We avoid the risk of overflow by using subtraction in this check. The stored size comes from
+     * disk, and if it is corrupted it might be close to the maximum integer value.
      */
     if (snaplen > src_len - SNAPPY_PREFIX) {
         (void)wt_api->err_printf(

--- a/ext/compressors/zstd/zstd_compress.c
+++ b/ext/compressors/zstd/zstd_compress.c
@@ -263,9 +263,8 @@ zstd_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *src, si
 #endif
 
     /*
-     * The stored length is only as trustworthy as the bytes on disk, so bound it with a
-     * subtraction: adding the prefix wraps for stored lengths within ZSTD_PREFIX of UINT64_MAX, and
-     * zstd tracks its remaining input as a counter, so it will read well past the end of the block.
+     * We avoid the risk of overflow by using subtraction in this check. The stored size comes from
+     * disk, and if it is corrupted it might be close to the maximum integer value.
      */
     if (zstd_len > src_len - ZSTD_PREFIX) {
         (void)wt_api->err_printf(

--- a/ext/compressors/zstd/zstd_compress.c
+++ b/ext/compressors/zstd/zstd_compress.c
@@ -248,6 +248,12 @@ zstd_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *src, si
     wt_api = ((ZSTD_COMPRESSOR *)compressor)->wt_api;
     zcompressor = (ZSTD_COMPRESSOR *)compressor;
 
+    if (src_len < ZSTD_PREFIX) {
+        (void)wt_api->err_printf(
+          wt_api, session, "WT_COMPRESSOR.decompress: source size is smaller than the size prefix");
+        return (WT_ERROR);
+    }
+
     /*
      * Retrieve the saved length, handling little- to big-endian conversion as necessary.
      */
@@ -255,7 +261,13 @@ zstd_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session, uint8_t *src, si
 #ifdef WORDS_BIGENDIAN
     zstd_len = zstd_bswap64(zstd_len);
 #endif
-    if (zstd_len + ZSTD_PREFIX > src_len) {
+
+    /*
+     * The stored length is only as trustworthy as the bytes on disk, so bound it with a
+     * subtraction: adding the prefix wraps for stored lengths within ZSTD_PREFIX of UINT64_MAX, and
+     * zstd tracks its remaining input as a counter, so it will read well past the end of the block.
+     */
+    if (zstd_len > src_len - ZSTD_PREFIX) {
         (void)wt_api->err_printf(
           wt_api, session, "WT_COMPRESSOR.decompress: stored size exceeds source size");
         return (WT_ERROR);

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -69,6 +69,7 @@ else()
         ext/test_key_provider.cpp
         ext/test_key_provider_header.cpp
         ext/test_checkpoint_meta_version.cpp
+        ext/test_compressor_stored_length.cpp
         sub_level_error/api/test_sub_level_error_session_get_last_error.cpp
         sub_level_error/api/test_sub_level_error_strerror.cpp
         sub_level_error/unit/test_sub_level_error_api_end.cpp
@@ -150,6 +151,31 @@ if(NOT HAVE_BUILTIN_EXTENSION_KEY_PROVIDER)
         PRIVATE
             KEY_PROVIDER_EXTENSION="$<TARGET_FILE:wiredtiger_key_provider>"
     )
+endif()
+
+# The compressor tests load whichever compressors this build has, and skip the rest.
+if(ENABLE_SNAPPY)
+    target_compile_definitions(catch2-unittests
+        PRIVATE
+            SNAPPY_EXTENSION="$<TARGET_FILE:wiredtiger_snappy>"
+    )
+    add_dependencies(catch2-unittests wiredtiger_snappy)
+endif()
+
+if(ENABLE_ZSTD)
+    target_compile_definitions(catch2-unittests
+        PRIVATE
+            ZSTD_EXTENSION="$<TARGET_FILE:wiredtiger_zstd>"
+    )
+    add_dependencies(catch2-unittests wiredtiger_zstd)
+endif()
+
+if(ENABLE_LZ4)
+    target_compile_definitions(catch2-unittests
+        PRIVATE
+            LZ4_EXTENSION="$<TARGET_FILE:wiredtiger_lz4>"
+    )
+    add_dependencies(catch2-unittests wiredtiger_lz4)
 endif()
 
 if(WT_POSIX)

--- a/test/catch2/ext/test_compressor_stored_length.cpp
+++ b/test/catch2/ext/test_compressor_stored_length.cpp
@@ -1,0 +1,278 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include "utils.h"
+
+#include "wiredtiger.h"
+#include "wt_internal.h"
+
+namespace {
+
+using extension_init_t = int (*)(WT_CONNECTION *, WT_CONFIG_ARG *);
+
+std::vector<std::string> captured_errors;
+
+int
+capture_error(WT_EVENT_HANDLER *handler, WT_SESSION *session, int error, const char *message)
+{
+    (void)handler;
+    (void)session;
+    (void)error;
+    captured_errors.emplace_back(message);
+    return (0);
+}
+
+WT_EVENT_HANDLER capture_handler = {capture_error, nullptr, nullptr, nullptr, nullptr};
+
+/*
+ * A failed stored-length check and a failed decompression both come back as WT_ERROR, so the return
+ * code alone cannot tell them apart. Watch the error stream instead, and match the two messages the
+ * extensions emit when they reject a stored length. Anything else means the length was accepted and
+ * the compression library was handed it.
+ */
+bool
+guard_rejected(WT_COMPRESSOR *c, WT_SESSION *session, std::vector<uint8_t> &src, size_t src_len,
+  std::vector<uint8_t> &dst)
+{
+    size_t result_len = 0;
+
+    captured_errors.clear();
+    if (c->decompress(c, session, src.data(), src_len, dst.data(), dst.size(), &result_len) !=
+      WT_ERROR)
+        return (false);
+
+    for (const std::string &m : captured_errors)
+        if (m.find("stored size exceeds source size") != std::string::npos ||
+          m.find("source size is smaller than the size prefix") != std::string::npos)
+            return (true);
+    return (false);
+}
+
+/*
+ * The compressed-length prefix is read back out of the block payload, so it is only as trustworthy
+ * as the bytes on disk. These tests drive decompress() directly rather than through a table read,
+ * which would otherwise mean producing a block whose checksum verifies.
+ */
+struct compressor_fixture {
+    WT_CONNECTION *conn = nullptr;
+    WT_SESSION *session = nullptr;
+    WT_COMPRESSOR *compressor = nullptr;
+
+    compressor_fixture(const char *name, extension_init_t init)
+    {
+        WT_NAMED_COMPRESSOR *ncomp;
+
+        utils::wiredtiger_cleanup(DB_HOME);
+        REQUIRE(mkdir(DB_HOME, 0700) == 0);
+        REQUIRE(wiredtiger_open(DB_HOME, &capture_handler, "create,in_memory", &conn) == 0);
+        REQUIRE(conn->open_session(conn, nullptr, nullptr, &session) == 0);
+        REQUIRE(init(conn, nullptr) == 0);
+
+        TAILQ_FOREACH (ncomp, &((WT_CONNECTION_IMPL *)conn)->ext.compqh, q)
+            if (std::strcmp(ncomp->name, name) == 0)
+                compressor = ncomp->compressor;
+        REQUIRE(compressor != nullptr);
+    }
+
+    ~compressor_fixture()
+    {
+        conn->close(conn, "");
+        utils::wiredtiger_cleanup(DB_HOME);
+    }
+};
+
+/*
+ * store_prefix64 --
+ *     Write a stored length the way the 64-bit-prefix compressors read it back.
+ */
+void
+store_prefix64(uint8_t *dst, uint64_t v)
+{
+#ifdef WORDS_BIGENDIAN
+    v = __wt_bswap64(v);
+#endif
+    std::memcpy(dst, &v, sizeof(v));
+}
+
+/*
+ * store_prefix32 --
+ *     Write a stored length the way the 32-bit-prefix compressors read it back.
+ */
+void
+store_prefix32(uint8_t *dst, uint32_t v)
+{
+#ifdef WORDS_BIGENDIAN
+    v = __wt_bswap32(v);
+#endif
+    std::memcpy(dst, &v, sizeof(v));
+}
+
+std::vector<uint8_t>
+sample_data()
+{
+    std::vector<uint8_t> raw(4096);
+
+    /* Compressible, but not so uniform that a compressor collapses it to nothing. */
+    for (size_t i = 0; i < raw.size(); ++i)
+        raw[i] = static_cast<uint8_t>(i % 64);
+    return raw;
+}
+
+std::vector<uint8_t>
+compress_buffer(WT_COMPRESSOR *c, WT_SESSION *session, std::vector<uint8_t> &raw)
+{
+    size_t dst_len, result_len;
+    int failed = 0;
+
+    REQUIRE(c->pre_size(c, session, raw.data(), raw.size(), &dst_len) == 0);
+
+    std::vector<uint8_t> dst(dst_len);
+    REQUIRE(c->compress(c, session, raw.data(), raw.size(), dst.data(), dst.size(), &result_len,
+              &failed) == 0);
+    REQUIRE(failed == 0);
+    dst.resize(result_len);
+    return dst;
+}
+
+/*
+ * check_round_trip --
+ *     An untouched block decompresses back to the original, and a block too short to hold the
+ *     stored-length prefix is rejected rather than read.
+ */
+void
+check_round_trip(compressor_fixture &f, std::vector<uint8_t> &raw, std::vector<uint8_t> &comp,
+  std::vector<uint8_t> &out, size_t prefix_size)
+{
+    WT_COMPRESSOR *c = f.compressor;
+    size_t result_len = 0;
+
+    REQUIRE(c->decompress(
+              c, f.session, comp.data(), comp.size(), out.data(), out.size(), &result_len) == 0);
+    REQUIRE(result_len == raw.size());
+    REQUIRE(std::memcmp(out.data(), raw.data(), raw.size()) == 0);
+
+    REQUIRE(guard_rejected(c, f.session, comp, prefix_size - 1, out));
+}
+
+/*
+ * check_guard_64 --
+ *     Exercise the compressors that store the compressed length as a 64-bit prefix.
+ */
+void
+check_guard_64(const char *name, extension_init_t init)
+{
+    compressor_fixture f(name, init);
+    std::vector<uint8_t> raw = sample_data();
+    std::vector<uint8_t> comp = compress_buffer(f.compressor, f.session, raw);
+    std::vector<uint8_t> out(raw.size() * 2);
+    std::vector<uint8_t> bad;
+
+    check_round_trip(f, raw, comp, out, sizeof(uint64_t));
+
+    /* A stored length larger than the block is rejected. */
+    bad = comp;
+    store_prefix64(bad.data(), bad.size() + 1000);
+    REQUIRE(guard_rejected(f.compressor, f.session, bad, bad.size(), out));
+
+    /*
+     * Stored lengths within the prefix size of UINT64_MAX are the values for which adding the
+     * prefix wraps. Every one of them must be rejected, along with the largest value below the
+     * window.
+     */
+    for (size_t i = 0; i <= sizeof(uint64_t); ++i) {
+        uint64_t stored = UINT64_MAX - i;
+        CAPTURE(name, i, stored);
+        bad = comp;
+        store_prefix64(bad.data(), stored);
+        REQUIRE(guard_rejected(f.compressor, f.session, bad, bad.size(), out));
+    }
+}
+
+/*
+ * check_guard_32 --
+ *     Exercise the compressors that store the compressed length as a 32-bit field. The addition
+ *     only wraps where size_t is 32 bits, but the guard must reject these values regardless.
+ */
+void
+check_guard_32(const char *name, extension_init_t init, size_t prefix_size)
+{
+    compressor_fixture f(name, init);
+    std::vector<uint8_t> raw = sample_data();
+    std::vector<uint8_t> comp = compress_buffer(f.compressor, f.session, raw);
+    std::vector<uint8_t> out(raw.size() * 2);
+    std::vector<uint8_t> bad;
+
+    check_round_trip(f, raw, comp, out, prefix_size);
+
+    for (size_t i = 0; i <= prefix_size; ++i) {
+        uint32_t stored = UINT32_MAX - static_cast<uint32_t>(i);
+        CAPTURE(name, i, stored);
+        bad = comp;
+        store_prefix32(bad.data(), stored);
+        REQUIRE(guard_rejected(f.compressor, f.session, bad, bad.size(), out));
+    }
+}
+
+} // namespace
+
+#if defined(HAVE_BUILTIN_EXTENSION_SNAPPY)
+extern "C" int snappy_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+#endif
+
+#if defined(HAVE_BUILTIN_EXTENSION_SNAPPY) || defined(SNAPPY_EXTENSION)
+TEST_CASE("snappy: a crafted stored length is rejected", "[compressor]")
+{
+#if defined(HAVE_BUILTIN_EXTENSION_SNAPPY)
+    check_guard_64("snappy", snappy_extension_init);
+#else
+    static utils::shared_library lib{SNAPPY_EXTENSION};
+    check_guard_64("snappy", lib.get<extension_init_t>("wiredtiger_extension_init"));
+#endif
+}
+#endif
+
+#if defined(HAVE_BUILTIN_EXTENSION_ZSTD)
+extern "C" int zstd_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+#endif
+
+#if defined(HAVE_BUILTIN_EXTENSION_ZSTD) || defined(ZSTD_EXTENSION)
+TEST_CASE("zstd: a crafted stored length is rejected", "[compressor]")
+{
+#if defined(HAVE_BUILTIN_EXTENSION_ZSTD)
+    check_guard_64("zstd", zstd_extension_init);
+#else
+    static utils::shared_library lib{ZSTD_EXTENSION};
+    check_guard_64("zstd", lib.get<extension_init_t>("wiredtiger_extension_init"));
+#endif
+}
+#endif
+
+#if defined(HAVE_BUILTIN_EXTENSION_LZ4)
+extern "C" int lz4_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+#endif
+
+#if defined(HAVE_BUILTIN_EXTENSION_LZ4) || defined(LZ4_EXTENSION)
+TEST_CASE("lz4: a crafted stored length is rejected", "[compressor]")
+{
+    /* Four 4B fields: compressed, uncompressed and useful lengths, and a reserved word. */
+    static const size_t lz4_prefix_size = 4 * sizeof(uint32_t);
+
+#if defined(HAVE_BUILTIN_EXTENSION_LZ4)
+    check_guard_32("lz4", lz4_extension_init, lz4_prefix_size);
+#else
+    static utils::shared_library lib{LZ4_EXTENSION};
+    check_guard_32("lz4", lib.get<extension_init_t>("wiredtiger_extension_init"), lz4_prefix_size);
+#endif
+}
+#endif

--- a/test/catch2/ext/test_compressor_stored_length.cpp
+++ b/test/catch2/ext/test_compressor_stored_length.cpp
@@ -13,6 +13,7 @@
 #include <catch2/catch.hpp>
 
 #include "utils.h"
+#include "wrappers/connection_wrapper.h"
 
 #include "wiredtiger.h"
 #include "wt_internal.h"
@@ -65,7 +66,7 @@ guard_rejected(WT_COMPRESSOR *c, WT_SESSION *session, std::vector<uint8_t> &src,
  * which would otherwise mean producing a block whose checksum verifies.
  */
 struct compressor_fixture {
-    WT_CONNECTION *conn = nullptr;
+    connection_wrapper conn{DB_HOME, "create,in_memory", &capture_handler};
     WT_SESSION *session = nullptr;
     WT_COMPRESSOR *compressor = nullptr;
 
@@ -73,22 +74,14 @@ struct compressor_fixture {
     {
         WT_NAMED_COMPRESSOR *ncomp;
 
-        utils::wiredtiger_cleanup(DB_HOME);
-        REQUIRE(mkdir(DB_HOME, 0700) == 0);
-        REQUIRE(wiredtiger_open(DB_HOME, &capture_handler, "create,in_memory", &conn) == 0);
-        REQUIRE(conn->open_session(conn, nullptr, nullptr, &session) == 0);
-        REQUIRE(init(conn, nullptr) == 0);
+        REQUIRE(conn.get_wt_connection()->open_session(
+                  conn.get_wt_connection(), nullptr, nullptr, &session) == 0);
+        REQUIRE(init(conn.get_wt_connection(), nullptr) == 0);
 
-        TAILQ_FOREACH (ncomp, &((WT_CONNECTION_IMPL *)conn)->ext.compqh, q)
+        TAILQ_FOREACH (ncomp, &conn.get_wt_connection_impl()->ext.compqh, q)
             if (std::strcmp(ncomp->name, name) == 0)
                 compressor = ncomp->compressor;
         REQUIRE(compressor != nullptr);
-    }
-
-    ~compressor_fixture()
-    {
-        conn->close(conn, "");
-        utils::wiredtiger_cleanup(DB_HOME);
     }
 };
 

--- a/test/catch2/ext/test_compressor_stored_length.cpp
+++ b/test/catch2/ext/test_compressor_stored_length.cpp
@@ -139,13 +139,12 @@ compress_buffer(WT_COMPRESSOR *c, WT_SESSION *session, std::vector<uint8_t> &raw
 }
 
 /*
- * check_round_trip --
- *     An untouched block decompresses back to the original, and a block too short to hold the
- *     stored-length prefix is rejected rather than read.
+ * check_decompresses_to_original --
+ *     An untouched block decompresses back to the bytes it was compressed from.
  */
 void
-check_round_trip(compressor_fixture &f, std::vector<uint8_t> &raw, std::vector<uint8_t> &comp,
-  std::vector<uint8_t> &out, size_t prefix_size)
+check_decompresses_to_original(compressor_fixture &f, std::vector<uint8_t> &raw,
+  std::vector<uint8_t> &comp, std::vector<uint8_t> &out)
 {
     WT_COMPRESSOR *c = f.compressor;
     size_t result_len = 0;
@@ -154,8 +153,17 @@ check_round_trip(compressor_fixture &f, std::vector<uint8_t> &raw, std::vector<u
               c, f.session, comp.data(), comp.size(), out.data(), out.size(), &result_len) == 0);
     REQUIRE(result_len == raw.size());
     REQUIRE(std::memcmp(out.data(), raw.data(), raw.size()) == 0);
+}
 
-    REQUIRE(guard_rejected(c, f.session, comp, prefix_size - 1, out));
+/*
+ * check_short_block_rejected --
+ *     A block too short to hold the stored-length prefix is rejected rather than read.
+ */
+void
+check_short_block_rejected(
+  compressor_fixture &f, std::vector<uint8_t> &comp, std::vector<uint8_t> &out, size_t prefix_size)
+{
+    REQUIRE(guard_rejected(f.compressor, f.session, comp, prefix_size - 1, out));
 }
 
 /*
@@ -171,7 +179,8 @@ check_guard_64(const char *name, extension_init_t init)
     std::vector<uint8_t> out(raw.size() * 2);
     std::vector<uint8_t> bad;
 
-    check_round_trip(f, raw, comp, out, sizeof(uint64_t));
+    check_decompresses_to_original(f, raw, comp, out);
+    check_short_block_rejected(f, comp, out, sizeof(uint64_t));
 
     /* A stored length larger than the block is rejected. */
     bad = comp;
@@ -206,7 +215,8 @@ check_guard_32(const char *name, extension_init_t init, size_t prefix_size)
     std::vector<uint8_t> out(raw.size() * 2);
     std::vector<uint8_t> bad;
 
-    check_round_trip(f, raw, comp, out, prefix_size);
+    check_decompresses_to_original(f, raw, comp, out);
+    check_short_block_rejected(f, comp, out, prefix_size);
 
     for (size_t i = 0; i <= prefix_size; ++i) {
         uint32_t stored = UINT32_MAX - static_cast<uint32_t>(i);

--- a/test/catch2/wrappers/connection_wrapper.cpp
+++ b/test/catch2/wrappers/connection_wrapper.cpp
@@ -14,7 +14,8 @@
 #include "connection_wrapper.h"
 #include "../utils.h"
 
-connection_wrapper::connection_wrapper(const std::string &db_home, const char *cfg_str)
+connection_wrapper::connection_wrapper(
+  const std::string &db_home, const char *cfg_str, WT_EVENT_HANDLER *event_handler)
     : _conn_impl(nullptr), _conn(nullptr), _db_home(db_home), _cfg_str(cfg_str), _do_cleanup(true)
 {
     struct stat sb;
@@ -31,7 +32,7 @@ connection_wrapper::connection_wrapper(const std::string &db_home, const char *c
     } else {
         utils::throw_if_non_zero(mkdir(_db_home.c_str(), 0700));
     }
-    utils::throw_if_non_zero(wiredtiger_open(_db_home.c_str(), nullptr, cfg_str, &_conn));
+    utils::throw_if_non_zero(wiredtiger_open(_db_home.c_str(), event_handler, cfg_str, &_conn));
     _conn_impl = (WT_CONNECTION_IMPL *)_conn;
 }
 

--- a/test/catch2/wrappers/connection_wrapper.h
+++ b/test/catch2/wrappers/connection_wrapper.h
@@ -24,7 +24,12 @@
  */
 class connection_wrapper {
 public:
-    connection_wrapper(const std::string &db_home, const char *cfg_str = "create");
+    /*
+     * Pass an event handler to inspect what the connection writes to the error or message streams;
+     * some behavior is only reported there and is not visible in a return code.
+     */
+    connection_wrapper(const std::string &db_home, const char *cfg_str = "create",
+      WT_EVENT_HANDLER *event_handler = nullptr);
     ~connection_wrapper();
 
     /*


### PR DESCRIPTION
The snappy, zstd and lz4 decompressors validated the stored compressed-length prefix by adding the prefix size to it and comparing against the source length. The addition wraps for stored lengths within the prefix size of the type's maximum, so the check passed and the unvalidated length reached the library as its source length.

Compare with a subtraction instead, and check the source is long enough to hold the prefix before dereferencing it.