### PR TITLE
WT-18441 Strip flush_tier_worker and tiered options from wtperf

### DIFF
--- a/bench/wtperf/track.c
+++ b/bench/wtperf/track.c
@@ -87,24 +87,6 @@ sum_ckpt_ops(WTPERF *wtperf)
 }
 
 /*
- * Return total flush_tier operations.
- */
-uint64_t
-sum_flush_ops(WTPERF *wtperf)
-{
-    CONFIG_OPTS *opts;
-    uint64_t total;
-
-    opts = wtperf->opts;
-
-    if (opts->tiered_flush_interval > 0)
-        total = wtperf->flushthreads->flush.ops;
-    else
-        total = 0;
-    return (total);
-}
-
-/*
  * Return total scan operations.
  */
 uint64_t

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1014,7 +1014,7 @@ populate_thread(void *arg)
 
     /* Do bulk loads if populate is single-threaded. */
     cursor_config = NULL;
-    if (opts->populate_threads == 1 && !opts->index && opts->tiered_flush_interval == 0)
+    if (opts->populate_threads == 1 && !opts->index)
         cursor_config = "bulk";
 
     /* Create the cursors. */
@@ -1256,13 +1256,13 @@ monitor(void *arg)
         cur_updates = (updates - last_updates) / opts->sample_interval;
 
         (void)fprintf(fp,
-          "%s,%" PRIu32 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%c,%c,%c,%c%" PRIu64
+          "%s,%" PRIu32 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%c,%c,%c%" PRIu64
           ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64
           ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n",
           buf, wtperf->totalsec, cur_inserts, cur_modifies, cur_reads, cur_updates,
-          wtperf->backup ? 'Y' : 'N', wtperf->ckpt ? 'Y' : 'N', wtperf->flush ? 'Y' : 'N',
-          wtperf->scan ? 'Y' : 'N', insert_avg, insert_min, insert_max, modify_avg, modify_min,
-          modify_max, read_avg, read_min, read_max, update_avg, update_min, update_max);
+          wtperf->backup ? 'Y' : 'N', wtperf->ckpt ? 'Y' : 'N', wtperf->scan ? 'Y' : 'N',
+          insert_avg, insert_min, insert_max, modify_avg, modify_min, modify_max, read_avg,
+          read_min, read_max, update_avg, update_min, update_max);
         if (jfp != NULL) {
             buf_size = strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &localt);
             testutil_assert(buf_size != 0);
@@ -1463,12 +1463,9 @@ checkpoint_worker(void *arg)
             if (stop || wtperf->error)
                 break;
         }
-        /* If tiered storage is disabled we are done. Otherwise, we want a final checkpoint. */
-        if (wtperf->error || (stop && opts->tiered_flush_interval == 0))
+        if (wtperf->error || stop)
             break;
 
-        if (stop)
-            lprintf(wtperf, 0, 1, "Last call before stopping checkpoint");
         wtperf->ckpt = true;
         if ((ret = session->checkpoint(session, NULL)) != 0) {
             lprintf(wtperf, ret, 0, "Checkpoint failed.");
@@ -1480,74 +1477,6 @@ checkpoint_worker(void *arg)
 
     if (session != NULL && ((ret = session->close(session, NULL)) != 0)) {
         lprintf(wtperf, ret, 0, "Error closing session in checkpoint worker.");
-        goto err;
-    }
-
-    /* Notify our caller we failed and shut the system down. */
-    if (0) {
-err:
-        wtperf->error = wtperf->stop = true;
-    }
-
-    return (WT_THREAD_RET_VALUE);
-}
-
-static WT_THREAD_RET
-flush_tier_worker(void *arg)
-{
-    CONFIG_OPTS *opts;
-    WTPERF *wtperf;
-    WTPERF_THREAD *thread;
-    WT_CONNECTION *conn;
-    WT_SESSION *session;
-    uint32_t i;
-    int ret;
-    bool stop;
-
-    thread = (WTPERF_THREAD *)arg;
-    wtperf = thread->wtperf;
-    opts = wtperf->opts;
-    conn = wtperf->conn;
-    session = NULL;
-
-    if ((ret = conn->open_session(conn, NULL, opts->sess_config, &session)) != 0) {
-        lprintf(wtperf, ret, 0, "open_session failed in flush_tier thread.");
-        goto err;
-    }
-
-    stop = false;
-    while (!stop) {
-        /* Break the sleep up, so we notice interrupts faster. */
-        for (i = 0; i < opts->tiered_flush_interval; i++) {
-            sleep(1);
-            /*
-             * We need to make a final call to flush_tier after the stop signal arrives. We
-             * therefore save the global stop signal into a local variable, so we are sure to
-             * complete another iteration of this loop and the final flush_tier before we exit.
-             */
-            stop = wtperf->stop;
-            if (stop || wtperf->error)
-                break;
-        }
-        /* If workers are done, do a final call to flush that last data. */
-        if (wtperf->error)
-            break;
-        /*
-         * In order to get all the data into the object when the work is done, we need to call
-         * checkpoint with flush_tier enabled.
-         */
-        wtperf->flush = true;
-        if ((ret = session->checkpoint(session, "flush_tier=(enabled)")) != 0) {
-            lprintf(wtperf, ret, 0, "Checkpoint with flush tier failed.");
-            goto err;
-        }
-
-        wtperf->flush = false;
-        ++thread->flush.ops;
-    }
-
-    if (session != NULL && ((ret = session->close(session, NULL)) != 0)) {
-        lprintf(wtperf, ret, 0, "Error closing session in flush_tier worker.");
         goto err;
     }
 
@@ -1686,29 +1615,6 @@ execute_populate(WTPERF *wtperf)
     opts = wtperf->opts;
     max_key = (uint64_t)opts->icount + (uint64_t)opts->scan_icount;
 
-    /*
-     * If this is going to be a tiered workload, start the checkpoint threads and the flush threads
-     * during the populate phase so that the tiers are created as we populate the database.
-     */
-    if (opts->tiered_flush_interval != 0) {
-        /* Start the checkpoint thread. */
-        if (opts->checkpoint_threads != 0) {
-            lprintf(
-              wtperf, 0, 1, "Starting %" PRIu32 " checkpoint thread(s)", opts->checkpoint_threads);
-            wtperf->ckptthreads = dcalloc(opts->checkpoint_threads, sizeof(WTPERF_THREAD));
-            start_threads(
-              wtperf, NULL, wtperf->ckptthreads, opts->checkpoint_threads, checkpoint_worker);
-        } else {
-            lprintf(wtperf, 0, 1,
-              "Running a flush-tier thread without checkpoint threads "
-              "on populate may hang the flush thread.");
-        }
-
-        lprintf(wtperf, 0, 1, "Starting 1 flush_tier thread");
-        wtperf->flushthreads = dcalloc(1, sizeof(WTPERF_THREAD));
-        start_threads(wtperf, NULL, wtperf->flushthreads, 1, flush_tier_worker);
-    }
-
     lprintf(wtperf, 0, 1, "Starting %" PRIu32 " populate thread(s) for %" PRIu64 " items",
       opts->populate_threads, max_key);
 
@@ -1782,24 +1688,6 @@ execute_populate(WTPERF *wtperf)
 
     /* Stop cycling idle tables. */
     stop_idle_table_cycle(wtperf, idle_table_cycle_thread);
-    /*
-     * Stop the flush and checkpoint threads if we used them during populate. We must stop the flush
-     * thread before stopping the checkpoint thread as the flush thread depends on a later
-     * checkpoint running.
-     */
-    wtperf->stop = true;
-    if (wtperf->flushthreads != NULL) {
-        stop_threads(1, wtperf->flushthreads);
-        free(wtperf->flushthreads);
-        wtperf->flushthreads = NULL;
-    }
-    wtperf->ckpt_stop = true;
-    if (wtperf->ckptthreads != NULL) {
-        stop_threads(1, wtperf->ckptthreads);
-        free(wtperf->ckptthreads);
-        wtperf->ckptthreads = NULL;
-    }
-    wtperf->ckpt_stop = wtperf->stop = false;
 
     return (0);
 }
@@ -1850,7 +1738,7 @@ execute_workload(WTPERF *wtperf)
     WT_CONNECTION *conn;
     WT_SESSION **sessions;
     wt_thread_t idle_table_cycle_thread;
-    uint64_t last_backup, last_ckpts, last_flushes, last_scans;
+    uint64_t last_backup, last_ckpts, last_scans;
     uint64_t last_inserts, last_reads, last_truncates;
     uint64_t last_modifies, last_updates;
     uint32_t interval, run_ops, run_time;
@@ -1863,7 +1751,7 @@ execute_workload(WTPERF *wtperf)
     wtperf->insert_ops = wtperf->read_ops = wtperf->truncate_ops = 0;
     wtperf->modify_ops = wtperf->update_ops = 0;
 
-    last_backup = last_ckpts = last_flushes = last_scans = 0;
+    last_backup = last_ckpts = last_scans = 0;
     last_inserts = last_reads = last_truncates = 0;
     last_modifies = last_updates = 0;
     ret = 0;
@@ -1930,7 +1818,6 @@ execute_workload(WTPERF *wtperf)
 
         /* Sum the operations we've done. */
         wtperf->ckpt_ops = sum_ckpt_ops(wtperf);
-        wtperf->flush_ops = sum_flush_ops(wtperf);
         wtperf->scan_ops = sum_scan_ops(wtperf);
         wtperf->insert_ops = sum_insert_ops(wtperf);
         wtperf->modify_ops = sum_modify_ops(wtperf);
@@ -1953,19 +1840,18 @@ execute_workload(WTPERF *wtperf)
         lprintf(wtperf, 0, 1,
           "%" PRIu64 " inserts, %" PRIu64 " modifies, %" PRIu64 " reads, %" PRIu64
           " truncates, %" PRIu64 " updates, %" PRIu64 " backups, %" PRIu64 " checkpoints, %" PRIu64
-          " flush_tiers, %" PRIu64 " scans in %" PRIu32 " secs (%" PRIu32 " total secs)",
+          " scans in %" PRIu32 " secs (%" PRIu32 " total secs)",
           wtperf->insert_ops - last_inserts, wtperf->modify_ops - last_modifies,
           wtperf->read_ops - last_reads, wtperf->truncate_ops - last_truncates,
           wtperf->update_ops - last_updates, wtperf->backup_ops - last_backup,
-          wtperf->ckpt_ops - last_ckpts, wtperf->flush_ops - last_flushes,
-          wtperf->scan_ops - last_scans, opts->report_interval, wtperf->totalsec);
+          wtperf->ckpt_ops - last_ckpts, wtperf->scan_ops - last_scans, opts->report_interval,
+          wtperf->totalsec);
         last_inserts = wtperf->insert_ops;
         last_modifies = wtperf->modify_ops;
         last_reads = wtperf->read_ops;
         last_truncates = wtperf->truncate_ops;
         last_updates = wtperf->update_ops;
         last_ckpts = wtperf->ckpt_ops;
-        last_flushes = wtperf->flush_ops;
         last_scans = wtperf->scan_ops;
         last_backup = wtperf->backup_ops;
     }
@@ -2181,7 +2067,6 @@ wtperf_copy(const WTPERF *src, WTPERF **retp)
 
     dest->backupthreads = NULL;
     dest->ckptthreads = NULL;
-    dest->flushthreads = NULL;
     dest->scanthreads = NULL;
     dest->popthreads = NULL;
 
@@ -2227,7 +2112,6 @@ wtperf_free(WTPERF *wtperf)
 
     free(wtperf->backupthreads);
     free(wtperf->ckptthreads);
-    free(wtperf->flushthreads);
     free(wtperf->scanthreads);
     free(wtperf->popthreads);
 
@@ -2280,77 +2164,6 @@ config_compress(WTPERF *wtperf)
         ret = EINVAL;
     }
     return (ret);
-}
-
-/*
- * config_tiered --
- *     Parse the tiered extension configuration
- */
-static int
-config_tiered(WTPERF *wtperf)
-{
-    CONFIG_OPTS *opts;
-    int ret;
-    const char *s;
-
-    opts = wtperf->opts;
-    ret = 0;
-
-    s = opts->tiered;
-    if (strcmp(s, "none") == 0) {
-        wtperf->tiered_ext = NULL;
-        return (0);
-    }
-    if (strcmp(s, "dir_store") != 0) {
-        fprintf(stderr, "invalid tiered extension configuration: %s\n", s);
-        return (EINVAL);
-    }
-    if (opts->tiered_flush_interval == 0) {
-        fprintf(stderr, "tiered_flush_interval must be non-zero for tiered extension: %s\n", s);
-        return (EINVAL);
-    }
-    if (strcmp(s, "dir_store") == 0) {
-        if (strstr(opts->conn_config, "dir_store") == NULL) {
-            fprintf(stderr, "tiered extension name not found in connection configuration: %s\n", s);
-            ret = EINVAL;
-        } else
-            wtperf->tiered_ext = DIR_EXT;
-    }
-    return (ret);
-}
-
-/*
- * create_tiered_bucket --
- *     Create the bucket directory required for tiered storage to work.
- */
-static int
-create_tiered_bucket(WTPERF *wtperf)
-{
-    CONFIG_OPTS *opts;
-    char buf[1024];
-    size_t home_len, bucket_len;
-
-    /* If tiered storage is not set, there is nothing to do. */
-    if (wtperf->tiered_ext == NULL)
-        return (0);
-    opts = wtperf->opts;
-    home_len = strlen(wtperf->home);
-    bucket_len = strlen(opts->tiered_bucket);
-
-    /* Check that we can fit the paths, separator, and null byte. */
-    if ((home_len + bucket_len + 2) > 1024) {
-        fprintf(stderr, "home and bucket directory names too long\n");
-        return (-1);
-    }
-
-    if (bucket_len != 0) {
-        strcpy(buf, wtperf->home);
-        strcat(buf, "/");
-        strcat(buf, opts->tiered_bucket);
-        testutil_mkdir(buf);
-    }
-
-    return (0);
 }
 
 static int
@@ -2489,12 +2302,6 @@ start_run(WTPERF *wtperf)
             start_threads(
               wtperf, NULL, wtperf->ckptthreads, opts->checkpoint_threads, checkpoint_worker);
         }
-        /* Start the flush_tier thread. */
-        if (opts->tiered_flush_interval != 0) {
-            lprintf(wtperf, 0, 1, "Starting 1 flush_tier thread");
-            wtperf->flushthreads = dcalloc(1, sizeof(WTPERF_THREAD));
-            start_threads(wtperf, NULL, wtperf->flushthreads, 1, flush_tier_worker);
-        }
         /* Start the scan thread. */
         if (opts->scan_interval != 0) {
             lprintf(wtperf, 0, 1, "Starting 1 scan thread");
@@ -2516,7 +2323,6 @@ start_run(WTPERF *wtperf)
         wtperf->update_ops = sum_update_ops(wtperf);
         wtperf->backup_ops = sum_backup_ops(wtperf);
         wtperf->ckpt_ops = sum_ckpt_ops(wtperf);
-        wtperf->flush_ops = sum_flush_ops(wtperf);
         wtperf->scan_ops = sum_scan_ops(wtperf);
         total_ops = wtperf->insert_ops + wtperf->modify_ops + wtperf->read_ops +
           wtperf->update_ops + wtperf->scan_ops;
@@ -2547,7 +2353,6 @@ start_run(WTPERF *wtperf)
           wtperf->scan_ops / wtperf->testsec);
         lprintf(wtperf, 0, 1, "Executed %" PRIu64 " backup operations", wtperf->backup_ops);
         lprintf(wtperf, 0, 1, "Executed %" PRIu64 " checkpoint operations", wtperf->ckpt_ops);
-        lprintf(wtperf, 0, 1, "Executed %" PRIu64 " flush_tier operations", wtperf->flush_ops);
 
         latency_print(wtperf);
     }
@@ -2562,8 +2367,6 @@ err:
     wtperf->stop = true;
 
     stop_threads(1, wtperf->backupthreads);
-    /* We must stop the flush thread before the checkpoint thread. */
-    stop_threads(1, wtperf->flushthreads);
     wtperf->ckpt_stop = true;
     stop_threads(1, wtperf->ckptthreads);
     stop_threads(1, wtperf->scanthreads);
@@ -2716,9 +2519,6 @@ main(int argc, char *argv[])
     if ((ret = config_compress(wtperf)) != 0)
         goto err;
 
-    if ((ret = config_tiered(wtperf)) != 0)
-        goto err;
-
     /* You can't have truncate on a random collection. */
     if (F_ISSET(wtperf, CFG_TRUNCATE) && opts->random_range) {
         lprintf(wtperf, 1, 0, "Cannot run truncate and random_range\n");
@@ -2736,10 +2536,9 @@ main(int argc, char *argv[])
 
     /* Concatenate non-default configuration strings. */
     if (user_cconfig != NULL || opts->session_count_idle > 0 || wtperf->compress_ext != NULL ||
-      opts->in_memory || wtperf->tiered_ext != NULL) {
+      opts->in_memory) {
         req_len = 20;
         req_len += wtperf->compress_ext != NULL ? strlen(wtperf->compress_ext) : 0;
-        req_len += wtperf->tiered_ext != NULL ? strlen(wtperf->tiered_ext) : 0;
         if (opts->session_count_idle > 0) {
             sreq_len = strlen("session_max=") + 6;
             req_len += sreq_len;
@@ -2756,11 +2555,6 @@ main(int argc, char *argv[])
         if (wtperf->compress_ext != NULL && strlen(wtperf->compress_ext) != 0) {
             testutil_snprintf_len_incr(
               cc_buf + pos, req_len - pos, &pos, "%s%s", append_comma, wtperf->compress_ext);
-            append_comma = ",";
-        }
-        if (wtperf->tiered_ext != NULL && strlen(wtperf->tiered_ext) != 0) {
-            testutil_snprintf_len_incr(
-              cc_buf + pos, req_len - pos, &pos, "%s%s", append_comma, wtperf->tiered_ext);
             append_comma = ",";
         }
         if (opts->in_memory) {
@@ -2824,7 +2618,7 @@ main(int argc, char *argv[])
     if ((ret = config_sanity(wtperf)) != 0)
         goto err;
 
-    /* If creating, remove and re-create the home and tiered bucket directories. */
+    /* If creating, remove and re-create the home directory. */
     if (opts->create != 0) {
         testutil_recreate_dir(wtperf->home);
         /* If running backups move down a directory level. */
@@ -2833,7 +2627,6 @@ main(int argc, char *argv[])
                 testutil_die(errno, "backup chdir: %s", wtperf->home);
             testutil_recreate_dir(wtperf->home);
         }
-        testutil_check(create_tiered_bucket(wtperf));
     } else if (opts->backup_interval != 0 && opts->backup_complete != 0) {
         if (chdir(wtperf->home) != 0)
             testutil_die(errno, "backup chdir: %s", wtperf->home);
@@ -2919,12 +2712,12 @@ start_threads(WTPERF *wtperf, WORKLOAD *workp, WTPERF_THREAD *base, u_int num,
          * Every thread gets tracking information and is initialized for latency measurements, for
          * the same reason.
          */
-        thread->backup.min_latency = thread->ckpt.min_latency = thread->flush.min_latency =
-          thread->scan.min_latency = thread->insert.min_latency = thread->modify.min_latency =
-            thread->read.min_latency = thread->update.min_latency = UINT64_MAX;
-        thread->backup.max_latency = thread->ckpt.max_latency = thread->flush.max_latency =
-          thread->scan.max_latency = thread->insert.max_latency = thread->modify.max_latency =
-            thread->read.max_latency = thread->update.max_latency = 0;
+        thread->backup.min_latency = thread->ckpt.min_latency = thread->scan.min_latency =
+          thread->insert.min_latency = thread->modify.min_latency = thread->read.min_latency =
+            thread->update.min_latency = UINT64_MAX;
+        thread->backup.max_latency = thread->ckpt.max_latency = thread->scan.max_latency =
+          thread->insert.max_latency = thread->modify.max_latency = thread->read.max_latency =
+            thread->update.max_latency = 0;
     }
 
     /* Start the threads. */

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1256,7 +1256,7 @@ monitor(void *arg)
         cur_updates = (updates - last_updates) / opts->sample_interval;
 
         (void)fprintf(fp,
-          "%s,%" PRIu32 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%c,%c,%c%" PRIu64
+          "%s,%" PRIu32 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%c,%c,%c,%" PRIu64
           ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64
           ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n",
           buf, wtperf->totalsec, cur_inserts, cur_modifies, cur_reads, cur_updates,

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -63,12 +63,6 @@ typedef struct __truncate_queue_entry TRUNCATE_QUEUE_ENTRY;
 #define ZSTD_BLK BLKCMP_PFX "zstd"
 #define ZSTD_EXT EXT_PFX EXTPATH ZSTD_PATH EXT_SFX
 
-/* Tiered Storage Extensions */
-#ifndef DIR_STORE_PATH
-#define DIR_STORE_PATH "storage_sources/dir_store/libwiredtiger_dir_store.so"
-#endif
-#define DIR_EXT EXT_PFX EXTPATH DIR_STORE_PATH EXT_SFX
-
 #define MAX_MODIFY_PCT 10
 #define MAX_MODIFY_NUM 16
 
@@ -153,12 +147,8 @@ struct __wtperf {          /* Per-database structure */
     const char *compress_ext;   /* Compression extension for conn */
     const char *compress_table; /* Compression arg to table create */
 
-    const char *tiered_ext;   /* Tiered extension for conn */
-    const char *tiered_table; /* Tiered arg to table create */
-
     WTPERF_THREAD *backupthreads; /* Backup threads */
     WTPERF_THREAD *ckptthreads;   /* Checkpoint threads */
-    WTPERF_THREAD *flushthreads;  /* Flush_tier threads */
     WTPERF_THREAD *popthreads;    /* Populate threads */
     WTPERF_THREAD *scanthreads;   /* Scan threads */
 
@@ -172,7 +162,6 @@ struct __wtperf {          /* Per-database structure */
     /* State tracking variables. */
     uint64_t backup_ops;   /* backup operations */
     uint64_t ckpt_ops;     /* checkpoint operations */
-    uint64_t flush_ops;    /* flush operations */
     uint64_t scan_ops;     /* scan operations */
     uint64_t insert_ops;   /* insert operations */
     uint64_t modify_ops;   /* modify operations */
@@ -186,7 +175,6 @@ struct __wtperf {          /* Per-database structure */
 
     volatile bool backup;    /* backup in progress */
     volatile bool ckpt;      /* checkpoint in progress */
-    volatile bool flush;     /* flush_tier in progress */
     volatile bool scan;      /* scan in progress */
     volatile bool error;     /* thread error */
     volatile bool ckpt_stop; /* notify checkpoint thread to stop */
@@ -290,7 +278,6 @@ struct __wtperf_thread {    /* Per-thread structure */
 
     TRACK backup;         /* Backup operations */
     TRACK ckpt;           /* Checkpoint operations */
-    TRACK flush;          /* Flush_tier operations */
     TRACK insert;         /* Insert operations */
     TRACK modify;         /* Modify operations */
     TRACK read;           /* Read operations */
@@ -328,7 +315,6 @@ void stop_idle_table_cycle(WTPERF *, wt_thread_t);
 void worker_throttle(WTPERF_THREAD *);
 uint64_t sum_backup_ops(WTPERF *);
 uint64_t sum_ckpt_ops(WTPERF *);
-uint64_t sum_flush_ops(WTPERF *);
 uint64_t sum_scan_ops(WTPERF *);
 uint64_t sum_insert_ops(WTPERF *);
 uint64_t sum_modify_ops(WTPERF *);

--- a/bench/wtperf/wtperf_config.c
+++ b/bench/wtperf/wtperf_config.c
@@ -736,7 +736,6 @@ config_sanity(WTPERF *wtperf)
     /* Various intervals should be less than the run-time. */
     if (opts->run_time > 0 &&
       ((opts->checkpoint_threads != 0 && opts->checkpoint_interval > opts->run_time) ||
-        (opts->tiered_flush_interval != 0 && opts->tiered_flush_interval > opts->run_time) ||
         opts->report_interval > opts->run_time || opts->sample_interval > opts->run_time ||
         opts->scan_interval > opts->run_time || opts->backup_interval > opts->run_time)) {
         fprintf(stderr, "interval value longer than the run-time\n");
@@ -974,10 +973,6 @@ config_opt_print(WTPERF *wtperf)
       "\t"
       "Checkpoint threads, interval: %" PRIu32 ", %" PRIu32 "\n",
       opts->checkpoint_threads, opts->checkpoint_interval);
-    printf(
-      "\t"
-      "Flush interval: %" PRIu32 "\n",
-      opts->tiered_flush_interval);
     printf(
       "\t"
       "Reporting interval: %" PRIu32 "\n",

--- a/bench/wtperf/wtperf_opt_inline.h
+++ b/bench/wtperf/wtperf_opt_inline.h
@@ -201,18 +201,6 @@ DEF_OPT_AS_STRING(threads, "",
   "'modify', 'modify_delta', 'modify_distribute', 'modify_force_update', 'reopen_cursor', "
   "'updates', 'update_delta', 'truncate', 'truncate_pct' and 'truncate_count'. There are also "
   "behavior modifiers, supported modifiers are 'ops_per_txn'")
-/*
- * Note for tiered storage usage, the test expects that the bucket will be specified in the runner's
- * 'conn_config' line. Any bucket or directory listed is assumed to already exist and the test
- * program will just use it. The program does not parse the connection configuration line.
- */
-DEF_OPT_AS_STRING(
-  tiered, "none", "tiered extension.  Allowed configuration values are: 'none', 'dir_store'")
-DEF_OPT_AS_STRING(tiered_bucket, "none", "Create this bucket directory before beginning the test.")
-DEF_OPT_AS_UINT32(tiered_flush_interval, 0,
-  "Call flush_tier every interval seconds during the workload phase. "
-  "We recommend this value be larger than the checkpoint_interval. 0 to disable. The "
-  "'tiered_extension' must be set to something other than 'none'.")
 DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
   "WT_SESSION.begin_transaction configuration string, applied during the populate phase when "
   "populate_ops_per_txn is nonzero")

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -232,12 +232,6 @@ number of tables to run operations over. Keys are divided evenly over the tables
 number of tables to create, that won't be populated. Default 0.
 @par threads (string, default="")
 workload configuration: each 'count' entry is the total number of threads, and the 'insert',  'modify', 'read' and 'update' entries are the ratios of insert, modify, read and update  operations done by each worker thread; If a throttle value is provided each thread will do a  maximum of that number of operations per second; multiple workload configurations may be  specified per threads configuration; for example, a more complex threads configuration might be  'threads=((count=2,reads=1),(count=8,reads=1,inserts=2,updates=1))' which would create 2  threads doing only reads and 8 threads each doing 50% inserts and 25% reads and updates.  Allowed configuration values are 'count', 'throttle', 'inserts', 'reads', 'read_range',  'modify', 'modify_delta', 'modify_distribute', 'modify_force_update', 'reopen_cursor',  'updates', 'update_delta', 'truncate', 'truncate_pct' and 'truncate_count'. There are also  behavior modifiers, supported modifiers are 'ops_per_txn'
-@par tiered (string, default="none")
-tiered extension.  Allowed configuration values are: 'none', 'dir_store'
-@par tiered_bucket (string, default="none")
-Create this bucket directory before beginning the test.
-@par tiered_flush_interval (unsigned int, default=0)
-Call flush_tier every interval seconds during the workload phase.  We recommend this value be larger than the checkpoint_interval. 0 to disable. The  'tiered_extension' must be set to something other than 'none'.
 @par transaction_config (string, default="")
 WT_SESSION.begin_transaction configuration string, applied during the populate phase when  populate_ops_per_txn is nonzero
 @par table_name (string, default="test")


### PR DESCRIPTION
> This PR was created by an automated coding agent.

Strip `flush_tier_worker`, `config_tiered`, `create_tiered_bucket`, `sum_flush_ops`, and `opts->tiered*` (`tiered`, `tiered_bucket`, `tiered_flush_interval`) from wtperf internals (`wtperf.c`, `wtperf.h`, `wtperf_opt_inline.h`, `track.c`, `wtperf_config.c`). Drop the matching flush-thread / `flush_ops` tracking fields. `dist/s_docs` regenerates the option list in `src/docs/wtperf.dox`. Leave `tiered-*.wtperf` runners and all of `src/` (except that generated option list) alone.

## Testing
- `cmake --build build` (Ninja Debug + Python) → success
- `./build/bench/wtperf/wtperf -O bench/wtperf/runners/small-btree.wtperf -o "icount=2000,run_time=2,report_interval=1,populate_threads=1,threads=((count=1,reads=1))"` → success
- `cd dist && ./s_fast` → s_docs clean after dox regen

Made with [Cursor](https://cursor.com)