### PR TITLE
WT-18440 Remove dir_store section from Catch2 drop-conflict tests

### DIFF
--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -152,9 +152,5 @@ if(NOT HAVE_BUILTIN_EXTENSION_KEY_PROVIDER)
     )
 endif()
 
-if(WT_POSIX)
-    add_dependencies(catch2-unittests wiredtiger_dir_store)
-endif()
-
 add_test(NAME unittest COMMAND $<TARGET_FILE:catch2-unittests>)
 set_tests_properties(unittest PROPERTIES LABELS "check;unittest")

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
@@ -12,7 +12,6 @@
 #include "wt_internal.h"
 #include "../../wrappers/connection_wrapper.h"
 #include "../utils_sub_level_error.h"
-#include "../../../utility/test_util.h"
 
 /*
  * [sub_level_error_drop_conflict]: test_sub_level_error_drop_conflict.cpp
@@ -91,35 +90,6 @@ TEST_CASE("Test WT_CONFLICT_BACKUP and WT_CONFLICT_DHANDLE",
         REQUIRE(session->drop(session, URI, NULL) == 0);
         utils::check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
-
-    /*
-     * This section gives us coverage in __drop_tiered. The dir_store extension is only supported
-     * for POSIX systems, so we skip this section on Windows.
-     */
-#ifndef _WIN32
-    SECTION("Test WT_CONFLICT_DHANDLE with tiered storage")
-    {
-        /* Set up the connection and session to use tiered storage. */
-        const char *home = "WT_TEST";
-        testutil_system("rm -rf %s && mkdir %s && mkdir %s/%s", home, home, home, "bucket");
-        connection_wrapper conn_wrapper = connection_wrapper(home,
-          "create,tiered_storage=(bucket=bucket,bucket_prefix=pfx-,name=dir_store),extensions=(./"
-          "ext/storage_sources/dir_store/libwiredtiger_dir_store.so)");
-
-        utils::prepare_session_and_error(&conn_wrapper, &session, &err_info);
-        REQUIRE(session->create(session, URI, config.c_str()) == 0);
-
-        /* Open a cursor on a table that uses tiered storage, then attempt to drop the table. */
-        REQUIRE(session->open_cursor(session, URI, NULL, NULL, &cursor) == 0);
-        REQUIRE(session->drop(session, URI, NULL) == EBUSY);
-        utils::check_error_info(err_info, EBUSY, WT_CONFLICT_DHANDLE, CONFLICT_DHANDLE_MSG);
-
-        /* Drop the table once the test is completed. */
-        cursor->close(cursor);
-        REQUIRE(session->drop(session, URI, NULL) == 0);
-        utils::check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
-    }
-#endif
 }
 
 /*


### PR DESCRIPTION
> This PR was created by an automated coding agent.

Removes the dir_store Catch2 SECTION from `test_sub_level_error_drop_conflict.cpp` (the WT_CONFLICT_DHANDLE-with-tiered-storage case that loaded `libwiredtiger_dir_store.so`) and drops `catch2-unittests`' `add_dependencies` on `wiredtiger_dir_store`. Leaves the remaining EBUSY drop tests (backup, simple-table and column dhandle, checkpoint/schema/table locks). Does not change other Catch2 tests, `src/`, or dir_store sources.

## Testing
- `cmake --build build`
- `./test/catch2/catch2-unittests "[sub_level_error_drop_conflict]"` → All tests passed (75 assertions in 2 test cases)
- `cd dist && ./s_fast`

Made with [Cursor](https://cursor.com)