### PR TITLE
WT-18448 schema-disagg-abort: An idle worker pins the frontier and livelocks a DROP

### DIFF
--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -69,7 +69,7 @@ Threads are created for each leader or follower phase.
 | generator | 1 for a leader or lone node | Advance the slot state machines and emit workload and role-transition events. |
 | reader | 1 | Read the self-pipe or peer pipe, demultiplex events and drain work at transition markers. |
 | worker | `-T N` | Apply events, relay leader events, append records and report completed timestamps. |
-| timestamp | 1 | Advance oldest, stable and stable-schema timestamps to the workers' completed frontier. |
+| timestamp | 1 | Advance oldest, stable and stable-schema timestamps to the completed frontier. |
 | checkpoint | 1 | Write leader checkpoints to PALite or adopt the latest checkpoint as follower. |
 
 Shutdown is ordered generator, reader, workers, checkpoint, timestamp. The last two remain available

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -159,23 +159,23 @@ thread_ckpt_run(void *arg)
 }
 
 /*
- * workers_min --
- *     Return the minimum completed timestamp across all worker threads: the frontier with no
- *     unfinished publish or commit at or below it. Returns 0 if any worker has not yet completed an
- *     operation this phase.
+ * frontier_advance --
+ *     Advance the frontier over the timestamps the workers completed: the frontier with no
+ *     unfinished publish or commit at or below it. Only the timestamp thread may call it.
  */
 static uint64_t
-workers_min(WORKLOAD_STATE *state)
+frontier_advance(WORKLOAD_STATE *state)
 {
-    uint64_t min_val = UINT64_MAX;
-    for (uint32_t i = 0; i < state->nth_workers; i++) {
-        const uint64_t val = __wt_atomic_load_uint64(&state->workers[i].completed_ts);
-        if (val == 0)
-            return (0);
-        if (val < min_val)
-            min_val = val;
+    uint64_t frontier_ts = __wt_atomic_load_uint64(&state->frontier_ts);
+
+    while (__wt_atomic_load_uint8(&state->completed_ts[(frontier_ts + 1) % FRONTIER_WINDOW]) != 0) {
+        /* Consume the mark for this timestamp. */
+        __wt_atomic_store_uint8(&state->completed_ts[(frontier_ts + 1) % FRONTIER_WINDOW], 0);
+        ++frontier_ts;
     }
-    return (min_val);
+    __wt_atomic_store_uint64(&state->frontier_ts, frontier_ts);
+
+    return (frontier_ts);
 }
 
 /*
@@ -189,6 +189,9 @@ thread_ts_run(void *arg)
     WORKLOAD_STATE *state = arg;
 
     while (workload_active(state, STAGE_TS)) {
+        /* Frontier of the fully complete operations across all workers. */
+        const uint64_t frontier_ts = frontier_advance(state);
+
         /*
          * Setting timestamps is a critical section: the stable frontier must not advance while a
          * step-down is in progress.
@@ -199,12 +202,9 @@ thread_ts_run(void *arg)
              * The single frontier serves both schema and data operations: everything at or below it
              * is published and committed.
              */
-            const uint64_t frontier = workers_min(state);
-            if (frontier != 0) {
-                const uint64_t cur_stable = query_ts(state->conn, TS_STABLE);
-                if (frontier >= cur_stable)
-                    set_ts(state->conn, TS_FRONTIER, frontier);
-            }
+            const uint64_t stable_ts = query_ts(state->conn, TS_STABLE);
+            if (frontier_ts >= stable_ts)
+                set_ts(state->conn, TS_FRONTIER, frontier_ts);
         }
         __wt_atomic_store_bool(&state->ts_busy, false);
 

--- a/test/csuite/schema_disagg_abort/evq.c
+++ b/test/csuite/schema_disagg_abort/evq.c
@@ -92,6 +92,20 @@ evq_is_empty(WORKLOAD_STATE *state, uint32_t thread_index)
 }
 
 /*
+ * evq_depth --
+ *     Report how many events are queued for one worker; a racy snapshot, for diagnostics.
+ */
+uint64_t
+evq_depth(WORKLOAD_STATE *state, uint32_t thread_index)
+{
+    EVENT_QUEUE *q = &state->workers[thread_index].evq;
+
+    /* Load the consumer's side first, or a concurrent pop underflows the difference. */
+    const uint64_t head = __wt_atomic_load_uint64(&q->head);
+    return (__wt_atomic_load_uint64(&q->tail) - head);
+}
+
+/*
  * evq_drain_barrier --
  *     Wait until every worker has applied everything queued so far. Only the reader may call it: it
  *     is the sole producer for the queues, so nothing new can arrive while it waits here. It runs

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -255,9 +255,12 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
     state->emitted = state->applied = 0;
     state->stepdown_ts = state->stepdown_ckpt_lsn = 0;
 
+    /* The frontier continues from the previous phase; nothing above it is completed yet. */
+    state->frontier_ts = state->current_ts;
+    memset(state->completed_ts, 0, sizeof(state->completed_ts));
+
     /* Reset workers' state. Note: tables' state survives role transitioning. */
     for (uint32_t i = 0; i < cfg->nth; i++) {
-        state->workers[i].completed_ts = 0;
         state->workers[i].busy = false;
         state->workers[i].evq.head = state->workers[i].evq.tail = 0;
         memset(state->workers[i].stepdown_insert, 0, sizeof(state->workers[i].stepdown_insert));

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -15,18 +15,17 @@
 #include "schema_disagg_abort.h"
 
 /*
- * workers_timestamps_assert --
- *     Assert that no worker completed an event above the given timestamp.
+ * frontier_assert --
+ *     Assert the frontier has not passed a drained stream's final timestamp: nothing above it was
+ *     delivered, so nothing above it can be complete.
  */
 static void
-workers_timestamps_assert(WORKLOAD_STATE *state, uint64_t timestamp)
+frontier_assert(WORKLOAD_STATE *state, uint64_t timestamp)
 {
-    for (uint32_t t = 0; t < state->nth_workers; t++) {
-        const uint64_t completed = __wt_atomic_load_uint64(&state->workers[t].completed_ts);
-        testutil_assertfmt(completed <= timestamp,
-          "step-down: worker %" PRIu32 " completed %" PRIu64 " above the marker's %" PRIu64, t,
-          completed, timestamp);
-    }
+    const uint64_t frontier_ts = __wt_atomic_load_uint64(&state->frontier_ts);
+
+    testutil_assertfmt(frontier_ts <= timestamp,
+      "step-down: the frontier %" PRIu64 " passed the marker's %" PRIu64, frontier_ts, timestamp);
 }
 
 /*
@@ -104,7 +103,7 @@ thread_reader_run(void *arg)
              * step-down timestamp.
              */
             evq_drain_barrier(state);
-            workers_timestamps_assert(state, ev.event_ts);
+            frontier_assert(state, ev.event_ts);
             reader_step_down(state, ev.event_ts);
             break;
         case EVENT_SWITCH:

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -55,6 +55,12 @@
 #define GEN_MIN_LEAD 64            /* lead floor, so the workers stay fed */
 #define GEN_STEPDOWN_MIN_EVENTS 64 /* minimum events a lone node emits during stepdown */
 
+/*
+ * Frontier window to track completed timestamps across workers. Must be large enough to accommodate
+ * all in-flight timestamps.
+ */
+#define FRONTIER_WINDOW 0x10000u
+
 #define MAX_CKPT_INVL 4 /* checkpoint thread: upper bound on the interval, in seconds */
 #define SCHEMA_EPOCH_BOOTSTRAP 1
 #define MAX_NODES 2
@@ -245,16 +251,18 @@ typedef struct {
 
     /* Single monotonic timestamp for schema epochs AND commit timestamps. */
     uint64_t current_ts;
+    uint64_t frontier_ts; /* every timestamp at or below it is applied; atomic access */
+    /* Circular buffer for completed timestamps of all workers; atomic access. */
+    uint8_t completed_ts[FRONTIER_WINDOW];
     uint64_t emitted; /* generator: how many events have been emitted */
     uint64_t applied; /* worker: how many events have been applied; atomic access */
     uint32_t nth_workers;
 
     /* Per-worker-thread state; the reader fills the queue, the slot model is the generator's. */
     struct {
-        wt_thread_t thr;       /* this worker's handle */
-        EVENT_QUEUE evq;       /* this worker's inbound events */
-        bool busy;             /* the worker is mid-apply; atomic access */
-        uint64_t completed_ts; /* the latest published or committed timestamp; atomic access */
+        wt_thread_t thr; /* this worker's handle */
+        EVENT_QUEUE evq; /* this worker's inbound events */
+        bool busy;       /* the worker is mid-apply; atomic access */
         /* Table state is carried across leader-follower transitions. */
         TABLE_STATE table_state[MAX_POOL_SIZE];
         /* Advanced by every create under -q, so a slot's table name is never reused. */
@@ -316,6 +324,7 @@ void workload_counter_advance(WORKLOAD_STATE *state, uint64_t v);
 void evq_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev);
 bool evq_dequeue(WORKLOAD_STATE *state, uint32_t thread_index, SCHEMA_EVENT *ev);
 bool evq_is_empty(WORKLOAD_STATE *state, uint32_t thread_index);
+uint64_t evq_depth(WORKLOAD_STATE *state, uint32_t thread_index);
 void evq_drain_barrier(WORKLOAD_STATE *state);
 
 /* event_pipe.c: the event framing every pipe shares. */

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -83,6 +83,19 @@ worker_record_open(const WORKLOAD_STATE *state, uint32_t thread_index)
 }
 
 /*
+ * schema_op_stall_report --
+ *     Report the frontier state a stalled schema operation is waiting on.
+ */
+static void
+schema_op_stall_report(WORKLOAD_STATE *state)
+{
+    println("Node %" PRIu32 ": stable %" PRIu64 ", frontier %" PRIu64, state->cfg->node_id,
+      query_ts(state->conn, TS_STABLE), __wt_atomic_load_uint64(&state->frontier_ts));
+    for (uint32_t t = 0; t < state->nth_workers; t++)
+        println("  worker %" PRIu32 ": %" PRIu64 " events queued", t, evq_depth(state, t));
+}
+
+/*
  * schema_op_execute --
  *     Execute one schema operation: create or drop the test's tables, on either role.
  */
@@ -112,6 +125,7 @@ schema_op_execute(WORKLOAD_STATE *state, WT_SESSION *session, const SCHEMA_EVENT
             int err, sub_err;
             const char *err_msg;
             session->get_last_error(session, &err, &sub_err, &err_msg);
+            schema_op_stall_report(state);
             testutil_die(ETIMEDOUT, "node%" PRIu32 " %s %s %s: EBUSY for %d seconds: %s",
               state->cfg->node_id, state->leads ? "leader" : "follower",
               is_create ? "CREATE" : "DROP", ev->uri, MAX_OP_WAIT, err_msg);
@@ -177,15 +191,21 @@ insert_data(
 
 /*
  * worker_complete --
- *     Mark one timestamp fully completed by a worker: adopt it - only a consuming phase needs that,
- *     a generating one allocated it already - and publish the thread's completed frontier.
+ *     Mark one timestamp fully completed by a worker: adopt it and mark it in the completion
+ *     window.
  */
 static void
-worker_complete(WORKLOAD_STATE *state, uint32_t thread_index, uint64_t value)
+worker_complete(WORKLOAD_STATE *state, uint64_t value)
 {
     workload_counter_advance(state, value);
     (void)__wt_atomic_add_uint64(&state->applied, 1);
-    __wt_atomic_store_uint64(&state->workers[thread_index].completed_ts, value);
+
+    /* One writer per timestamp, so the mark needs no read-modify-write. */
+    const uint64_t frontier_ts = __wt_atomic_load_uint64(&state->frontier_ts);
+    testutil_assertfmt(value > frontier_ts && value - frontier_ts < FRONTIER_WINDOW,
+      "completed timestamp %" PRIu64 " outside the window above the frontier %" PRIu64, value,
+      frontier_ts);
+    __wt_atomic_store_uint8(&state->completed_ts[value % FRONTIER_WINDOW], 1);
 }
 
 /*
@@ -215,7 +235,7 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
         record_event_line(ctx->record_fp, ev);
-        worker_complete(state, thread_index, ev->event_ts);
+        worker_complete(state, ev->event_ts);
         break;
     case EVENT_CREATE:
     case EVENT_DROP:
@@ -231,7 +251,7 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const
             (void)pipe_relay_event(state->cfg, ev);
         record_event_line(ctx->record_fp, ev);
         schema_op_publish(ctx->session, ev->uri, ev->event_ts);
-        worker_complete(state, thread_index, ev->event_ts);
+        worker_complete(state, ev->event_ts);
         break;
     case EVENT_NONE:
     case EVENT_STEPDOWN:


### PR DESCRIPTION
Workers may be blocked on their schema DROP and wait for a checkpoint to unblock them. If `stable_ts` is set to the minimum across all workers, then checkpoints cannot unblock workers who have recent INSERT above this minimum.

Solution:
- track the completion frontier timestamp across workers,
- use the frontier timestamp to set `stable_ts`.