### PR TITLE
WT-18369 Rebuild missing stable constituents with their create-time configuration

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -203,8 +203,8 @@ __block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool fail
          * they capture the checkpoint state of the stable table that was just checkpointed.
          */
         WT_SAVE_DHANDLE(session,
-          ret = __wt_disagg_enqueue_metadata_operation(
-            session, stable_uri, table_name, WT_SHARED_METADATA_UPDATE, schema_epoch, false, NULL));
+          ret = __wt_disagg_enqueue_metadata_operation(session, stable_uri, table_name,
+            WT_SHARED_METADATA_UPDATE, schema_epoch, false, NULL, NULL));
         WT_ERR(ret);
     }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -61,17 +61,9 @@ __layered_stable_page_log_config(
     WT_DECL_ITEM(buf);
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
 
-    /* Read the page_log field from the layered metadata, if present. */
+    /* Read the page_log field from the layered metadata. */
     WT_CONFIG_ITEM cval;
-    WT_ERR_NOTFOUND_OK(
-      __wt_config_getones(session, layered_cfg, "disaggregated.page_log", &cval), true);
-
-    if (ret != 0 || cval.len == 0) {
-        /* Fall back to the connection's page log. */
-        const char *conn_page_log = S2C(session)->disaggregated_storage.page_log;
-        cval.str = conn_page_log == NULL ? "" : conn_page_log;
-        cval.len = strlen(cval.str);
-    }
+    WT_ERR(__wt_config_getones(session, layered_cfg, "disaggregated.page_log", &cval));
 
     /* Format the selected page log for the final configuration. */
     WT_ERR(__wt_buf_fmt(session, buf, "disaggregated=(page_log=%.*s)", (int)cval.len, cval.str));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -125,17 +125,16 @@ __layered_create_missing_stable_table(
   WT_SESSION_IMPL *session, const char *uri, const char *layered_cfg, const char *stable_create_cfg)
 {
     WT_DECL_RET;
-    bool free_required = false;
+    const char *config, *derived_config = NULL;
 
-    if (stable_create_cfg == NULL) {
-        WT_RET(__layered_stable_config_from_ingest(session, layered_cfg, &stable_create_cfg));
-        free_required = true; /* stable_create_cfg is now locally allocated. */
+    config = stable_create_cfg;
+    if (config == NULL) {
+        WT_RET(__layered_stable_config_from_ingest(session, layered_cfg, &derived_config));
+        config = derived_config; /* config now points to locally allocated memory. */
     }
 
-    WT_WITH_SCHEMA_LOCK(session, ret = __wt_schema_create(session, uri, stable_create_cfg));
-
-    if (free_required)
-        __wt_free(session, stable_create_cfg);
+    WT_WITH_SCHEMA_LOCK(session, ret = __wt_schema_create(session, uri, config));
+    __wt_free(session, derived_config);
 
     return (ret);
 }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -17,11 +17,11 @@ static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
  */
 static int
 __layered_file_config_from_ingest(
-  WT_SESSION_IMPL *session, const char *layered_cfg, char **projectedp)
+  WT_SESSION_IMPL *session, const char *layered_cfg, char **file_cfgp)
 {
     WT_DECL_RET;
     char *ingest_meta = NULL;
-    *projectedp = NULL;
+    *file_cfgp = NULL;
 
     /* Determine the ingest URI. */
     WT_DECL_ITEM(ingest_uri);
@@ -39,7 +39,7 @@ __layered_file_config_from_ingest(
     cfg[0] = WT_CONFIG_BASE(session, file_config);
     cfg[1] = ingest_meta;
     cfg[2] = NULL;
-    WT_ERR(__wt_config_collapse(session, cfg, projectedp));
+    WT_ERR(__wt_config_collapse(session, cfg, file_cfgp));
 
 err:
     __wt_free(session, ingest_meta);
@@ -92,10 +92,10 @@ __layered_stable_config_from_ingest(
   WT_SESSION_IMPL *session, const char *layered_cfg, const char **stable_cfgp)
 {
     WT_DECL_RET;
-    char *page_log_cfg = NULL, *projected = NULL;
+    char *ingest_file_cfg = NULL, *page_log_cfg = NULL;
     *stable_cfgp = NULL;
 
-    WT_ERR(__layered_file_config_from_ingest(session, layered_cfg, &projected));
+    WT_ERR(__layered_file_config_from_ingest(session, layered_cfg, &ingest_file_cfg));
     WT_ERR(__layered_stable_page_log_config(session, layered_cfg, &page_log_cfg));
 
     /*
@@ -103,14 +103,14 @@ __layered_stable_config_from_ingest(
      * sibling settings such as storage_tier.
      */
     const char *cfg[4];
-    cfg[0] = projected;
+    cfg[0] = ingest_file_cfg;
     cfg[1] = "block_manager=disagg,in_memory=false,log=(enabled=false)";
     cfg[2] = page_log_cfg;
     cfg[3] = NULL;
     WT_ERR(__wt_config_merge(session, cfg, NULL, stable_cfgp));
 
 err:
-    __wt_free(session, projected);
+    __wt_free(session, ingest_file_cfg);
     __wt_free(session, page_log_cfg);
     return (ret);
 }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -11,27 +11,129 @@
 static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
 
 /*
+ * __layered_file_config_from_ingest --
+ *     Build a file configuration from the ingest constituent's metadata. Exclude the file ID and
+ *     checkpoint state because the stable constituent gets its own.
+ */
+static int
+__layered_file_config_from_ingest(
+  WT_SESSION_IMPL *session, const char *layered_cfg, char **projectedp)
+{
+    WT_DECL_RET;
+    char *ingest_meta = NULL;
+
+    /* Determine the ingest URI. */
+    WT_DECL_ITEM(ingest_uri);
+    WT_ERR(__wt_scr_alloc(session, 0, &ingest_uri));
+
+    WT_CONFIG_ITEM cval;
+    WT_ERR(__wt_config_getones(session, layered_cfg, "ingest", &cval));
+    WT_ERR(__wt_buf_fmt(session, ingest_uri, "%.*s", (int)cval.len, cval.str));
+
+    /* Read the metadata for that ingest URI. */
+    WT_ERR(__wt_metadata_search(session, ingest_uri->data, &ingest_meta));
+
+    /* Use ingest metadata values where available and file configuration defaults otherwise. */
+    const char *cfg[3];
+    cfg[0] = WT_CONFIG_BASE(session, file_config);
+    cfg[1] = ingest_meta;
+    cfg[2] = NULL;
+    WT_ERR(__wt_config_collapse(session, cfg, projectedp));
+
+err:
+    __wt_free(session, ingest_meta);
+    __wt_scr_free(session, &ingest_uri);
+    return (ret);
+}
+
+/*
+ * __layered_stable_page_log_config --
+ *     Build the page log portion of the stable constituent's configuration.
+ */
+static int
+__layered_stable_page_log_config(
+  WT_SESSION_IMPL *session, const char *layered_cfg, char **page_log_cfgp)
+{
+    WT_DECL_RET;
+
+    WT_DECL_ITEM(buf);
+    WT_ERR(__wt_scr_alloc(session, 0, &buf));
+
+    /* Read the page_log field from the layered metadata, if present. */
+    WT_CONFIG_ITEM cval;
+    WT_ERR_NOTFOUND_OK(
+      __wt_config_getones(session, layered_cfg, "disaggregated.page_log", &cval), true);
+
+    if (ret != 0 || cval.len == 0) {
+        /* Fall back to the connection's page log. */
+        const char *conn_page_log = S2C(session)->disaggregated_storage.page_log;
+        cval.str = conn_page_log == NULL ? "" : conn_page_log;
+        cval.len = strlen(cval.str);
+    }
+
+    /* Format the selected page log for the final configuration. */
+    WT_ERR(__wt_buf_fmt(session, buf, "disaggregated=(page_log=%.*s)", (int)cval.len, cval.str));
+    WT_ERR(__wt_strndup(session, buf->data, buf->size, page_log_cfgp));
+
+err:
+    __wt_scr_free(session, &buf);
+    return (ret);
+}
+
+/*
+ * __layered_stable_config_from_ingest --
+ *     Build the stable constituent's configuration by adding stable-specific settings to the file
+ *     configuration derived from the ingest constituent.
+ */
+static int
+__layered_stable_config_from_ingest(
+  WT_SESSION_IMPL *session, const char *layered_cfg, const char **stable_cfgp)
+{
+    WT_DECL_RET;
+    char *page_log_cfg = NULL, *projected = NULL;
+
+    WT_ERR(__layered_file_config_from_ingest(session, layered_cfg, &projected));
+    WT_ERR(__layered_stable_page_log_config(session, layered_cfg, &page_log_cfg));
+
+    /*
+     * Apply the stable constituent's settings. Merge nested fields so setting page_log preserves
+     * sibling settings such as storage_tier.
+     */
+    const char *cfg[4];
+    cfg[0] = projected;
+    cfg[1] = "block_manager=disagg,in_memory=false,log=(enabled=false)";
+    cfg[2] = page_log_cfg;
+    cfg[3] = NULL;
+    WT_ERR(__wt_config_merge(session, cfg, NULL, stable_cfgp));
+
+err:
+    __wt_free(session, projected);
+    __wt_free(session, page_log_cfg);
+    return (ret);
+}
+
+/*
  * __layered_create_missing_stable_table --
- *     Create a missing stable table from an existing layered table configuration.
+ *     Create a missing stable table, using the caller-provided configuration or deriving one from
+ *     the ingest constituent.
  */
 static int
 __layered_create_missing_stable_table(
-  WT_SESSION_IMPL *session, const char *uri, const char *layered_cfg)
+  WT_SESSION_IMPL *session, const char *uri, const char *layered_cfg, const char *stable_create_cfg)
 {
     WT_DECL_RET;
-    const char *constituent_cfg;
-    const char *stable_cfg[4] = {WT_CONFIG_BASE(session, table_meta), layered_cfg, NULL, NULL};
+    bool free_required = false;
 
-    constituent_cfg = NULL;
+    if (stable_create_cfg == NULL) {
+        WT_RET(__layered_stable_config_from_ingest(session, layered_cfg, &stable_create_cfg));
+        free_required = true; /* stable_create_cfg is now locally allocated. */
+    }
 
-    /* Disable logging on the stable table so we have timestamps. */
-    stable_cfg[2] = "log=(enabled=false)";
+    WT_WITH_SCHEMA_LOCK(session, ret = __wt_schema_create(session, uri, stable_create_cfg));
 
-    WT_ERR(__wt_config_merge(session, stable_cfg, NULL, &constituent_cfg));
-    WT_WITH_SCHEMA_LOCK(session, ret = __wt_schema_create(session, uri, constituent_cfg));
+    if (free_required)
+        __wt_free(session, stable_create_cfg);
 
-err:
-    __wt_free(session, constituent_cfg);
     return (ret);
 }
 
@@ -87,7 +189,7 @@ __layered_create_missing_stable_tables_legacy(WT_SESSION_IMPL *session)
          */
         if (ret == WT_NOTFOUND) {
             WT_ERR_MSG_CHK(session,
-              __layered_create_missing_stable_table(session, stable_uri, layered_cfg),
+              __layered_create_missing_stable_table(session, stable_uri, layered_cfg, NULL),
               "Failed to create missing stable table \"%s\" from \"%s\"", stable_uri, layered_cfg);
 
             /*
@@ -96,7 +198,7 @@ __layered_create_missing_stable_tables_legacy(WT_SESSION_IMPL *session)
              */
             WT_ERR(__wt_disagg_enqueue_metadata_operation(session, stable_uri,
               layered_uri + strlen("layered:"), WT_SHARED_METADATA_CREATE,
-              WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL));
+              WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL, NULL));
             __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Created missing stable table \"%s\" from \"%s\"", stable_uri, layered_uri);
         }
@@ -201,7 +303,8 @@ __layered_create_missing_stable_tables_helper(WT_SESSION_IMPL *session)
 
         /* The table hasn't been dropped, so create it. */
         WT_ERR_MSG_CHK(session,
-          __layered_create_missing_stable_table(session, entry->stable_uri, entry->layered_value),
+          __layered_create_missing_stable_table(
+            session, entry->stable_uri, entry->layered_value, entry->stable_create_config),
           "Failed to create missing stable table \"%s\" with schema epoch %" PRIu64
           " from layered config \"%s\"",
           entry->stable_uri, entry->schema_epoch, entry->layered_value);
@@ -266,6 +369,7 @@ __disagg_shared_metadata_queue_free(WT_SESSION_IMPL *session, WT_DISAGG_METADATA
     __wt_free(session, (*entry)->layered_value);
     __wt_free(session, (*entry)->stable_value);
     __wt_free(session, (*entry)->table_value);
+    __wt_free(session, (*entry)->stable_create_config);
     __wt_free(session, *entry);
     *entry = NULL;
 }
@@ -321,12 +425,14 @@ err:
  * __wt_disagg_enqueue_metadata_operation --
  *     Enqueue a metadata operation for a given URI into the shared metadata table to be done at the
  *     next checkpoint. A caller that has already removed the local metadata passes the stable
- *     table's configuration in stable_value, since it can no longer be read from local metadata.
+ *     table's configuration in stable_value, since it can no longer be read from local metadata. A
+ *     caller creating a table passes the stable table's create configuration in
+ *     stable_create_config, so that step-up can recreate a missing stable constituent.
  */
 int
 __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *stable_uri,
   const char *table_name, WT_SHARED_METADATA_OP metadata_op, wt_timestamp_t schema_epoch,
-  bool deferred, const char *stable_value)
+  bool deferred, const char *stable_value, const char *stable_create_config)
 {
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *cursor;
@@ -363,6 +469,8 @@ __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *sta
         WT_ERR(__wt_strdup(session, stable_value, &entry->stable_value));
     else
         WT_ERR(__disagg_save_metadata(session, cursor, "", stable_uri, &entry->stable_value));
+    if (stable_create_config != NULL)
+        WT_ERR(__wt_strdup(session, stable_create_config, &entry->stable_create_config));
 
     /*
      * Schema operations (create, drop) start deferred: at the start of each checkpoint, while the
@@ -393,6 +501,8 @@ __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *sta
       entry->table_value == NULL ? "<none>" : entry->table_value);
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE, "  stable: %s",
       entry->stable_value == NULL ? "<none>" : entry->stable_value);
+    __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE, "  stable create config: %s",
+      entry->stable_create_config == NULL ? "<none>" : entry->stable_create_config);
 
     /* No need to free the entry structure here as it has been added to the queue. */
     entry = NULL;

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -128,6 +128,11 @@ __layered_create_missing_stable_table(
     const char *config, *derived_config = NULL;
 
     config = stable_create_cfg;
+
+    /*
+     * Step-up without schema epochs clears the queue that carries stable_create_cfg. Derive the
+     * configuration from ingest metadata instead.
+     */
     if (config == NULL) {
         WT_RET(__layered_stable_config_from_ingest(session, layered_cfg, &derived_config));
         config = derived_config; /* config now points to locally allocated memory. */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -61,7 +61,12 @@ __layered_stable_page_log_config(
     WT_DECL_ITEM(buf);
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
 
-    /* Read the page_log field from the layered metadata, if present. */
+    /*
+     * Read the page_log field from the layered metadata, if present.
+     *
+     * FIXME-WT-18475: page_log can be absent because table-level disaggregated settings replace
+     * connection-level settings. Remove the WT_NOTFOUND handling when this absence is resolved.
+     */
     WT_CONFIG_ITEM cval;
     WT_ERR_NOTFOUND_OK(
       __wt_config_getones(session, layered_cfg, "disaggregated.page_log", &cval), true);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -61,9 +61,17 @@ __layered_stable_page_log_config(
     WT_DECL_ITEM(buf);
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
 
-    /* Read the page_log field from the layered metadata. */
+    /* Read the page_log field from the layered metadata, if present. */
     WT_CONFIG_ITEM cval;
-    WT_ERR(__wt_config_getones(session, layered_cfg, "disaggregated.page_log", &cval));
+    WT_ERR_NOTFOUND_OK(
+      __wt_config_getones(session, layered_cfg, "disaggregated.page_log", &cval), true);
+
+    if (ret != 0 || cval.len == 0) {
+        /* Fall back to the connection's page log. */
+        const char *conn_page_log = S2C(session)->disaggregated_storage.page_log;
+        cval.str = conn_page_log == NULL ? "" : conn_page_log;
+        cval.len = strlen(cval.str);
+    }
 
     /* Format the selected page log for the final configuration. */
     WT_ERR(__wt_buf_fmt(session, buf, "disaggregated=(page_log=%.*s)", (int)cval.len, cval.str));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -21,6 +21,7 @@ __layered_file_config_from_ingest(
 {
     WT_DECL_RET;
     char *ingest_meta = NULL;
+    *projectedp = NULL;
 
     /* Determine the ingest URI. */
     WT_DECL_ITEM(ingest_uri);
@@ -55,6 +56,7 @@ __layered_stable_page_log_config(
   WT_SESSION_IMPL *session, const char *layered_cfg, char **page_log_cfgp)
 {
     WT_DECL_RET;
+    *page_log_cfgp = NULL;
 
     WT_DECL_ITEM(buf);
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
@@ -91,6 +93,7 @@ __layered_stable_config_from_ingest(
 {
     WT_DECL_RET;
     char *page_log_cfg = NULL, *projected = NULL;
+    *stable_cfgp = NULL;
 
     WT_ERR(__layered_file_config_from_ingest(session, layered_cfg, &projected));
     WT_ERR(__layered_stable_page_log_config(session, layered_cfg, &page_log_cfg));

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -199,6 +199,9 @@ struct __wt_disagg_metadata_op {
     char *stable_value;   /* The value for the stable component. */
     char *table_value;    /* The value for the table component. */
 
+    /* The create-time configuration of the stable component, for recreating it at step-up. */
+    char *stable_create_config;
+
     WT_SHARED_METADATA_OP metadata_op; /* The type of the metadata operation. */
     wt_timestamp_t schema_epoch;       /* The schema epoch of the metadata operation. */
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -601,7 +601,8 @@ extern int __wt_disagg_config_get_role(WT_SESSION_IMPL *session, const char **cf
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *stable_uri,
   const char *table_name, WT_SHARED_METADATA_OP metadata_op, wt_timestamp_t schema_epoch,
-  bool deferred, const char *stable_value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  bool deferred, const char *stable_value, const char *stable_create_config)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_get_database_size(WT_SESSION_IMPL *session, uint64_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_parse_meta(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf,

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1203,6 +1203,10 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
       session, tmp, "ingest=\"%s\",stable=\"%s\",log=(enabled=false)", ingest_uri, stable_uri));
     layered_cfg[3] = tmp->data;
 
+    /*
+     * FIXME-WT-18475: the table-level disaggregated category replaces the connection-level
+     * category, so storage_tier removes page_log from the layered metadata.
+     */
     WT_ERR(__wt_config_collapse(session, layered_cfg, &tablecfg));
     WT_ERR(__wt_metadata_insert(session, uri, tablecfg));
 

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1112,7 +1112,7 @@ __create_table(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const 
             WT_ERR(__wt_scr_alloc(session, 0, &tmp));
             WT_ERR(__wt_buf_fmt(session, tmp, "file:%s.wt_stable", tablename));
             WT_ERR(__wt_disagg_enqueue_metadata_operation(session, tmp->data, tablename,
-              WT_SHARED_METADATA_CREATE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL));
+              WT_SHARED_METADATA_CREATE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL, NULL));
         }
 
 err:
@@ -1221,6 +1221,13 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
     WT_ERR(__wt_schema_create(session, ingest_uri, constituent_cfg));
     __wt_free(session, constituent_cfg);
 
+    /* Build the stable constituent configuration for a later step-up. */
+    stable_cfg[1] = disagg_config->data;
+
+    /* Disable logging on the stable table to ensure we have timestamps. */
+    stable_cfg[3] = "log=(enabled=false)";
+    WT_ERR(__wt_config_merge(session, stable_cfg, NULL, &constituent_cfg));
+
     /*
      * Once the step-down timestamp is set, all writes go to the ingest constituent, so a stable
      * constituent would stay empty. Create the table in the follower shape instead, and the next
@@ -1231,13 +1238,7 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
     step_down_ts = __wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_timestamp);
     if (__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         if (step_down_ts == WT_TS_NONE) {
-            stable_cfg[1] = disagg_config->data;
-
-            /* Disable logging on the stable table to ensure we have timestamps. */
-            stable_cfg[3] = "log=(enabled=false)";
-            WT_ERR(__wt_config_merge(session, stable_cfg, NULL, &constituent_cfg));
             WT_ERR(__wt_schema_create(session, stable_uri, constituent_cfg));
-            __wt_free(session, constituent_cfg);
         } else {
             WT_STAT_CONN_INCR(session, disagg_step_down_window_creates);
             __wt_verbose_info(session, WT_VERB_LAYERED,
@@ -1253,7 +1254,7 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
      * of a table creation, it would result in doing extra work.
      */
     WT_ERR(__wt_disagg_enqueue_metadata_operation(session, stable_uri, tablename,
-      WT_SHARED_METADATA_CREATE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL));
+      WT_SHARED_METADATA_CREATE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL, constituent_cfg));
 
 err:
     __wt_scr_free(session, &disagg_config);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -249,7 +249,7 @@ __drop_layered(
      */
     WT_SAVE_DHANDLE(session,
       ret = __wt_disagg_enqueue_metadata_operation(session, stable_uri, tablename,
-        WT_SHARED_METADATA_REMOVE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL));
+        WT_SHARED_METADATA_REMOVE, WT_SCHEMA_EPOCH_UNPUBLISHED, true, NULL, NULL));
     WT_ERR(ret);
 
 err:

--- a/test/suite/test_layered_schema31.py
+++ b/test/suite/test_layered_schema31.py
@@ -41,16 +41,13 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_config = 'disaggregated=(role="leader",lose_all_my_data=true)'
 
-    uri = f"layered:{test_name}"
-    ref_uri = f"layered:{test_name}_ref"
-
     # Create the table with a non-default value for every user-settable
     # immutable file setting, so the comparison exercises the full set of
     # fields the rebuild must preserve.
     # Encryption belongs to the same set but needs an encryptor extension, so
     # it is left out. The storage tier exercises the recursive merge of the
     # disaggregated category when the rebuild overrides the page log.
-    table_config = (
+    base_config = (
         "key_format=i,value_format=S,"
         "allocation_size=512B,"
         "block_allocation=first,"
@@ -74,23 +71,40 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         "split_pct=80"
     )
 
+    uri_scenarios = [
+        (
+            "layered",
+            {
+                "uri": f"layered:{test_name}",
+                "ref_uri": f"layered:{test_name}_ref",
+                "table_config": base_config,
+            },
+        ),
+        (
+            "table",
+            {
+                "uri": f"table:{test_name}",
+                "ref_uri": f"table:{test_name}_ref",
+                "table_config": base_config + ",type=layered",
+            },
+        ),
+    ]
+
     def conn_extensions(self, extlist):
         self.add_scenario_config()
         extlist.extension("compressors", "snappy")
         return self.disagg_conn_extensions(extlist)
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
-    scenarios = make_scenarios(disagg_storages)
+    scenarios = make_scenarios(disagg_storages, uri_scenarios)
 
-    def create_on_follower_then_step_up(self, config=None):
+    def create_on_follower_then_step_up(self, config):
         """
         Create and publish the table in the follower role, then step up to
         rebuild the missing stable constituent. A twin table created in the
         leader role first provides the reference stable constituent row the
         rebuild must reproduce.
         """
-        if config is None:
-            config = self.table_config
         self.set_stable_epoch(1)
         self.session.create(self.ref_uri, config)
         self.step_down()
@@ -176,7 +190,7 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         )
 
     def test_stepup_rebuild_keeps_file_settings(self):
-        self.create_on_follower_then_step_up()
+        self.create_on_follower_then_step_up(self.table_config)
         self.set_stable_epoch(10)
         self.check_rebuild_keeps_file_settings()
 
@@ -189,36 +203,10 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         Verify step-up uses the saved configuration rather than the
         ingest-derived fallback.
         """
-        self.create_on_follower_then_step_up("key_format=i,value_format=S")
+        config = self.table_config.replace("block_manager=disagg,", "")
+        self.create_on_follower_then_step_up(config)
         self.assert_matches_reference(
             self.read_stable_config(
                 self.conn, self.layered_stable_uri(self.uri)
             )
-        )
-
-    def test_stepup_rebuild_keeps_file_settings_table_prefix(self):
-        """
-        Verify creating a layered table through a URI starting with "table:"
-        preserves the saved configuration.
-        """
-        uri = f"table:{self.test_name}_tbl"
-        ref_uri = f"table:{self.test_name}_tbl_ref"
-        config = (
-            self.table_config.replace("block_manager=disagg,", "")
-            + ",type=layered"
-        )
-        stable_uri = self.layered_stable_uri(uri)
-
-        self.set_stable_epoch(1)
-        self.session.create(ref_uri, config)
-        self.step_down()
-
-        self.session.create(uri, config)
-        self.publish(uri, 5)
-        self.assertFalse(self.stable_exists_locally(self.conn, stable_uri))
-
-        self.step_up()
-        self.set_stable_epoch(10)
-        self.assert_matches_reference(
-            self.read_stable_config(self.conn, stable_uri), ref_uri
         )

--- a/test/suite/test_layered_schema31.py
+++ b/test/suite/test_layered_schema31.py
@@ -205,8 +205,4 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         """
         config = self.table_config.replace("block_manager=disagg,", "")
         self.create_on_follower_then_step_up(config)
-        self.assert_matches_reference(
-            self.read_stable_config(
-                self.conn, self.layered_stable_uri(self.uri)
-            )
-        )
+        self.check_rebuild_keeps_file_settings()

--- a/test/suite/test_layered_schema31.py
+++ b/test/suite/test_layered_schema31.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# When step-up creates a missing stable constituent, its immutable file
+# settings must match those of a stable constituent created in the leader
+# role.
+
+from helper_disagg import DisaggSchemaEpochMixin
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wttest import WiredTigerTestCase
+
+
+@disagg_test_class
+class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_config = 'disaggregated=(role="leader",lose_all_my_data=true)'
+
+    uri = f"layered:{test_name}"
+    ref_uri = f"layered:{test_name}_ref"
+
+    # Create the table with a non-default value for every user-settable
+    # immutable file setting, so the comparison exercises the full set of
+    # fields the rebuild must preserve.
+    # Encryption belongs to the same set but needs an encryptor extension, so
+    # it is left out. The storage tier exercises the recursive merge of the
+    # disaggregated category when the rebuild overrides the page log.
+    table_config = (
+        "key_format=i,value_format=S,"
+        "allocation_size=512B,"
+        "block_allocation=first,"
+        "block_compressor=snappy,"
+        "block_manager=disagg,"
+        "checksum=unencrypted,"
+        "dictionary=100,"
+        "disaggregated=(storage_tier=cold),"
+        "internal_key_truncate=false,"
+        "internal_page_max=8KB,"
+        "key_gap=20,"
+        "leaf_key_max=256,"
+        "leaf_page_max=8KB,"
+        "leaf_value_max=1KB,"
+        "memory_page_image_max=64KB,"
+        "memory_page_max=1MB,"
+        "prefix_compression=true,"
+        "prefix_compression_min=8,"
+        "split_deepen_min_child=100,"
+        "split_deepen_per_child=50,"
+        "split_pct=80"
+    )
+
+    def conn_extensions(self, extlist):
+        self.add_scenario_config()
+        extlist.extension("compressors", "snappy")
+        return self.disagg_conn_extensions(extlist)
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def create_on_follower_then_step_up(self, config=None):
+        """
+        Create and publish the table in the follower role, then step up to
+        rebuild the missing stable constituent. A twin table created in the
+        leader role first provides the reference stable constituent row the
+        rebuild must reproduce.
+        """
+        if config is None:
+            config = self.table_config
+        self.set_stable_epoch(1)
+        self.session.create(self.ref_uri, config)
+        self.step_down()
+
+        # A follower-era create has no stable constituent: only the ingest
+        # constituent and the layered table entry exist until the next step-up.
+        self.session.create(self.uri, config)
+        self.publish(self.uri, 5)
+        self.assertFalse(
+            self.stable_exists_locally(
+                self.conn, self.layered_stable_uri(self.uri)
+            )
+        )
+
+        self.step_up()
+
+    def create_on_follower_then_step_up_legacy(self):
+        """
+        The same flow without schema epochs, exercising the legacy step-up
+        path that reconstructs the missing stable constituent from the
+        ingest constituent.
+        """
+        self.session.create(self.ref_uri, self.table_config)
+        self.step_down()
+
+        self.session.create(self.uri, self.table_config)
+        self.assertFalse(
+            self.stable_exists_locally(
+                self.conn, self.layered_stable_uri(self.uri)
+            )
+        )
+
+        self.step_up()
+
+    def layered_stable_uri(self, uri):
+        """Return the stable constituent URI for a layered: or table: URI."""
+        return "file:" + uri.split(":", 1)[1] + ".wt_stable"
+
+    def read_stable_config(self, conn, stable_uri):
+        """Return the stable constituent's local create configuration."""
+        session = conn.open_session("")
+        cursor = session.open_cursor("metadata:create")
+        cursor.set_key(stable_uri)
+        self.assertEqual(
+            cursor.search(), 0, f"no local metadata for {stable_uri}"
+        )
+        config = cursor.get_value()
+        cursor.close()
+        session.close()
+        return config
+
+    def stable_exists_locally(self, conn, stable_uri):
+        """
+        Return True if the stable constituent has a row in conn's local
+        metadata.
+        """
+        session = conn.open_session("")
+        cursor = session.open_cursor("metadata:")
+        cursor.set_key(stable_uri)
+        found = cursor.search() == 0
+        cursor.close()
+        session.close()
+        return found
+
+    def assert_matches_reference(self, rebuilt_config, ref_uri=None):
+        """
+        Assert a stable constituent's create configuration matches the
+        leader-created reference.
+        """
+        reference_config = self.read_stable_config(
+            self.conn, self.layered_stable_uri(ref_uri or self.ref_uri)
+        )
+        self.assertEqual(rebuilt_config, reference_config)
+
+    def check_rebuild_keeps_file_settings(self):
+        """
+        The rebuilt stable constituent keeps the create-time file settings.
+        """
+        self.assert_matches_reference(
+            self.read_stable_config(
+                self.conn, self.layered_stable_uri(self.uri)
+            )
+        )
+
+    def test_stepup_rebuild_keeps_file_settings(self):
+        self.create_on_follower_then_step_up()
+        self.set_stable_epoch(10)
+        self.check_rebuild_keeps_file_settings()
+
+    def test_stepup_rebuild_keeps_file_settings_legacy(self):
+        self.create_on_follower_then_step_up_legacy()
+        self.check_rebuild_keeps_file_settings()
+
+    def test_stepup_rebuild_keeps_default_config(self):
+        """
+        Verify step-up uses the saved configuration rather than the
+        ingest-derived fallback.
+        """
+        self.create_on_follower_then_step_up("key_format=i,value_format=S")
+        self.assert_matches_reference(
+            self.read_stable_config(
+                self.conn, self.layered_stable_uri(self.uri)
+            )
+        )
+
+    def test_stepup_rebuild_keeps_file_settings_table_prefix(self):
+        """
+        Verify creating a layered table through a URI starting with "table:"
+        preserves the saved configuration.
+        """
+        uri = f"table:{self.test_name}_tbl"
+        ref_uri = f"table:{self.test_name}_tbl_ref"
+        config = (
+            self.table_config.replace("block_manager=disagg,", "")
+            + ",type=layered"
+        )
+        stable_uri = self.layered_stable_uri(uri)
+
+        self.set_stable_epoch(1)
+        self.session.create(ref_uri, config)
+        self.step_down()
+
+        self.session.create(uri, config)
+        self.publish(uri, 5)
+        self.assertFalse(self.stable_exists_locally(self.conn, stable_uri))
+
+        self.step_up()
+        self.set_stable_epoch(10)
+        self.assert_matches_reference(
+            self.read_stable_config(self.conn, stable_uri), ref_uri
+        )

--- a/test/suite/test_layered_schema31.py
+++ b/test/suite/test_layered_schema31.py
@@ -26,27 +26,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# When step-up creates a missing stable constituent, its immutable file
-# settings must match those of a stable constituent created in the leader
-# role.
+# Step-up creates a missing stable table from its recorded configuration when
+# available; legacy mode derives the configuration from ingest metadata.
 
 from helper_disagg import DisaggSchemaEpochMixin
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
-from wttest import WiredTigerTestCase
-
+from wttest import WiredTigerTestCase, open_cursor
 
 @disagg_test_class
 class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
-    test_name = __qualname__
     conn_config = 'disaggregated=(role="leader",lose_all_my_data=true)'
 
-    # Create the table with a non-default value for every user-settable
-    # immutable file setting, so the comparison exercises the full set of
-    # fields the rebuild must preserve.
-    # Encryption belongs to the same set but needs an encryptor extension, so
-    # it is left out. The storage tier exercises the recursive merge of the
-    # disaggregated category when the rebuild overrides the page log.
+    # Exercise every user-settable field except encryption, which requires an
+    # encryptor extension.
     base_config = (
         "key_format=i,value_format=S,"
         "allocation_size=512B,"
@@ -75,134 +68,93 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         (
             "layered",
             {
-                "uri": f"layered:{test_name}",
-                "ref_uri": f"layered:{test_name}_ref",
-                "table_config": base_config,
+                "uri": f"layered:{__qualname__}",
+                "config": base_config,
             },
         ),
         (
             "table",
             {
-                "uri": f"table:{test_name}",
-                "ref_uri": f"table:{test_name}_ref",
-                "table_config": base_config + ",type=layered",
+                "uri": f"table:{__qualname__}",
+                "config": base_config + ",type=layered",
             },
         ),
     ]
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, uri_scenarios)
 
     def conn_extensions(self, extlist):
         self.add_scenario_config()
         extlist.extension("compressors", "snappy")
         return self.disagg_conn_extensions(extlist)
 
-    disagg_storages = gen_disagg_storages(disagg_only=True)
-    scenarios = make_scenarios(disagg_storages, uri_scenarios)
-
-    def create_on_follower_then_step_up(self, config):
+    def create_on_follower_then_step_up(self, config, use_schema_epochs=True):
         """
-        Create and publish the table in the follower role, then step up to
-        rebuild the missing stable constituent. A twin table created in the
-        leader role first provides the reference stable constituent row the
-        rebuild must reproduce.
+        Create the table in the follower role, then step up to create the
+        missing stable table.
         """
-        self.set_stable_epoch(1)
-        self.session.create(self.ref_uri, config)
         self.step_down()
 
-        # A follower-era create has no stable constituent: only the ingest
-        # constituent and the layered table entry exist until the next step-up.
+        if use_schema_epochs:
+            self.set_stable_epoch(1)
+
+        # A follower create leaves the stable table missing until step-up.
         self.session.create(self.uri, config)
-        self.publish(self.uri, 5)
-        self.assertFalse(
-            self.stable_exists_locally(
-                self.conn, self.layered_stable_uri(self.uri)
-            )
-        )
+
+        if use_schema_epochs:
+            self.publish(self.uri, epoch=5)
 
         self.step_up()
 
-    def create_on_follower_then_step_up_legacy(self):
+    def read_stable_config(self, layered_uri):
+        """Return the stable configuration for a layered table."""
+        stable_uri = "file:" + layered_uri.split(":", 1)[1] + ".wt_stable"
+        with open_cursor(self.session, "metadata:create") as cursor:
+            return cursor[stable_uri]
+
+    def check_step_up_stable_config(self, config):
         """
-        The same flow without schema epochs, exercising the legacy step-up
-        path that reconstructs the missing stable constituent from the
-        ingest constituent.
+        Check that step-up creates the stable table with the expected
+        configuration.
         """
-        self.session.create(self.ref_uri, self.table_config)
-        self.step_down()
+        # Get the config produced when the leader creates the stable table.
+        leader_table_uri = self.uri + "_leader"
+        self.session.create(leader_table_uri, config)
+        expected_config = self.read_stable_config(leader_table_uri)
 
-        self.session.create(self.uri, self.table_config)
-        self.assertFalse(
-            self.stable_exists_locally(
-                self.conn, self.layered_stable_uri(self.uri)
-            )
-        )
+        # Compare it with the config of the stable table created at step-up.
+        step_up_config = self.read_stable_config(self.uri)
+        self.assertEqual(step_up_config, expected_config)
 
-        self.step_up()
-
-    def layered_stable_uri(self, uri):
-        """Return the stable constituent URI for a layered: or table: URI."""
-        return "file:" + uri.split(":", 1)[1] + ".wt_stable"
-
-    def read_stable_config(self, conn, stable_uri):
-        """Return the stable constituent's local create configuration."""
-        session = conn.open_session("")
-        cursor = session.open_cursor("metadata:create")
-        cursor.set_key(stable_uri)
-        self.assertEqual(
-            cursor.search(), 0, f"no local metadata for {stable_uri}"
-        )
-        config = cursor.get_value()
-        cursor.close()
-        session.close()
-        return config
-
-    def stable_exists_locally(self, conn, stable_uri):
+    def test_schema_epoch_step_up_matches_leader_config(self):
         """
-        Return True if the stable constituent has a row in conn's local
+        Verify that schema epoch step-up matches the leader's stable
+        configuration.
+        """
+        self.create_on_follower_then_step_up(self.config)
+        self.check_step_up_stable_config(self.config)
+
+    def test_legacy_step_up_derives_config_from_ingest(self):
+        """
+        Verify that legacy step-up derives the stable configuration from ingest
         metadata.
         """
-        session = conn.open_session("")
-        cursor = session.open_cursor("metadata:")
-        cursor.set_key(stable_uri)
-        found = cursor.search() == 0
-        cursor.close()
-        session.close()
-        return found
-
-    def assert_matches_reference(self, rebuilt_config, ref_uri=None):
-        """
-        Assert a stable constituent's create configuration matches the
-        leader-created reference.
-        """
-        reference_config = self.read_stable_config(
-            self.conn, self.layered_stable_uri(ref_uri or self.ref_uri)
+        self.create_on_follower_then_step_up(
+            self.config, use_schema_epochs=False
         )
-        self.assertEqual(rebuilt_config, reference_config)
+        self.check_step_up_stable_config(self.config)
 
-    def check_rebuild_keeps_file_settings(self):
+    def test_schema_epoch_step_up_does_not_derive_from_ingest(self):
         """
-        The rebuilt stable constituent keeps the create-time file settings.
+        Verify that schema epoch step-up does not derive the stable
+        configuration from ingest metadata.
         """
-        self.assert_matches_reference(
-            self.read_stable_config(
-                self.conn, self.layered_stable_uri(self.uri)
-            )
+        # Deriving the configuration from ingest metadata forces
+        # block_manager=disagg. If block_manager=default is found after
+        # step-up, it proves the ingest-derived path was not used.
+        table_config = self.config.replace(
+            "block_manager=disagg", "block_manager=default"
         )
-
-    def test_stepup_rebuild_keeps_file_settings(self):
-        self.create_on_follower_then_step_up(self.table_config)
-        self.set_stable_epoch(10)
-        self.check_rebuild_keeps_file_settings()
-
-    def test_stepup_rebuild_keeps_file_settings_legacy(self):
-        self.create_on_follower_then_step_up_legacy()
-        self.check_rebuild_keeps_file_settings()
-
-    def test_stepup_rebuild_keeps_default_config(self):
-        """
-        Verify step-up uses the saved configuration rather than the
-        ingest-derived fallback.
-        """
-        config = self.table_config.replace("block_manager=disagg,", "")
-        self.create_on_follower_then_step_up(config)
-        self.check_rebuild_keeps_file_settings()
+        self.create_on_follower_then_step_up(table_config)
+        self.check_step_up_stable_config(table_config)


### PR DESCRIPTION
A layered table created by a follower (or a leader in the step-down window) has no stable constituent; step-up rebuilt it from the collapsed layered: metadata row, which lost every file-level setting (block_compressor, block_manager, page sizes). The rebuilt table diverged from peers and aborted them at checkpoint pickup.

In schema-epoch mode, save the merged stable configuration in the shared metadata queue at create and replay it at step-up. In legacy mode, where the queue does not survive, derive the configuration from the ingest constituent's metadata.