### PR TITLE
WT-18410 Don't queue pages with stalled prune timestamps for eviction

### DIFF
--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -1072,3 +1072,16 @@ __evict_page_updates_candidate(WT_PAGE *page)
      */
     return (page->modify->bytes_updates != 0);
 }
+
+/*
+ * __wti_evict_prune_ts_unmoved --
+ *     Return whether the prune timestamp has not advanced since the page's last reconciliation.
+ */
+static WT_INLINE bool
+__wti_evict_prune_ts_unmoved(WT_SESSION_IMPL *session, WT_PAGE *page)
+{
+    wt_timestamp_t prune_timestamp;
+
+    prune_timestamp = __wt_atomic_load_uint64_acquire(&S2BT(session)->prune_timestamp);
+    return (prune_timestamp != WT_TS_NONE && page->modify->rec_prune_timestamp >= prune_timestamp);
+}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1176,10 +1176,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
              * prune timestamp, do not attempt reconciliation again. Repeating the reconciliation
              * without the prune timestamp advancing will yield no progress in garbage collection.
              */
-            wt_timestamp_t prune_timestamp =
-              __wt_atomic_load_uint64_acquire(&btree->prune_timestamp);
-            if (prune_timestamp != WT_TS_NONE &&
-              page->modify->rec_prune_timestamp >= prune_timestamp) {
+            if (__wti_evict_prune_ts_unmoved(session, page)) {
                 WT_STAT_CONN_INCR(session, cache_eviction_blocked_prune_timestamp);
                 return (__wt_set_return(session, EBUSY));
             }

--- a/src/evict/evict_private.h
+++ b/src/evict/evict_private.h
@@ -94,6 +94,8 @@ extern void __wti_evict_queue_clear_page_locked(
 extern void __wti_evict_set_saved_walk_tree(WT_SESSION_IMPL *session, WT_DATA_HANDLE *new_dhandle);
 static WT_INLINE bool __wti_evict_hs_dirty(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wti_evict_prune_ts_unmoved(WT_SESSION_IMPL *session, WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wti_evict_readgen_is_soon_or_wont_need(uint64_t *readgen)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wti_evict_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -787,9 +787,15 @@ __evict_skip_dirty_candidate(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
             wt_timestamp_t prune_timestamp =
               __wt_atomic_load_uint64_relaxed(&btree->prune_timestamp);
-            if (prune_timestamp != WT_TS_NONE && newest_commit_timestamp > prune_timestamp) {
-                WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp);
-                return (true);
+            if (prune_timestamp != WT_TS_NONE) {
+                if (newest_commit_timestamp > prune_timestamp) {
+                    WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp);
+                    return (true);
+                }
+                if (page->modify->rec_prune_timestamp >= prune_timestamp) {
+                    WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp_not_move);
+                    return (true);
+                }
             }
         } else {
             if (newest_commit_timestamp > __wt_txn_pinned_stable_timestamp(session)) {

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -787,15 +787,9 @@ __evict_skip_dirty_candidate(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
             wt_timestamp_t prune_timestamp =
               __wt_atomic_load_uint64_relaxed(&btree->prune_timestamp);
-            if (prune_timestamp != WT_TS_NONE) {
-                if (newest_commit_timestamp > prune_timestamp) {
-                    WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp);
-                    return (true);
-                }
-                if (page->modify->rec_prune_timestamp >= prune_timestamp) {
-                    WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp_not_move);
-                    return (true);
-                }
+            if (prune_timestamp != WT_TS_NONE && newest_commit_timestamp > prune_timestamp) {
+                WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp);
+                return (true);
             }
         } else {
             if (newest_commit_timestamp > __wt_txn_pinned_stable_timestamp(session)) {

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -787,15 +787,9 @@ __evict_skip_dirty_candidate(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
             wt_timestamp_t prune_timestamp =
               __wt_atomic_load_uint64_relaxed(&btree->prune_timestamp);
-            if (prune_timestamp != WT_TS_NONE) {
-                if (newest_commit_timestamp > prune_timestamp) {
-                    WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp);
-                    return (true);
-                }
-                if (page->modify->rec_prune_timestamp >= prune_timestamp) {
-                    WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp_not_move);
-                    return (true);
-                }
+            if (prune_timestamp != WT_TS_NONE && newest_commit_timestamp > prune_timestamp) {
+                WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp);
+                return (true);
             }
         } else {
             if (newest_commit_timestamp > __wt_txn_pinned_stable_timestamp(session)) {
@@ -1244,6 +1238,16 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
             WT_STAT_CONN_INCR(session, eviction_server_skip_intl_page_non_aggressive);
             return;
         }
+    }
+
+    /*
+     * Skip while the prune timestamp is stalled: one that never advances floods the queue and pins
+     * the eviction server on this tree forever.
+     */
+    if (modified && F_ISSET(ref, WT_REF_FLAG_LEAF) && F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
+      __wti_evict_prune_ts_unmoved(session, page)) {
+        WT_STAT_CONN_INCR(session, eviction_server_skip_pages_prune_timestamp_not_move);
+        return;
     }
 
     /* Evaluate dirty page candidacy, when eviction is not aggressive. */

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1247,8 +1247,8 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     }
 
     /*
-     * Skip while the prune timestamp is stalled: one that never advances floods the queue and pins
-     * the eviction server on this tree forever.
+     * Skip while the prune timestamp is stalled for leaf pages, one that never advances floods the
+     * queue and pins the eviction server on this tree forever.
      */
     if (modified && F_ISSET(ref, WT_REF_FLAG_LEAF) && F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
       __wti_evict_prune_ts_unmoved(session, page)) {


### PR DESCRIPTION
While a disaggregated follower's ingest btree has a frozen prune_timestamp, every modified leaf in that tree is rejected by __evict_review with EBUSY. The eviction walk cannot tell: the walk-side copy of that check is bypassed under aggressive eviction, so it queues those pages anyway.

A walk pass ends as soon as the queue's 100 slots are filled and the next pass resumes from the saved tree, and a page that fails eviction is immediately re-queueable. Filling its full target also resets the tree's walk period to 0, so it is scored as the best tree in cache.

The result is a lock-in: the server queues 100 unevictable pages per pass indefinitely, never reaches another dhandle, and eviction stops entirely even though plenty of evictable content is resident. The size of the tree does not matter — it only has to supply 100 pages per pass.

The solution for this PR is to skip a garbage-collect tree whose prune timestamp has not advanced since a visit that produced no evictions.