### PR TITLE
WT-18445 Strip flush_tier from test/checkpoint

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -83,7 +83,6 @@ start_threads(void)
 void
 end_threads(void)
 {
-    /* Shutdown checkpoint after flush thread completes because flush depends on checkpoint. */
     testutil_check(__wt_thread_join(NULL, &g.checkpoint_thread));
 
     if (g.use_timestamps) {
@@ -210,25 +209,6 @@ checkpointer(void *arg)
 }
 
 /*
- * set_flush_tier_delay --
- *     Set up a random delay for the next flush_tier.
- */
-void
-set_flush_tier_delay(WT_RAND_STATE *rnd)
-{
-    /*
-     * When we are in sweep stress mode, we checkpoint between 4 and 8 seconds, so we'll flush
-     * between 5 and 15 seconds (that is, 5 million and 15 million microseconds). When we aren't in
-     * sweep stress mode, we are checkpointing constantly, and we'll do a flush tier with a random
-     * delay between 0 - 10000 microseconds.
-     */
-    if (g.sweep_stress)
-        g.opts.tiered_flush_interval_us = 5 * WT_MILLION + __wt_random(rnd) % (10 * WT_MILLION);
-    else
-        g.opts.tiered_flush_interval_us = __wt_random(rnd) % 10001;
-}
-
-/*
  * real_checkpointer --
  *     Do the work of creating checkpoints and then verifying them. Also responsible for finishing
  *     in a timely fashion.
@@ -241,13 +221,11 @@ real_checkpointer(THREAD_DATA *td)
     wt_timestamp_t tmp_ts;
     uint64_t delay;
     int ret;
-    char buf[128], flush_tier_config[128], timestamp_buf[64];
+    char buf[128], timestamp_buf[64];
     const char *checkpoint_config, *ts_config;
-    bool flush_tier;
 
     ts_config = "use_timestamp=false";
     verify_ts = WT_TS_NONE;
-    flush_tier = false;
 
     while (g.ntables > g.ntables_created && g.opts.running)
         __wt_yield();
@@ -263,12 +241,6 @@ real_checkpointer(THREAD_DATA *td)
         checkpoint_config = buf;
     } else
         checkpoint_config = ts_config;
-
-    testutil_snprintf(
-      flush_tier_config, sizeof(flush_tier_config), "flush_tier=(enabled,force),%s", ts_config);
-
-    /* Use the extra random generator as the tier delay doesn't affect the actual data content. */
-    set_flush_tier_delay(&td->extra_rnd);
 
     while (g.opts.running) {
         /*
@@ -307,27 +279,10 @@ real_checkpointer(THREAD_DATA *td)
         }
 
         /* Execute a checkpoint */
-        if ((ret = session->checkpoint(
-               session, flush_tier ? flush_tier_config : checkpoint_config)) != 0)
+        if ((ret = session->checkpoint(session, checkpoint_config)) != 0)
             return (log_print_err("session.checkpoint", ret, 1));
         printf("Finished a checkpoint\n");
         fflush(stdout);
-        if (flush_tier) {
-            /*
-             * FIXME: when we change the API to notify that a flush_tier has completed, we'll need
-             * to set up a general event handler and catch that notification, so we can pass the
-             * flush_tier "cookie" to the test utility function.
-             */
-            testutil_tiered_flush_complete(&g.opts, session, NULL);
-            flush_tier = false;
-            printf("Finished a flush_tier\n");
-
-            /*
-             * Use the extra random generator as the tier delay doesn't affect the actual data
-             * content.
-             */
-            set_flush_tier_delay(&td->extra_rnd);
-        }
 
         if (!g.opts.running)
             goto done;
@@ -350,16 +305,17 @@ real_checkpointer(THREAD_DATA *td)
             testutil_check(g.conn->set_timestamp(g.conn, timestamp_buf));
         }
 
-        if (g.sweep_stress)
+        if (g.sweep_stress) {
             /*
-             * Random value between 4 and 8 seconds. Use the extra random generator as the tier
-             * sleep delay doesn't affect the actual data content.
+             * Random value between 4 and 8 seconds. Use the extra random generator as the sleep
+             * delay doesn't affect the actual data content.
              */
             delay = __wt_random(&td->extra_rnd) % 5 + 4;
-        else
-            /* Just find out if we should flush_tier. */
-            delay = 0;
-        testutil_tiered_sleep(&g.opts, session, delay, &flush_tier);
+            while (delay > 0 && g.opts.running) {
+                __wt_sleep(1, 0);
+                --delay;
+            }
+        }
     }
 
 done:

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -436,26 +436,10 @@ wt_connect(const char *config_open)
         if (g.prepare)
             strcat(config, ",preserve_prepared=true");
     }
-    /*
-     * If we are using tiered add in the extension and tiered storage configuration.
-     */
-    if (g.opts.tiered_storage) {
-        testutil_snprintf(buf, sizeof(buf), "%s/bucket", g.home);
-        testutil_recreate_dir(buf);
-    }
 
     printf("WT open config: %s\n", config);
     fflush(stdout);
     testutil_wiredtiger_open(&g.opts, g.home, config, &event_handler, &g.conn, false, false);
-
-    if (g.opts.tiered_storage) {
-        /* testutil_tiered_begin needs the connection. */
-        g.opts.conn = g.conn;
-
-        /* Set up a random delay for the first flush. */
-        set_flush_tier_delay(&g.opts.extra_rnd);
-        testutil_tiered_begin(&g.opts);
-    }
 }
 
 /*
@@ -469,9 +453,6 @@ wt_shutdown(void)
 
     if (g.conn == NULL)
         return (0);
-
-    if (g.opts.tiered_storage)
-        testutil_tiered_end(&g.opts);
 
     printf("Closing connection\n");
     fflush(stdout);

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -115,7 +115,6 @@ typedef struct {
     WT_RWLOCK clock_lock;          /* Clock synchronization */
     wt_thread_t checkpoint_thread; /* Checkpoint thread */
     wt_thread_t clock_thread;      /* Clock thread */
-    wt_thread_t flush_thread;      /* Flush thread */
 } GLOBAL;
 extern GLOBAL g;
 
@@ -125,7 +124,6 @@ extern GLOBAL g;
 
 void end_threads(void);
 int log_print_err_worker(const char *, int, const char *, int, int);
-void set_flush_tier_delay(WT_RAND_STATE *);
 void start_threads(void);
 int start_workers(void);
 const char *type_to_string(table_type);


### PR DESCRIPTION
> This PR was created by an automated coding agent.

Keep `test/checkpoint`. Remove `set_flush_tier_delay`, unused `flush_thread`, and all `flush_tier` / `testutil_tiered_*` call sites from `checkpointer.c`, `test_checkpoint.c`, and `test_checkpoint.h`. Checkpoints still run and verify; sweep-stress still sleeps 4–8s between checkpoints. Leave `src/`, abort tests, and `test/utility/tiered.c` unchanged.

## Testing
- `cmake --build build` (Ninja Debug, Python, diagnostic, unittest)
- `./test_checkpoint -t r -T 3 -n 5000 -k 1000` (no `-PT`) → pass
- `./test_checkpoint -t m -T 4 -n 3000 -k 1000 -x` (no `-PT`) → pass
- `cd dist && ./s_fast` (evergreen validate skipped: no CLI login)

Made with [Cursor](https://cursor.com)