### PR TITLE
WT-17851 Poll the expired-close sweep stat for an idle handle close in test_layered_checkpoint08

### DIFF
--- a/test/suite/test_layered_checkpoint08.py
+++ b/test/suite/test_layered_checkpoint08.py
@@ -64,18 +64,18 @@ class test_layered_checkpoint08(checkpoint_util):
         # Take the sweep baseline after all initial sweeps has been settled. Any future sweeps is
         # exclusively from the test table.
         time.sleep(2)
-        sweep_closes_before = self.get_stat(wiredtiger.stat.conn.dh_sweep_dead_close)
+        sweep_closes_before = self.get_stat(wiredtiger.stat.conn.dh_sweep_expired_close)
 
         session2.close()
 
         # Wait until the sweep has closed any idle handles. With close_scan_interval=1 and
-        # close_idle_time=1, a dead handle is closed within a couple of sweep cycles, so bound the
+        # close_idle_time=1, an idle handle expires within a couple of sweep cycles, so bound the
         # wait to fail fast with a clear error rather than spin until the task timeout if the sweep
         # never makes progress.
-        self.assertStatGreaterSoon(wiredtiger.stat.conn.dh_sweep_dead_close, sweep_closes_before,
+        self.assertStatGreaterSoon(wiredtiger.stat.conn.dh_sweep_expired_close, sweep_closes_before,
             timeout=60, msg='sweep server did not close the idle table handle within 60 seconds')
         self.pr(f"Dhandles closed by sweep: "
-            f"{self.get_stat(wiredtiger.stat.conn.dh_sweep_dead_close) - sweep_closes_before}")
+            f"{self.get_stat(wiredtiger.stat.conn.dh_sweep_expired_close) - sweep_closes_before}")
 
         # Start a checkpoint in a separate thread
         def checkpoint_thread_fn(conn):


### PR DESCRIPTION
`test_layered_checkpoint08` waits for the sweep server to close an idle table handle after `session2.close()`, but polls `dh_sweep_dead_close`. That counter is only incremented for handles that reach the dead-tree discard loop while still marked open. Idle expiry goes through `__sweep_expire_one()`, which marks the handle dead and closes it in the same `__wt_conn_dhandle_close()` call, clearing `WT_DHANDLE_OPEN`; such a handle never reaches the discard loop and is counted by `dh_sweep_expired_close` instead.

The test therefore only passed when unrelated dead closes — disagg outdated or dropped handles — happened to land inside the 60 second window, and timed out on a slower host. Switching the poll to `dh_sweep_expired_close` observes the idle expiry directly.

Instrumenting the same wait locally shows `dh_sweep_expired_close` moving by 3 while `dh_sweep_dead_close` moves by 2 incidentally, confirming which counter tracks the close the test is waiting on. 15/15 green with the change.