### PR TITLE
WT-12880 Harden test_prepare_hs03's salvage coverage and add a dictionary scenario

### DIFF
--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -57,33 +57,31 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
     ]
 
     # The impact of corrupting the database file depends on how much of the file is overwritten,
-    # depending on what the rest of the test does and expects. Sizing this as a fraction of the
-    # table rather than as a byte count keeps it proportionate however well the values happen to
-    # compress. The amount of data that is corrupted by the 'string-row' test is much larger, as
-    # that increases the chance of interactions with, for example, the results of combining
+    # depending on what the rest of the test does and expects. A fraction of the table keeps this
+    # proportionate however well the values happen to compress; a fraction of zero corrupts a
+    # single block. The amount of data that is corrupted by the 'string-row' tests is much larger,
+    # as that increases the chance of interactions with, for example, the results of combining
     # timestamp hooks into the test.
-    format_values = [
-        ('column', dict(key_format='r', corrupt_fraction=0.0003)),
-        ('string-row', dict(key_format='S', corrupt_fraction=0.033)),
-    ]
+    corrupt_fraction = 0.033
 
     # A dictionary collapses this test's uniform values by more than an order of magnitude, which
     # exercises salvage against a far denser file.
-    dictionary_values = [
-        ('no_dictionary', dict(dictionary=False)),
-        ('dictionary', dict(dictionary=True)),
+    format_values = [
+        ('column', dict(key_format='r', corrupt_fraction=0, dictionary=False)),
+        ('string-row', dict(key_format='S', dictionary=False)),
+        ('string-row-dictionary', dict(key_format='S', dictionary=True)),
     ]
 
     value_format='u'
 
     # Every key checked by this test passes through three values: an untimestamped initial load, a
     # committed update, and a prepared update that is never resolved.
-    load_rows = 10000
+    load_end = 10000
     load_value = b"aaaaa" * 100
     commit_value = b"bbbbb" * 100
     prepare_value = b"ccccc" * 100
 
-    scenarios = make_scenarios(corrupt_values, format_values, dictionary_values)
+    scenarios = make_scenarios(corrupt_values, format_values)
 
     def value_is_acceptable(self, i, value):
         if value == self.commit_value:
@@ -93,7 +91,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # committed update. Only the keys the initial load wrote have such an older value, and only
         # a corrupted table can send salvage looking for one. The prepared value is never
         # acceptable: it must not be visible below the prepare timestamp.
-        return self.corrupt and i < self.load_rows and value == self.load_value
+        return self.corrupt and i < self.load_end and value == self.load_value
 
     def corrupt_table(self):
         tablename=f"{self.test_name}.wt"
@@ -141,14 +139,15 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
                 break
             self.session.checkpoint()
 
-    def check_data(self, ds, message, nkeys, nrows, timestamp):
+    def check_data(self, ds, message, nkeys_end, nrows, timestamp):
         # Search for the keys inserted with commit timestamp
         cursor = self.session.open_cursor(self.uri)
         self.pr('check_data: {}'.format(message))
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(timestamp))
         nkeys_checked = 0
+        nkeys_stale = 0
         unexpected = []
-        for i in range(1, nkeys):
+        for i in range(1, nkeys_end):
             key = nrows + i
             cursor.set_key(ds.key(key))
             # It is not guaranteed that salvage recovers all the data in the table, so count the
@@ -157,14 +156,21 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
                 self.pr('Key {} not found'.format(key))
                 continue
             nkeys_checked += 1
-            # Report the value a key came back with, not just how many keys disagreed.
-            if not self.value_is_acceptable(i, cursor.get_value()):
-                unexpected.append((key, cursor.get_value()[:16]))
-        self.pr("nkeys_checked = {}, unexpected = {}".format(nkeys_checked, len(unexpected)))
+            value = cursor.get_value()
+            # Report the value a key came back with, not just how many keys disagreed. Count the
+            # keys salvage rebuilt from an older image separately: accepting them is necessary but
+            # it is also the tolerance most likely to hide a real regression, so it must be
+            # visible rather than silent.
+            if value == self.load_value:
+                nkeys_stale += 1
+            if not self.value_is_acceptable(i, value):
+                unexpected.append((key, value[:16]))
+        self.pr("nkeys_checked = {}, nkeys_stale = {}, unexpected = {}".format(
+            nkeys_checked, nkeys_stale, len(unexpected)))
         self.assertEqual(unexpected, [], 'unexpected values: {}'.format(unexpected[:10]))
         # Bound how much salvage is allowed to lose. Counting only the keys a search finds says
         # nothing about how many it found, so without a floor this passes having recovered one key.
-        nkeys_expected = nkeys - 1
+        nkeys_expected = nkeys_end - 1
         if self.corrupt:
             # A key whose only copy was in the corrupted range is gone for good, but the corruption
             # covers a small fraction of the file, so losing most of the table means salvage
@@ -246,7 +252,9 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
             if cursor.search() != 0:
                 continue
             # A read below the prepare timestamp sees the committed value, never the prepared one.
-            self.assertTrue(self.value_is_acceptable(i, cursor.get_value()))
+            value = cursor.get_value()
+            self.assertTrue(self.value_is_acceptable(i, value),
+                'key {} holds unexpected value {}'.format(nrows + i, value[:16]))
         cursor.close()
 
         # Close all sessions (and cursors), this will cause prepared updates to be rolled back.
@@ -276,6 +284,9 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
         # After simulating a crash, corrupt the table, call salvage to recover data from the
         # corrupted table and call verify
+        # FIXME-WT-18449: The connection is now open on the copied directory, but corrupt_table
+        # builds a relative file name and so overwrites the pre-restart file. This salvages an
+        # intact table, and the post-crash corruption path is untested.
         self.corrupt_salvage_verify()
 
     def test_prepare_hs(self):
@@ -287,7 +298,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
         # Initially load huge data
         cursor = self.session.open_cursor(self.uri)
-        for i in range(1, self.load_rows):
+        for i in range(1, self.load_end):
             cursor.set_key(ds.key(nrows + i))
             cursor.set_value(self.load_value)
             self.assertEqual(cursor.insert(), 0)

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -67,7 +67,24 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
     value_format='u'
 
+    # Every key checked by this test passes through three values: an untimestamped initial load, a
+    # committed update, and a prepared update that is never resolved.
+    load_rows = 10000
+    load_value = b"aaaaa" * 100
+    commit_value = b"bbbbb" * 100
+    prepare_value = b"ccccc" * 100
+
     scenarios = make_scenarios(corrupt_values, format_values)
+
+    def value_is_acceptable(self, i, value):
+        if value == self.commit_value:
+            return True
+        # Salvage recovers a key range whose current page was corrupted from an older copy of that
+        # range elsewhere in the file, so a key can come back holding the value it had before the
+        # committed update. Only the keys the initial load wrote have such an older value, and only
+        # a corrupted table can send salvage looking for one. The prepared value is never
+        # acceptable: it must not be visible below the prepare timestamp.
+        return self.corrupt and i < self.load_rows and value == self.load_value
 
     def corrupt_table(self, data_to_corrupt_with):
         tablename=f"{self.test_name}.wt"
@@ -112,28 +129,27 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
                 break
             self.session.checkpoint()
 
-    def check_data(self, ds, message, nkeys, nrows, timestamp, expected_value):
+    def check_data(self, ds, message, nkeys, nrows, timestamp):
         # Search for the keys inserted with commit timestamp
         cursor = self.session.open_cursor(self.uri)
         self.pr('check_data: {}'.format(message))
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(timestamp))
-        correct_values = 0
         nkeys_checked = 0
+        unexpected = []
         for i in range(1, nkeys):
             key = nrows + i
-            if cursor.set_key(ds.key(key)) != 0:
-                # It is not guaranteed that salvage recovers all the data in the table. Therefore
-                # perform a search and increment number of keys once search is successful.
-                search_result = cursor.search()
-                if search_result == 0:
-                    nkeys_checked += 1
-                    # Correctness Test - expected_value should be visible
-                    if cursor.get_value() == expected_value:
-                        correct_values += 1
-                else:
-                    self.pr('Key {} not found'.format(key))
-        self.pr("nkeys_checked = {}, correct_values = {}".format(nkeys_checked, correct_values))
-        self.assertEqual(nkeys_checked, correct_values)
+            cursor.set_key(ds.key(key))
+            # It is not guaranteed that salvage recovers all the data in the table, so count the
+            # keys a search actually finds rather than requiring all of them.
+            if cursor.search() != 0:
+                self.pr('Key {} not found'.format(key))
+                continue
+            nkeys_checked += 1
+            # Report the value a key came back with, not just how many keys disagreed.
+            if not self.value_is_acceptable(i, cursor.get_value()):
+                unexpected.append((key, cursor.get_value()[:16]))
+        self.pr("nkeys_checked = {}, unexpected = {}".format(nkeys_checked, len(unexpected)))
+        self.assertEqual(unexpected, [], 'unexpected values: {}'.format(unexpected[:10]))
         cursor.close()
         self.session.commit_transaction()
 
@@ -147,9 +163,6 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
             return 1, 2, 3
 
     def prepare_updates(self, ds, nrows, nsessions, nkeys):
-        commit_value = b"bbbbb" * 100
-        prepare_value = b"ccccc" * 100
-
         # Three timestamps are required for this test, and they must be in the sequence 'early', 'middle' & 'later'.
         timestamps = self.get_timestamps()
         timestamp_early = timestamps[0]
@@ -163,7 +176,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         for i in range(1, nsessions * nkeys):
             self.session.begin_transaction()
             cursor.set_key(ds.key(nrows + i))
-            cursor.set_value(commit_value)
+            cursor.set_value(self.commit_value)
             self.assertEqual(cursor.insert(), 0)
             self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(timestamp_early))
         cursor.close()
@@ -190,7 +203,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
             end = start + nkeys
             for i in range(start, end):
                 cursors[j].set_key(ds.key(nrows + i))
-                cursors[j].set_value(prepare_value)
+                cursors[j].set_value(self.prepare_value)
                 self.assertEqual(cursors[j].insert(), 0)
             sessions[j].prepare_transaction('prepare_timestamp=' + self.timestamp_str(timestamp_later))
 
@@ -199,19 +212,18 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # Assert if not writing anything to the history store.
         self.assertGreaterEqual(hs_writes, 0)
 
-        self.check_data(ds, "(step 1)", nsessions * nkeys, nrows, timestamp_middle, commit_value)
+        self.check_data(ds, "(step 1)", nsessions * nkeys, nrows, timestamp_middle)
 
-        # Test if we can read prepared updates from the history store.
+        # Test if we can read prepared updates from the history store. Hold the read transaction
+        # open across the rollback of the prepared updates below.
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(timestamp_middle))
         for i in range(1, nsessions * nkeys):
             cursor.set_key(ds.key(nrows + i))
-            # The search should pass.
-            self.assertEqual(cursor.search(), 0)
-            # Correctness Test - commit_value should be visible
-            self.assertEqual(cursor.get_value(), commit_value)
-            # Correctness Test - prepare_value should NOT be visible
-            self.assertNotEqual(cursor.get_value(), prepare_value)
+            if cursor.search() != 0:
+                continue
+            # A read below the prepare timestamp sees the committed value, never the prepared one.
+            self.assertTrue(self.value_is_acceptable(i, cursor.get_value()))
         cursor.close()
 
         # Close all sessions (and cursors), this will cause prepared updates to be rolled back.
@@ -220,13 +232,13 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
         self.session.commit_transaction()
 
-        self.check_data(ds, "(step 2)", nsessions * nkeys, nrows, timestamp_later, commit_value)
+        self.check_data(ds, "(step 2)", nsessions * nkeys, nrows, timestamp_later)
 
         # Corrupt the table, call salvage to recover data from the corrupted table and call verify
         self.corrupt_salvage_verify()
 
         # Finally, search for the keys inserted with commit timestamp
-        self.check_data(ds, "(step 3)", nsessions * nkeys, nrows, timestamp_later, commit_value)
+        self.check_data(ds, "(step 3)", nsessions * nkeys, nrows, timestamp_later)
 
         self.session.checkpoint()
 
@@ -237,7 +249,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         self.conn = self.setUpConnectionOpen("RESTART")
         self.session = self.setUpSessionOpen(self.conn)
 
-        self.check_data(ds, "(step 4)", nsessions * nkeys, nrows, timestamp_later, commit_value)
+        self.check_data(ds, "(step 4)", nsessions * nkeys, nrows, timestamp_later)
 
         # After simulating a crash, corrupt the table, call salvage to recover data from the
         # corrupted table and call verify
@@ -249,13 +261,11 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
             self, self.uri, nrows, key_format=self.key_format, value_format=self.value_format)
         ds.populate()
 
-        bigvalue = b"aaaaa" * 100
-
         # Initially load huge data
         cursor = self.session.open_cursor(self.uri)
-        for i in range(1, 10000):
+        for i in range(1, self.load_rows):
             cursor.set_key(ds.key(nrows + i))
-            cursor.set_value(bigvalue)
+            cursor.set_value(self.load_value)
             self.assertEqual(cursor.insert(), 0)
         cursor.close()
         self.session.checkpoint()

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -150,6 +150,17 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
                 unexpected.append((key, cursor.get_value()[:16]))
         self.pr("nkeys_checked = {}, unexpected = {}".format(nkeys_checked, len(unexpected)))
         self.assertEqual(unexpected, [], 'unexpected values: {}'.format(unexpected[:10]))
+        # Bound how much salvage is allowed to lose. Counting only the keys a search finds says
+        # nothing about how many it found, so without a floor this passes having recovered one key.
+        nkeys_expected = nkeys - 1
+        if self.corrupt:
+            # A key whose only copy was in the corrupted range is gone for good, but the corruption
+            # covers a small fraction of the file, so losing most of the table means salvage
+            # discarded data it could have kept.
+            self.assertGreaterEqual(nkeys_checked, nkeys_expected // 2,
+                'salvage recovered {} of {} keys'.format(nkeys_checked, nkeys_expected))
+        else:
+            self.assertEqual(nkeys_checked, nkeys_expected)
         cursor.close()
         self.session.commit_transaction()
 

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -56,13 +56,22 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         ('dont_corrupt_table', dict(corrupt=False))
     ]
 
-    # The impact of corrupting the database file can depend on the number of bytes overwritten,
-    # depending on what the rest of the test does and expects. The amount of data that
-    # is corrupted by the 'string-row' test is much larger, as that increases the chance of interactions
-    # with, for example, the results of combining timestamp hooks into the test.
+    # The impact of corrupting the database file depends on how much of the file is overwritten,
+    # depending on what the rest of the test does and expects. Sizing this as a fraction of the
+    # table rather than as a byte count keeps it proportionate however well the values happen to
+    # compress. The amount of data that is corrupted by the 'string-row' test is much larger, as
+    # that increases the chance of interactions with, for example, the results of combining
+    # timestamp hooks into the test.
     format_values = [
-        ('column', dict(key_format='r', data_to_corrupt_with='Bad!' * 1024)),
-        ('string-row', dict(key_format='S', data_to_corrupt_with='Bad!' * 100 * 1024)),
+        ('column', dict(key_format='r', corrupt_fraction=0.0003)),
+        ('string-row', dict(key_format='S', corrupt_fraction=0.033)),
+    ]
+
+    # A dictionary collapses this test's uniform values by more than an order of magnitude, which
+    # exercises salvage against a far denser file.
+    dictionary_values = [
+        ('no_dictionary', dict(dictionary=False)),
+        ('dictionary', dict(dictionary=True)),
     ]
 
     value_format='u'
@@ -74,7 +83,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
     commit_value = b"bbbbb" * 100
     prepare_value = b"ccccc" * 100
 
-    scenarios = make_scenarios(corrupt_values, format_values)
+    scenarios = make_scenarios(corrupt_values, format_values, dictionary_values)
 
     def value_is_acceptable(self, i, value):
         if value == self.commit_value:
@@ -86,7 +95,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # acceptable: it must not be visible below the prepare timestamp.
         return self.corrupt and i < self.load_rows and value == self.load_value
 
-    def corrupt_table(self, data_to_corrupt_with):
+    def corrupt_table(self):
         tablename=f"{self.test_name}.wt"
         self.assertEqual(os.path.exists(tablename), True)
 
@@ -96,7 +105,10 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # the test whenever the file layout happens to place an extent-list block in the range below.
         protect = sorted(checkpoint_extent_list_blocks(self.session, 'file:' + self.test_name + '.wt'))
         start = 1024
-        data = bytes(data_to_corrupt_with, 'latin-1')
+        # Overwrite at least one block however small the table turned out to be.
+        size = max(4096, int(os.path.getsize(tablename) * self.corrupt_fraction))
+        pattern = b'Bad!'
+        data = (pattern * (size // len(pattern) + 1))[:size]
         end = start + len(data)
         with open(tablename, 'r+b') as f:
             pos = start
@@ -118,8 +130,8 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # clear the dirty data, but eviction can re-dirty the cache between the checkpoint and the
         # open attempt, we have to loop.
         self.session.checkpoint()
-        if self.corrupt == True:
-            self.corrupt_table(self.data_to_corrupt_with)
+        if self.corrupt:
+            self.corrupt_table()
         while True:
             if not self.raisesBusy(lambda: self.session.salvage(self.uri, "force")):
                 break
@@ -269,7 +281,8 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
     def test_prepare_hs(self):
         nrows = 100
         ds = SimpleDataSet(
-            self, self.uri, nrows, key_format=self.key_format, value_format=self.value_format)
+            self, self.uri, nrows, key_format=self.key_format, value_format=self.value_format,
+            config='dictionary=1' if self.dictionary else '')
         ds.populate()
 
         # Initially load huge data

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -94,7 +94,10 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         return self.corrupt and i < self.load_end and value == self.load_value
 
     def corrupt_table(self):
-        tablename=f"{self.test_name}.wt"
+        # Resolve the table against the connection's home: after the simulated crash the connection
+        # is open on the copied directory, and a relative name would corrupt the database the test
+        # has already finished with rather than the one it is about to salvage.
+        tablename=os.path.join(self.home, f"{self.test_name}.wt")
         self.assertEqual(os.path.exists(tablename), True)
 
         # Leave the checkpoint's extent-list blocks intact. Salvage cannot recover a corrupt extent
@@ -284,10 +287,9 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
         # After simulating a crash, corrupt the table, call salvage to recover data from the
         # corrupted table and call verify
-        # FIXME-WT-18449: The connection is now open on the copied directory, but corrupt_table
-        # builds a relative file name and so overwrites the pre-restart file. This salvages an
-        # intact table, and the post-crash corruption path is untested.
         self.corrupt_salvage_verify()
+
+        self.check_data(ds, "(step 5)", nsessions * nkeys, nrows, timestamp_later)
 
     def test_prepare_hs(self):
         nrows = 100


### PR DESCRIPTION
`test_prepare_hs03` fails when a dictionary is configured on the table, but not because of anything wrong with dictionaries or salvage. The corruption the test injects is a hard-coded byte count calibrated against uncompressed data. Every value in this test is identical, so a dictionary collapses them all into copy cells and shrinks the table from 11.75MB to 0.81MB — the same 400KB then overwrites roughly half the file rather than a few percent of it, and salvage legitimately cannot recover about a quarter of the keys. Salvage verbose output confirms no page was rejected for containing dictionary cells and nothing failed verify, and reconciliation already rebuilds pre-existing copy cells in `__rec_cell_repack`.

The first change closes the hole that let this sit unnoticed. `check_data` counts only the keys a search finds and compares that count to how many held the right value, so it never checks how many it found: the test passes having recovered a single key out of twelve thousand, and a salvage regression that dropped most of a file would go unreported. An intact table must now recover every key, and a corrupted one at least half. The margin is deliberately wide rather than tuned — every scenario recovers all 11999 keys — so it is a guard against catastrophe, not a threshold that will drift on a slower variant. Verified it has teeth by widening the corruption until salvage recovered 2976 of 11999, which the current assertions accept silently.

The corruption is then sized as a fraction of the table, and the dictionary added as a third row-store scenario. The two existing scenarios keep their names, their positions and the sizes they corrupt today: column-store asks for a single block, and row-store lands between 389KB and 454KB against its current 400KB. Keeping the names matters because both this ticket and WT-14622 refer to `corrupt_table.string-row`. With the corruption proportionate, all six scenarios recover every key, which leaves the value check doing the real work and the recovery floor slack. Left absolute, the dictionary scenario recovered between 8458 and 9092 keys over twelve runs — it would have passed the floor, but only because a quarter of the table was permanently gone.

Also fixes WT-18449, found while reviewing this. The corruption after the simulated crash was overwriting the pre-restart file: reopening the connection on the copied directory does not change the working directory, so the relative file name resolved against the database the test had already finished with. The final salvage had been running against an intact table. Confirmed by printing the absolute path each corruption targets against the connection's home, and confirmed fixed the same way. The data is now checked after that salvage too, so the newly reached path asserts something beyond salvage and verify not returning an error; all six scenarios recover every key there.

Worth noting that WT-12880's reported signature is no longer reachable on develop: it included wrong values, and today the dictionary produces key loss only. This makes the scenario supportable and closes the coverage gaps the ticket exposed rather than fixing a live failure.