### PR TITLE
WT-18451 Assert direction rather than a symmetric delta in test_stat17

### DIFF
--- a/test/suite/test_stat17.py
+++ b/test/suite/test_stat17.py
@@ -171,16 +171,18 @@ class test_stat17(wttest.WiredTigerTestCase):
         fast_pages = self._dsrc_stat(stat.dsrc.btree_row_leaf_pages)
         fast_avg   = self._dsrc_stat(stat.dsrc.btree_row_leaf_avg_entries)
 
-        # A handful of concurrent eviction splits between the walk snapshot and
-        # this read is expected; allow the drift to be within 2% of the count
-        # (with a small floor for tiny trees) rather than requiring exact match.
-        max_pages_drift = max(2, exact_pages // 50)
+        # Concurrent eviction splits between the walk snapshot and this read only
+        # ever add pages, so the corrected count is the floor: dropping below it
+        # means the correction was lost. The ceiling only rules out a runaway
+        # counter, so it is deliberately generous.
+        min_pages = exact_pages
+        max_pages = exact_pages + max(10, exact_pages // 4)
         exact_avg = exact_entries // exact_pages
         max_avg_drift = max(1, exact_avg // 50)
 
-        self.assertAlmostEqual(fast_pages, exact_pages, delta=max_pages_drift,
-            msg='fast read after tree-walk correction should be near %d, got %d'
-            % (exact_pages, fast_pages))
+        self.assertTrue(min_pages <= fast_pages <= max_pages,
+            f'fast pages {fast_pages} outside acceptable range '
+            f'({min_pages}-{max_pages}) after tree-walk correction')
         self.assertAlmostEqual(fast_avg, exact_avg, delta=max_avg_drift,
             msg='fast avg after tree-walk correction should be near %d, got %d'
             % (exact_avg, fast_avg))


### PR DESCRIPTION
`test_stat17.test_correction_persists_in_memory` failed again with `83 != 80 within 2 delta`. This is the same flake as WT-17878, which replaced strict equality with `assertAlmostEqual(delta=max(2, exact_pages // 50))`. On the small trees this test builds that delta floors at 2, and the test's own comment already predicts that eviction splits concurrent with the tree walk will legitimately bump the approximate leaf-page count after the walk's snapshot is taken. Three such splits are enough to fail it.

The drift is one-sided, since splits only add leaf pages, so a symmetric delta with a small floor is the wrong shape of assertion. The check now requires the fast read to be at least the corrected value, which is the property a regression in the correction path would break, with a loose upper bound to keep it close. The EWMA check is unchanged; that value can drift in either direction and there is no evidence of it failing.