### PR TITLE
WT-18320 Run epoch-less operations during schema-disagg-abort test

### DIFF
--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -11,8 +11,9 @@ the durable state against per-operation record files.
   and the workers apply and relay the events to the follower through a process pipe.
 - A peered follower consumes the leader's relay. A lone follower generates its own workload but
   cannot make it durable until it becomes leader.
-- Creates and drops have separate operation and publish events, allowing checkpoints and crashes to
-  land between the two. Inserts are generated only after the create is published.
+- In epoch mode, creates and drops have separate operation and publish events, allowing checkpoints
+  and crashes to land between the two. In legacy mode each schema operation is complete without a
+  publish event. Inserts are generated only after the create is complete.
 - Leaders write checkpoints to the shared page log; followers adopt them. Role changes are events in
   the same stream, so all earlier work is drained before the connection is reconfigured.
 
@@ -38,7 +39,8 @@ WT_TEST.foo.SAVE/                 pre-verification copy of the home
 ## Generator state machine
 
 Each worker owns a pool of table slots. The generator chooses a slot and takes one valid transition
-or lingers, widening the window in which a checkpoint or crash can occur.
+or lingers, widening the window in which a checkpoint or crash can occur. (The diagram shows epoch
+mode only.)
 
 ```mermaid
 stateDiagram-v2
@@ -69,7 +71,7 @@ Threads are created for each leader or follower phase.
 | generator | 1 for a leader or lone node | Advance the slot state machines and emit workload and role-transition events. |
 | reader | 1 | Read the self-pipe or peer pipe, demultiplex events and drain work at transition markers. |
 | worker | `-T N` | Apply events, relay leader events, append records and report completed timestamps. |
-| timestamp | 1 | Advance oldest, stable and stable-schema timestamps to the completed frontier. |
+| timestamp | 1 | Advance oldest and stable timestamps, plus the stable schema epoch in epoch mode, to the completed frontier. |
 | checkpoint | 1 | Write leader checkpoints to PALite or adopt the latest checkpoint as follower. |
 
 Shutdown is ordered generator, reader, workers, checkpoint, timestamp. The last two remain available
@@ -81,13 +83,17 @@ The verifier discards each node's local data and rebuilds it from the shared pag
 describe creates, drops and inserts; records newer than the recovered durable schema epoch are
 ignored. The verifier checks table presence, inserted values and the relayed event prefix.
 
+Note: Legacy (epoch-less) mode has limited verification. Slots with schema operations after the last
+checkpont cannot be verified reliably.
+
 ## Running
 
 ```text
-test_schema_disagg_abort [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N]
-                         [-T threads] [-t time] [-u pool] [-v]
+test_schema_disagg_abort [-b build-dir] [-e] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf]
+                         [-s N] [-T threads] [-t time] [-q] [-u pool] [-v]
 ```
 
 `-r` selects a lone leader, lone follower or leader/follower pair. `-s` schedules role switches,
 `-k` schedules kills, and `-t` sets the graceful stop time. Every run prints a reproducible `CONFIG:`
-line including its random seeds.
+line including its random seeds. `-e` runs legacy schema operations and requires a single-node
+`-r l` or `-r f` topology.

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -8,9 +8,7 @@
 
 /*
  * The checkpoint stage: the node's checkpoint duty, paced independently of the workload - produced
- * while leading, adopted from the page log while following. Off the event stream so a checkpoint
- * can land between a schema operation and its publish, and can still be taken while a worker is
- * blocked waiting for one; on its own thread so a slow checkpoint cannot freeze the frontier.
+ * while leading, adopted from the page log while following.
  */
 
 #include "schema_disagg_abort.h"
@@ -136,7 +134,7 @@ thread_ckpt_run(void *arg)
     __wt_epoch(NULL, &ckpt.phase_start);
 
     /* The cadence draws from the stream one past the generator's per-worker streams. */
-    WT_RAND_STATE *rnd = &state->gen_rnd[state->nth_workers];
+    WT_RAND_STATE *rnd = &state->gen_rnd[state->worker_count];
     struct timespec last = ckpt.phase_start;
     uint64_t wait = 1 + __wt_random(rnd) % MAX_CKPT_INVL;
 
@@ -161,7 +159,7 @@ thread_ckpt_run(void *arg)
 /*
  * frontier_advance --
  *     Advance the frontier over the timestamps the workers completed: the frontier with no
- *     unfinished publish or commit at or below it. Only the timestamp thread may call it.
+ *     unfinished schema operation or commit at or below it. Only the timestamp thread may call it.
  */
 static uint64_t
 frontier_advance(WORKLOAD_STATE *state)
@@ -180,8 +178,7 @@ frontier_advance(WORKLOAD_STATE *state)
 
 /*
  * thread_ts_run --
- *     Advances the oldest and stable timestamps and the stable schema epoch to the workers'
- *     completed frontier, keeping stable data on published tables only.
+ *     Advance the oldest and stable timestamps, plus the stable schema epoch, when in use.
  */
 WT_THREAD_RET
 thread_ts_run(void *arg)
@@ -200,11 +197,11 @@ thread_ts_run(void *arg)
         if (__wt_atomic_load_uint64(&state->stepdown_ts) == 0) {
             /*
              * The single frontier serves both schema and data operations: everything at or below it
-             * is published and committed.
+             * is completed.
              */
             const uint64_t stable_ts = query_ts(state->conn, TS_STABLE);
             if (frontier_ts >= stable_ts)
-                set_ts(state->conn, TS_FRONTIER, frontier_ts);
+                set_ts(state->cfg, state->conn, TS_FRONTIER, frontier_ts);
         }
         __wt_atomic_store_bool(&state->ts_busy, false);
 
@@ -235,13 +232,13 @@ leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
         return;
     }
 
-    /* The timestamp thread owns the stable epoch and timestamps; just checkpoint. */
+    /* The timestamp thread owns the frontier; just checkpoint. */
     testutil_check(session->checkpoint(session, "use_timestamp=true"));
 
     println(
       "Node %" PRIu32 ": checkpoint %" PRIu32 " complete", state->cfg->node_id, ++ckpt->produced);
 
-    /* A stable frontier implies every worker published, so this checkpoint has a schema op. */
+    /* A stable frontier implies every worker completed an operation this phase. */
     if (ckpt->produced == 1u)
         testutil_sentinel(NULL, LEADER_READY_FILE);
 }

--- a/test/csuite/schema_disagg_abort/evq.c
+++ b/test/csuite/schema_disagg_abort/evq.c
@@ -64,7 +64,7 @@ evq_empty(EVENT_QUEUE *q)
 void
 evq_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
 {
-    testutil_assert(ev->thread_id < state->nth_workers);
+    testutil_assert(ev->thread_id < state->worker_count);
 
     EVENT_QUEUE *q = &state->workers[ev->thread_id].evq;
     while (!evq_push(q, ev) && workload_active(state, STAGE_WORKERS))
@@ -115,7 +115,7 @@ evq_depth(WORKLOAD_STATE *state, uint32_t thread_index)
 void
 evq_drain_barrier(WORKLOAD_STATE *state)
 {
-    for (uint32_t t = 0; t < state->nth_workers; t++)
+    for (uint32_t t = 0; t < state->worker_count; t++)
         while (
           (!evq_empty(&state->workers[t].evq) || __wt_atomic_load_bool(&state->workers[t].busy)) &&
           workload_active(state, STAGE_WORKERS))

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -43,10 +43,10 @@ generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
  *     state's valid moves at random. Reports whether an event was emitted; taking no move is valid,
  *     and lingering widens the window a checkpoint can land in.
  *
- * One gate keeps every move safe to execute: an insert only after its table's create published, so
- *     its commit exceeds the create's epoch. A published table with data that no checkpoint covers
- *     yet is left droppable on purpose - the drop retries in EBUSY until the checkpoint thread's
- *     next checkpoint clears it.
+ * One gate keeps every move safe to execute: an insert only after its table's create completes, so
+ *     its commit exceeds the create's publish epoch or legacy operation timestamp. A table with
+ *     data that no checkpoint covers yet is left droppable on purpose - the drop retries in EBUSY
+ *     until the checkpoint thread's next checkpoint clears it.
  */
 static bool
 generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
@@ -54,20 +54,21 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
     const bool stepping_down = phase == GEN_STEPDOWN;
     WT_RAND_STATE *rnd = &state->gen_rnd[t];
     const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
-    TABLE_STATE *slot_state = &state->workers[t].table_state[slot];
+    TABLE_STATE *slot_state = &state->workers[t].table[slot].state;
     /* Set while stepping down; such a slot cannot be dropped until the term ends. */
-    bool *stepdown_insert = &state->workers[t].stepdown_insert[slot];
+    bool *stepdown_insert = &state->workers[t].table[slot].stepdown_insert;
 
     SCHEMA_EVENT ev = {0}; /* EVENT_NONE until a move is taken */
     switch (*slot_state) {
     case TABLE_NONE:
-        /* The only move: a fresh table; its publish is a later event of its own. */
+        /* A legacy create is complete immediately; epoch mode publishes it in a later event. */
         ev.type = EVENT_CREATE;
-        *slot_state = TABLE_CREATED;
+        *slot_state = state->cfg->epoch_less ? TABLE_PUBLISHED : TABLE_CREATED;
         if (state->cfg->unique_tables)
-            ++state->workers[t].slot_gen[slot];
+            ++state->workers[t].table[slot].gen;
         break;
     case TABLE_CREATED:
+        testutil_assert(!state->cfg->epoch_less);
         switch (__wt_random(rnd) % 3) {
         case 0: /* publish the create */
             ev.type = EVENT_PUBLISH_CREATE;
@@ -90,10 +91,11 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         } else if (__wt_random(rnd) % GEN_DROP_ODDS == 0 && (!stepping_down || !*stepdown_insert)) {
             /* Such a drop would wait on a checkpoint the step-down cannot take. */
             ev.type = EVENT_DROP;
-            *slot_state = TABLE_DROPPED;
+            *slot_state = state->cfg->epoch_less ? TABLE_NONE : TABLE_DROPPED;
         }
         break;
     case TABLE_DROPPED:
+        testutil_assert(!state->cfg->epoch_less);
         /* Publish the drop, which frees the slot, or linger in the window. */
         if (__wt_random(rnd) % 2 == 0) {
             ev.type = EVENT_PUBLISH_DROP;
@@ -106,13 +108,15 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
 
     ev.thread_id = t;
     testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot,
-      state->workers[t].slot_gen[slot]);
+      state->workers[t].table[slot].gen);
     if (ev.type == EVENT_INSERT) {
         ev.key_min = DATA_KEY_MIN;
         ev.key_max = DATA_KEY_MAX;
     }
-    /* This event needs a timestamp. */
-    if (ev.type == EVENT_INSERT || ev.type == EVENT_PUBLISH_CREATE || ev.type == EVENT_PUBLISH_DROP)
+    /* Only an epoch-mode schema operation defers its timestamp to its publish event. */
+    const bool deferred_ts =
+      !state->cfg->epoch_less && (ev.type == EVENT_CREATE || ev.type == EVENT_DROP);
+    if (!deferred_ts)
         ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
 
     generator_emit(state, &ev);
@@ -133,7 +137,7 @@ generator_round(WORKLOAD_STATE *state, uint64_t lead_max, GENERATOR_PHASE phase)
 
     bool emitted = false;
 
-    for (uint32_t t = 0; t < state->nth_workers && workload_active(state, STAGE_GENERATOR); t++)
+    for (uint32_t t = 0; t < state->worker_count && workload_active(state, STAGE_GENERATOR); t++)
         if (generator_op(state, t, phase))
             emitted = true;
     return (emitted);
@@ -141,7 +145,7 @@ generator_round(WORKLOAD_STATE *state, uint64_t lead_max, GENERATOR_PHASE phase)
 
 /* A leading generator's pacing state. */
 typedef struct {
-    uint64_t lead_max; /* events that may be in flight; UINT64_MAX when nothing bounds it */
+    uint64_t lead_max; /* events that may be in flight */
     struct timespec last_poll;
 
     uint64_t stepdown_emitted;      /* events emitted since the step-down started */
@@ -157,14 +161,13 @@ generator_pacing_init(GENERATOR_PACING *pacing, const TEST_CONFIG *cfg)
 {
     WT_CLEAR(*pacing);
     __wt_epoch(NULL, &pacing->last_poll);
-    /*-
-     * How much lead the generator may have over the workers:
-     *   - no roles switching: no limit, the event pipe will be always full,
-     *   - otherwise: throttle the generator, so role switch happens within reasonable time.
+    /*
+     * How much lead the generator may have over the workers: enough to keep every worker fed, and
+     * enough that a role switch, which drains what is queued first, completes in reasonable time.
+     * Bounding it also keeps a graceful stop prompt, since the stop drains the same queues.
      */
-    pacing->lead_max = cfg->switch_interval == 0 ?
-      UINT64_MAX :
-      WT_MAX(cfg->switch_interval * GEN_APPLY_RATE_FLOOR, GEN_MIN_LEAD);
+    pacing->lead_max = WT_MAX((uint64_t)cfg->thread_count * GEN_LEAD_PER_THREAD,
+      (uint64_t)cfg->switch_interval * GEN_APPLY_RATE_FLOOR);
 }
 
 /*
@@ -192,9 +195,12 @@ generator_switch_requested(GENERATOR_PACING *pacing)
 static void
 generator_flush_publishes(WORKLOAD_STATE *state)
 {
-    for (uint32_t t = 0; t < state->nth_workers; t++)
+    if (state->cfg->epoch_less)
+        return;
+
+    for (uint32_t t = 0; t < state->worker_count; t++)
         for (uint32_t slot = 0; slot < state->cfg->pool_size; slot++) {
-            TABLE_STATE *slot_state = &state->workers[t].table_state[slot];
+            TABLE_STATE *slot_state = &state->workers[t].table[slot].state;
             if (*slot_state != TABLE_CREATED && *slot_state != TABLE_DROPPED)
                 continue;
 
@@ -203,7 +209,7 @@ generator_flush_publishes(WORKLOAD_STATE *state)
             ev.thread_id = t;
             ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
             testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t,
-              slot, state->workers[t].slot_gen[slot]);
+              slot, state->workers[t].table[slot].gen);
 
             *slot_state = *slot_state == TABLE_CREATED ? TABLE_PUBLISHED : TABLE_NONE;
             generator_emit(state, &ev);

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -86,12 +86,14 @@ query_ts(WT_CONNECTION *conn, uint8_t bit)
  *     Set the selected connection timestamps to given value.
  */
 void
-set_ts(WT_CONNECTION *conn, uint8_t mask, uint64_t ts)
+set_ts(const TEST_CONFIG *cfg, WT_CONNECTION *conn, uint8_t mask, uint64_t ts)
 {
+    if (cfg->epoch_less)
+        mask &= (uint8_t)~TS_SCHEMA_EPOCHS;
+    testutil_assert(mask != 0);
+
     char config[256];
     size_t len = 0;
-
-    testutil_assert(mask != 0);
     for (uint8_t bit = 1; bit != 0; bit = (uint8_t)(bit << 1)) {
         if ((mask & bit) == 0)
             continue;
@@ -146,11 +148,12 @@ static void
 usage(void)
 {
     fprintf(stderr,
-      "usage: %s [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N] [-T threads] "
+      "usage: %s [-b build-dir] [-e] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N] [-T threads] "
       "[-t time] [-q] [-u pool] [-v]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-b build directory (required for PALite extension)\n"
+      "\t-e run legacy schema operations without epochs (single node only)\n"
       "\t-h home directory\n"
       "\t-k kill after N seconds: lN the current leader, fN the current follower (two nodes),\n"
       "\t   plain N the lone node (single node); may be given more than once\n"
@@ -243,10 +246,10 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
 
     *rand_thp = *rand_timep = true;
 
-    testutil_parse_begin_opt(argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:q", cfg->opts);
+    testutil_parse_begin_opt(argc, argv, "A:b:eh:i:k:pP:r:R:s:t:T:u:vW:q", cfg->opts);
 
     int ch;
-    while ((ch = __wt_getopt(progname, argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:q")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "A:b:eh:i:k:pP:r:R:s:t:T:u:vW:q")) != EOF)
         switch (ch) {
         case 'A':
             if (strcmp(__wt_optarg, "l") == 0)
@@ -255,6 +258,9 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
                 cfg->start_leader = false;
             else
                 usage();
+            break;
+        case 'e':
+            cfg->epoch_less = true;
             break;
         case 'i':
             cfg->node_id = parse_uint_in_range(__wt_optarg, 0, MAX_NODES - 1, "Node id");
@@ -277,7 +283,7 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
             break;
         case 'T':
             *rand_thp = false;
-            cfg->nth = parse_uint_in_range(__wt_optarg, 1, MAX_TH, "Thread count");
+            cfg->thread_count = parse_uint_in_range(__wt_optarg, 1, MAX_TH, "Thread count");
             break;
         case 'q':
             cfg->unique_tables = true;
@@ -334,9 +340,9 @@ randomize_run_parameters(TEST_CONFIG *cfg, bool rand_th, bool rand_time)
 
     const uint32_t rand_value = __wt_random(&cfg->opts->data_rnd);
     if (rand_th) {
-        cfg->nth = rand_value % MAX_TH;
-        if (cfg->nth < MIN_TH)
-            cfg->nth = MIN_TH;
+        cfg->thread_count = rand_value % MAX_TH;
+        if (cfg->thread_count < MIN_TH)
+            cfg->thread_count = MIN_TH;
     }
 
     /* No -r: run a random single node. */
@@ -365,6 +371,11 @@ validate_run_parameters(const TEST_CONFIG *cfg)
         fprintf(stderr, "-k lN / -k fN target roles; use plain -k N with a single node\n");
         usage();
     }
+    if (cfg->epoch_less && multi_node) {
+        fprintf(
+          stderr, "-e supports single-node roles only; schema epochs are required with -r lf\n");
+        usage();
+    }
 }
 
 /*
@@ -389,8 +400,9 @@ print_run_banner(const TEST_CONFIG *cfg)
     println("Parent: roles %s; %" PRIu32 " schema threads; pool %" PRIu32
             " slots; switch every %" PRIu32 "s; kill leader@%" PRIu32 " follower@%" PRIu32
             " lone@%" PRIu32 "; stop at %" PRIu32 "s",
-      roles_arg(cfg), cfg->nth, cfg->pool_size, cfg->switch_interval, cfg->kill_time[KILL_LEADER],
-      cfg->kill_time[KILL_FOLLOWER], cfg->kill_time[KILL_LONE], cfg->total_time);
+      roles_arg(cfg), cfg->thread_count, cfg->pool_size, cfg->switch_interval,
+      cfg->kill_time[KILL_LEADER], cfg->kill_time[KILL_FOLLOWER], cfg->kill_time[KILL_LONE],
+      cfg->total_time);
 
     char switch_arg[32] = "", kill_args[64] = "";
     if (cfg->switch_interval != 0)
@@ -401,10 +413,10 @@ print_run_banner(const TEST_CONFIG *cfg)
             testutil_snprintf_len_incr(kill_args, sizeof(kill_args), &len, " -k %s%" PRIu32,
               kill_prefix[k], cfg->kill_time[k]);
 
-    println("CONFIG: %s -r %s%s%s -u %" PRIu32 " -T %" PRIu32 " -t %" PRIu32
+    println("CONFIG: %s%s -r %s%s%s -u %" PRIu32 " -T %" PRIu32 " -t %" PRIu32
             " " TESTUTIL_SEED_FORMAT,
-      progname, roles_arg(cfg), switch_arg, kill_args, cfg->pool_size, cfg->nth, cfg->total_time,
-      cfg->opts->data_seed, cfg->opts->extra_seed);
+      progname, cfg->epoch_less ? " -e" : "", roles_arg(cfg), switch_arg, kill_args, cfg->pool_size,
+      cfg->thread_count, cfg->total_time, cfg->opts->data_seed, cfg->opts->extra_seed);
 }
 
 /*
@@ -420,7 +432,7 @@ main(int argc, char *argv[])
 
     TEST_CONFIG cfg = {0};
     cfg.opts = &s_opts;
-    cfg.nth = MIN_TH;
+    cfg.thread_count = MIN_TH;
     /*
      * Default: 32 slots per thread. A wide pool keeps the generator's picks off the few slots gated
      * behind a checkpoint, so it rarely comes up empty and has to wait.

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -191,7 +191,7 @@ node_transition_done(const TEST_CONFIG *cfg, WORKLOAD_STATE *state, bool complet
 
 /*
  * node_stage_stopped --
- *     Whether every thread of a stage has been joined. STAGE_WORKERS is nth_workers threads wide,
+ *     Whether every thread of a stage has been joined. STAGE_WORKERS is worker_count threads wide,
  *     the other stages are one thread each, and STAGE_NONE is no thread at all.
  */
 bool
@@ -200,7 +200,7 @@ node_stage_stopped(WORKLOAD_STATE *state, uint32_t stage)
     if (stage != STAGE_WORKERS)
         return (!state->aux_thr[stage].created);
 
-    for (uint32_t i = 0; i < state->nth_workers; i++)
+    for (uint32_t i = 0; i < state->worker_count; i++)
         if (state->workers[i].thr.created)
             return (false);
     return (true);
@@ -244,9 +244,9 @@ static void
 workload_start(WORKLOAD_STATE *state, bool as_leader)
 {
     TEST_CONFIG *cfg = state->cfg;
-    testutil_assert(cfg->nth <= MAX_TH);
+    testutil_assert(cfg->thread_count <= MAX_TH);
 
-    state->nth_workers = cfg->nth;
+    state->worker_count = cfg->thread_count;
     state->leads = as_leader;
     /* A leader feeds itself; so does a follower with no peer. Snapshot it: peer_alive can flip. */
     state->generates = as_leader || !cfg->peer_alive;
@@ -259,17 +259,19 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
     state->frontier_ts = state->current_ts;
     memset(state->completed_ts, 0, sizeof(state->completed_ts));
 
-    /* Reset workers' state. Note: tables' state survives role transitioning. */
-    for (uint32_t i = 0; i < cfg->nth; i++) {
+    /* Reset workers' state. */
+    for (uint32_t i = 0; i < cfg->thread_count; i++) {
         state->workers[i].busy = false;
         state->workers[i].evq.head = state->workers[i].evq.tail = 0;
-        memset(state->workers[i].stepdown_insert, 0, sizeof(state->workers[i].stepdown_insert));
+        for (uint32_t j = 0; j < cfg->pool_size; j++)
+            state->workers[i].table[j].stepdown_insert = false;
+        /* State and slot generation survive role transitioning. */
     }
 
     /* Re-seed the phase's worker and auxiliary streams. */
-    for (uint32_t i = 0; i <= cfg->nth; i++)
+    for (uint32_t i = 0; i <= cfg->thread_count; i++)
         testutil_random_from_random(
-          &state->gen_rnd[i], i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
+          &state->gen_rnd[i], i < cfg->thread_count ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
 
     node_aux_start(state, STAGE_TS, thread_ts_run);
     node_workers_start(state);
@@ -340,7 +342,7 @@ node_step_up(WORKLOAD_STATE *state, uint64_t final_ts)
 
     /* Restore the timestamps on the new leader's connection. */
     if (final_ts != 0)
-        set_ts(state->conn, TS_FRONTIER, final_ts);
+        set_ts(state->cfg, state->conn, TS_FRONTIER, final_ts);
 }
 
 /*
@@ -428,13 +430,9 @@ node_main(TEST_CONFIG *cfg)
 
     const NODE_ROLE *role = node_role(cfg->start_leader);
     node_open(state, role->name);
-    /*
-     * Enter the epoch world before the workload can publish anything, on either role: a follower
-     * publishes the operations it applies too. Timestamps start at the same point, so the first
-     * event's epoch is above the stable one.
-     */
-    workload_seed_counter(state, SCHEMA_EPOCH_BOOTSTRAP);
-    set_ts(state->conn, TS_FRONTIER, SCHEMA_EPOCH_BOOTSTRAP);
+    /* Seed the timestamp sequence; epoch mode also enters the schema epoch world at this value. */
+    workload_seed_counter(state, TS_BOOTSTRAP);
+    set_ts(cfg, state->conn, TS_FRONTIER, TS_BOOTSTRAP);
     println("Node %" PRIu32 ": starting as %s", cfg->node_id, role->name);
 
     return (node_run(cfg, state, role));

--- a/test/csuite/schema_disagg_abort/parent.c
+++ b/test/csuite/schema_disagg_abort/parent.c
@@ -79,10 +79,10 @@ spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool
     static const char *const node_names[SUBPROC_SLOTS] = {"node0", "node1"};
     testutil_assert(node_id < SUBPROC_SLOTS);
 
-    char id_arg[16], nth_arg[16], pool_arg[16], rfd_arg[16], switch_arg[16], wfd_arg[16],
+    char id_arg[16], thr_count_arg[16], pool_arg[16], rfd_arg[16], switch_arg[16], wfd_arg[16],
       seed_arg[80];
     testutil_snprintf(id_arg, sizeof(id_arg), "%" PRIu32, node_id);
-    testutil_snprintf(nth_arg, sizeof(nth_arg), "%" PRIu32, cfg->nth);
+    testutil_snprintf(thr_count_arg, sizeof(thr_count_arg), "%" PRIu32, cfg->thread_count);
     testutil_snprintf(pool_arg, sizeof(pool_arg), "%" PRIu32, cfg->pool_size);
     testutil_snprintf(rfd_arg, sizeof(rfd_arg), "%d", read_fd);
     testutil_snprintf(switch_arg, sizeof(switch_arg), "%" PRIu32, cfg->switch_interval);
@@ -106,9 +106,11 @@ spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool
         argv[n++] = cfg->opts->build_dir;
     }
     argv[n++] = "-T";
-    argv[n++] = nth_arg;
+    argv[n++] = thr_count_arg;
     argv[n++] = "-u";
     argv[n++] = pool_arg;
+    if (cfg->epoch_less)
+        argv[n++] = "-e";
     if (cfg->unique_tables)
         argv[n++] = "-q";
     /* The node bounds how far its generator runs ahead so a hand-over drains inside a period. */

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -42,8 +42,12 @@ reader_step_down(WORKLOAD_STATE *state, uint64_t ts)
     while (__wt_atomic_load_bool(&state->ts_busy))
         __wt_sleep(0, WT_THOUSAND);
 
-    set_ts(conn, TS_STEPDOWN, ts);
-    set_ts(conn, TS_FRONTIER, ts);
+    /*
+     * FIXME-WT-18314: Reject step down timestamp without the epoch. The `-e` mode with role
+     * switches becomes illegal.
+     */
+    set_ts(state->cfg, conn, TS_STEPDOWN, ts);
+    set_ts(state->cfg, conn, TS_FRONTIER, ts);
 
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -7,37 +7,18 @@
  */
 
 /*
- * Disaggregated schema epoch crash recovery test.
+ * Disaggregated schema crash recovery test: one or two nodes create, populate and drop tables over
+ * a shared page log while the parent switches their roles, kills them or stops them cleanly. Each
+ * node is then recovered from shared storage and verified against per-operation record files. See
+ * README.md for the architecture, the generator's slot model and what verification asserts.
  *
- * The test binary runs in one of two roles, each in its own process:
- *
- *   parent - orchestrator and verifier. Spawns one or two symmetric nodes per the -r topology,
- *            then drives a timeline: role switches every -s seconds, SIGKILLs at the -k times,
- *            and a graceful stop at the -t timeout. Afterwards it reopens the surviving state
- *            and verifies it against the record files.
- *   node   - a database node that leads or follows, described below.
- *
- * Events are the single currency, and both node roles run the identical pipeline: a source writes
- * events to a pipe, the reader demuxes them to per-thread queues, and the workers execute them. A
- * leader's source is its own generator thread writing the full stream (the workload and the switch
- * event that ends a term) to a self-pipe; a follower's source is the peer's relay. The only role
- * difference in the pipeline is that a leader relays every applied event to the peer. A follower
- * with no event source (no peer, or the peer died) simply idles in role.
- *
- * Checkpoints are deliberately not part of the stream: a checkpoint thread paces them on its own,
- * producing them while leading and adopting the latest one while following. That independence is
- * what lets a checkpoint land anywhere between an operation and its publish, and what keeps
- * checkpoints coming while a worker sits blocked waiting for one.
- *
- * Nodes switch roles on the switch event: the leader's generator emits it when the parent drops the
- * switch-request sentinel, and the hand-over relays it to the peer; a lone follower's generator
- * consumes the sentinel and reports the hand-over directly. Nodes stop gracefully when the parent
- * drops the stop sentinel.
- *
- * The children are started by re-spawning this binary with internal options, so no state is
- * inherited by forking: everything a node needs travels through the command line. The two nodes
- * are connected by a pair of pipes, one per direction; a node writes to its out-pipe while
- * leading and reads from its in-pipe while following.
+ * Main parts:
+ *   - the parent: orchestrates and verifies;
+ *   - a node: leads or follows;
+ *   - events: generator writes them to a pipe, the reader demuxes them to
+ *     per-worker queues, the workers apply them;
+ *   - checkpoints are in their own thread, independent of the workers;
+ *   - role changes and the graceful stop are driven by sentinel files the parent drops;
  */
 
 #pragma once
@@ -52,7 +33,7 @@
 #define GEN_INSERT_ODDS 64         /* an insert: 1 in N visits to a published slot */
 #define GEN_DROP_ODDS 48           /* a drop: 1 in N visits to a published slot */
 #define GEN_APPLY_RATE_FLOOR 30    /* applied values/second, the multi-node worst case */
-#define GEN_MIN_LEAD 64            /* lead floor, so the workers stay fed */
+#define GEN_LEAD_PER_THREAD 32     /* in-flight events per worker, so the workers stay fed */
 #define GEN_STEPDOWN_MIN_EVENTS 64 /* minimum events a lone node emits during stepdown */
 
 /*
@@ -62,7 +43,7 @@
 #define FRONTIER_WINDOW 0x10000u
 
 #define MAX_CKPT_INVL 4 /* checkpoint thread: upper bound on the interval, in seconds */
-#define SCHEMA_EPOCH_BOOTSTRAP 1
+#define TS_BOOTSTRAP 1  /* the timestamp sequence starts here, on either mode */
 #define MAX_NODES 2
 /*
  * In-node: a retried op gives up, before the parent stops waiting. A blocked drop waits for the
@@ -70,12 +51,12 @@
  */
 #define MAX_OP_WAIT 30
 #define MAX_POOL_SIZE 64
-#define MAX_TH 12
 #define MAX_TIME 40
+#define MIN_TIME 10
 #define MAX_WAIT 60 /* parent: a child starting, stopping, or posting a sentinel */
 #define MIN_POOL_SIZE 2
+#define MAX_TH 12
 #define MIN_TH 2
-#define MIN_TIME 10
 
 /* Directory layout under the test home. */
 #define NODE_HOME_FMT "WT_NODE%" PRIu32
@@ -124,6 +105,8 @@
 #define TS_LAST_CHECKPOINT 0x40u
 #define TS_FRONTIER (TS_OLDEST | TS_STABLE | TS_STABLE_SCHEMA_EPOCH)
 #define TS_STEPDOWN (TS_STEPDOWN_TIMESTAMP | TS_STEPDOWN_SCHEMA_EPOCH)
+/* The epoch bits set_ts drops when epochs are off; setting either one leaves legacy mode. */
+#define TS_SCHEMA_EPOCHS (TS_STABLE_SCHEMA_EPOCH | TS_STEPDOWN_SCHEMA_EPOCH)
 
 /* Which process this instance of the binary is. */
 typedef enum { ROLE_PARENT = 0, ROLE_NODE } TEST_ROLE;
@@ -149,8 +132,9 @@ typedef struct {
     uint32_t thread_id;
     /*
      * The timestamp whose completion this event represents: a publish epoch, an insert's commit
-     * timestamp (which the rows also hold), or a term's final timestamp. CREATE/DROP carry none - a
-     * schema operation completes with its publish.
+     * timestamp (which the rows also hold), a legacy schema operation's timestamp, or a term's
+     * final timestamp. CREATE/DROP carry none when schema epochs are in use - a schema operation
+     * then completes with its publish.
      */
     uint64_t event_ts;
     uint32_t key_min;
@@ -182,10 +166,11 @@ typedef struct {
     bool peer_alive;    /* this node has a live peer; cleared on pipe EOF/EPIPE */
     char home[PATH_MAX];
     char page_log_home[PATH_MAX];
-    uint32_t nth;
+    uint32_t thread_count;
     uint32_t pool_size;
     /* FIXME-WT-18403: Remove -q once all the known create/drop/create issues are gone. */
     bool unique_tables;               /* -q: never reuse a table name */
+    bool epoch_less;                  /* -e: legacy schema operations without epochs or publish */
     uint32_t total_time;              /* -t: graceful stop after this many seconds */
     uint32_t switch_interval;         /* -s: switch roles every N seconds; 0: never */
     uint32_t kill_time[KILL_TARGETS]; /* -k [l|f]N: SIGKILL the target at N; 0: never */
@@ -249,26 +234,29 @@ typedef struct {
     uint64_t stepdown_ckpt_lsn; /* the step-down checkpoint, once taken */
     bool ts_busy;               /* the timestamp thread is mid-advance; atomic access */
 
-    /* Single monotonic timestamp for schema epochs AND commit timestamps. */
+    /* Single monotonic value for schema operations and commit timestamps. */
     uint64_t current_ts;
     uint64_t frontier_ts; /* every timestamp at or below it is applied; atomic access */
     /* Circular buffer for completed timestamps of all workers; atomic access. */
     uint8_t completed_ts[FRONTIER_WINDOW];
-    uint64_t emitted; /* generator: how many events have been emitted */
-    uint64_t applied; /* worker: how many events have been applied; atomic access */
-    uint32_t nth_workers;
+    uint64_t emitted;      /* generator: how many events have been emitted */
+    uint64_t applied;      /* worker: how many events have been applied; atomic access */
+    uint32_t worker_count; /* how many workers are in use this phase */
 
     /* Per-worker-thread state; the reader fills the queue, the slot model is the generator's. */
     struct {
         wt_thread_t thr; /* this worker's handle */
         EVENT_QUEUE evq; /* this worker's inbound events */
         bool busy;       /* the worker is mid-apply; atomic access */
-        /* Table state is carried across leader-follower transitions. */
-        TABLE_STATE table_state[MAX_POOL_SIZE];
-        /* Advanced by every create under -q, so a slot's table name is never reused. */
-        uint32_t slot_gen[MAX_POOL_SIZE];
-        /* Slot took an insert while stepping down; not droppable until the step-down completes. */
-        bool stepdown_insert[MAX_POOL_SIZE];
+        struct {
+            /* Table state is carried across leader-follower transitions. */
+            TABLE_STATE state;
+            /* Advanced by every create under -q, so a slot's table name is never reused. */
+            uint32_t gen;
+            /* Slot took an insert while stepping down; not droppable until the step-down completes.
+             */
+            bool stepdown_insert;
+        } table[MAX_POOL_SIZE];
     } workers[MAX_TH];
 
     /* The single-threaded stages, indexed by stage: generator, reader, checkpoint, timestamp. */
@@ -300,7 +288,7 @@ typedef struct {
 /* main.c */
 void println(const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 1, 2)));
 uint64_t query_ts(WT_CONNECTION *conn, uint8_t bit);
-void set_ts(WT_CONNECTION *conn, uint8_t mask, uint64_t ts);
+void set_ts(const TEST_CONFIG *cfg, WT_CONNECTION *conn, uint8_t mask, uint64_t ts);
 void adopted_lsn_publish(uint32_t node_id, uint64_t lsn);
 uint64_t adopted_lsn_read(void);
 

--- a/test/csuite/schema_disagg_abort/smoke.sh
+++ b/test/csuite/schema_disagg_abort/smoke.sh
@@ -42,6 +42,12 @@ $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -h WT_TEST.schema_disa
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 4 -h WT_TEST.schema_disagg_abort.l4
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -u 4 -h WT_TEST.schema_disagg_abort.u4
 
+# Legacy schema mode: only single node is supported.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -e -r l -t 10 -T 2 -h WT_TEST.schema_disagg_abort.el
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -e -r l -k 8 -t 10 -T 2 -h WT_TEST.schema_disagg_abort.ek
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -e -r l -s 5 -k 12 -t 20 -T 2 \
+    -h WT_TEST.schema_disagg_abort.elsk
+
 # A lone follower generates its own workload and never checkpoints, so nothing becomes durable; the
 # second run then steps up over the operations it accumulated, the way a fresh node bootstraps its
 # own tables before taking leadership.

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -20,14 +20,24 @@
 
 /* The last durable create or drop recorded for one URI slot, and its inserted data if any. */
 typedef struct {
-    uint64_t epoch;
+    uint64_t schema_ts; /* publish epoch, or the legacy operation's test timestamp */
     uint64_t commit_ts; /* DATA_COMMIT_TS_NONE when the create has no durable insert record */
     uint32_t key_min;
     uint32_t key_max;
     bool is_create;
     bool valid;
-    char uri[64]; /* filled when valid, so the checks need not rebuild it */
+    bool newer_schema_op; /* legacy schema record above the checkpoint timestamp */
+    char uri[64];         /* filled when valid, so the checks need not rebuild it */
 } SLOT_STATE;
+
+/* What the checks asserted, so a run that verifies nothing is visible in the log. */
+typedef struct {
+    uint32_t present; /* slots asserted present */
+    uint32_t absent;  /* slots asserted absent */
+    uint32_t rows;    /* slots whose rows were compared */
+    uint32_t skipped_slots;
+    uint32_t skipped_rows;
+} VERIFY_STATS;
 
 /*
  * parse_record_uri --
@@ -49,15 +59,15 @@ parse_record_uri(
 
 /*
  * parse_schema_records --
- *     Read a record file and accumulate the last durable operation per slot. Records above
- *     durable_epoch never reached a checkpoint before the crash, so they are ignored.
+ *     Read a record file and accumulate the last durable operation per slot. Epoch-mode records
+ *     above the cutoff are not durable; legacy schema records there have an unknown outcome.
  *
  * This function is called for both leader's and follower's record files to recreate the last
  *     durable state of the database after recovery.
  */
 static void
-parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t durable_epoch,
-  SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
+parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t durable_ts,
+  bool epoch_less, SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
 {
     FILE *fp;
     testutil_assert_errno((fp = fopen(fname, "r")) != NULL);
@@ -75,7 +85,7 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
         }
 
         char rec_uri[128];
-        uint64_t op_ts; /* the publish epoch, or an insert's commit timestamp */
+        uint64_t op_ts; /* publish epoch, legacy schema timestamp, or insert commit timestamp */
         uint32_t key_max = 0, key_min = 0, s;
         bool parsed = false;
 
@@ -93,9 +103,14 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
             continue;
         }
 
-        /* Skip non-durable ops: values a checkpoint never covered, other slots. */
-        if (op_ts > durable_epoch || !parse_record_uri(rec_uri, node, t, pool_size, &s))
+        if (!parse_record_uri(rec_uri, node, t, pool_size, &s))
             continue;
+        /* Legacy schema entries above the checkpoint timestamp may or may not have been drained. */
+        if (op_ts > durable_ts) {
+            if (epoch_less && (strcmp(op, "CREATE") == 0 || strcmp(op, "DROP") == 0))
+                states[s].newer_schema_op = true;
+            continue;
+        }
 
         if (strcmp(op, "INSERT") == 0) {
             /*
@@ -103,15 +118,15 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
              * because earlier values are overwritten.
              */
             const bool latest_insert = states[s].valid && states[s].is_create &&
-              op_ts > states[s].epoch && op_ts > states[s].commit_ts;
+              op_ts > states[s].schema_ts && op_ts > states[s].commit_ts;
 
             if (latest_insert) {
                 states[s].commit_ts = op_ts;
                 states[s].key_min = key_min;
                 states[s].key_max = key_max;
             }
-        } else if (op_ts > states[s].epoch) { /* most recent CREATE or DROP */
-            states[s].epoch = op_ts;
+        } else if (op_ts > states[s].schema_ts) { /* most recent CREATE or DROP */
+            states[s].schema_ts = op_ts;
             states[s].commit_ts = DATA_COMMIT_TS_NONE;
             states[s].is_create = strcmp(op, "CREATE") == 0;
             states[s].valid = true;
@@ -123,12 +138,11 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
 
 /*
  * check_schema_presence --
- *     For each slot with a durable record, assert that a table whose last operation was a create
- *     still exists and one whose last operation was a drop is absent.
+ *     Check table presence where legacy checkpoint and role-switch semantics make it knowable.
  */
 static void
-check_schema_presence(
-  WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
+check_schema_presence(WT_SESSION *session, const TEST_CONFIG *cfg,
+  const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size, VERIFY_STATS *stats)
 {
     /* Validate presence against the metadata entry rather than instantiating each table. */
     WT_CURSOR *md_cursor;
@@ -142,12 +156,22 @@ check_schema_presence(
         const int ret = md_cursor->search(md_cursor);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
-        if (states[s].is_create)
-            testutil_assertfmt(ret == 0, "%s missing after recovery (CREATE at epoch %" PRIu64 ")",
-              states[s].uri, states[s].epoch);
-        else
+        const bool uncertain_tail = cfg->epoch_less && states[s].newer_schema_op;
+        /* A legacy step-up rebuilds shared metadata from local metadata, and enqueue creates
+         * only, so a drop applied while following is resurrected. */
+        const bool switched_legacy_drop =
+          cfg->epoch_less && cfg->switch_interval != 0 && !states[s].is_create;
+
+        if (states[s].is_create && !uncertain_tail) {
+            testutil_assertfmt(ret == 0, "%s missing after recovery (CREATE at %" PRIu64 ")",
+              states[s].uri, states[s].schema_ts);
+            ++stats->present;
+        } else if (!states[s].is_create && !uncertain_tail && !switched_legacy_drop) {
             testutil_assertfmt(
               ret == WT_NOTFOUND, "%s present after recovery (last op was DROP)", states[s].uri);
+            ++stats->absent;
+        } else
+            ++stats->skipped_slots;
     }
 
     testutil_check(md_cursor->close(md_cursor));
@@ -162,7 +186,7 @@ check_schema_presence(
  */
 static void
 check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size,
-  uint64_t last_ckpt_ts)
+  uint64_t last_ckpt_ts, VERIFY_STATS *stats)
 {
     for (uint32_t s = 0; s < pool_size; s++) {
         if (!states[s].valid || !states[s].is_create)
@@ -171,6 +195,11 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
             continue;
         if (last_ckpt_ts > 0 && states[s].commit_ts > last_ckpt_ts)
             continue;
+        if (states[s].newer_schema_op) {
+            ++stats->skipped_rows;
+            continue;
+        }
+        ++stats->rows;
 
         WT_CURSOR *cursor;
         testutil_check(session->open_cursor(session, states[s].uri, NULL, NULL, &cursor));
@@ -184,8 +213,9 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
             testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
             cursor->set_key(cursor, key_buf);
             const int ret = cursor->search(cursor);
-            testutil_assertfmt(ret == 0, "%s key %s: %s (epoch %" PRIu64 ")", states[s].uri,
-              key_buf, ret == WT_NOTFOUND ? "missing" : wiredtiger_strerror(ret), states[s].epoch);
+            testutil_assertfmt(ret == 0, "%s key %s: %s (schema op %" PRIu64 ")", states[s].uri,
+              key_buf, ret == WT_NOTFOUND ? "missing" : wiredtiger_strerror(ret),
+              states[s].schema_ts);
 
             const char *actual_val;
             testutil_check(cursor->get_value(cursor, &actual_val));
@@ -201,27 +231,37 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
  *     Verify schema and data state after recovery.
  *
  * Every node's records are checked against the recovered database, since the shared page log makes
- *     all of them visible to any node. last_disaggregated_schema_epoch is the durability cutoff.
+ *     all of them visible to any node. Epoch mode uses the checkpoint's schema epoch as the cutoff;
+ *     legacy mode uses its stable timestamp.
  */
 void
 verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
 {
+    const uint64_t last_ckpt_ts = query_ts(conn, TS_LAST_CHECKPOINT);
     const uint64_t durable_epoch = query_ts(conn, TS_LAST_SCHEMA_EPOCH);
-    println("Schema verify: last_disaggregated_schema_epoch = %" PRIu64, durable_epoch);
+    /* An epoch-less database has no schema epoch; a -v rerun that forgot -e would check nothing. */
+    testutil_assertfmt(!cfg->epoch_less || durable_epoch == 0,
+      "-e verify against a database with schema epoch %" PRIu64, durable_epoch);
+
+    const uint64_t durable_ts = cfg->epoch_less ? last_ckpt_ts : durable_epoch;
+    println("Schema verify: %s = %" PRIu64,
+      cfg->epoch_less ? "last_checkpoint_timestamp" : "last_disaggregated_schema_epoch",
+      durable_ts);
     /* Nothing durable means no record is below the cutoff, so there is nothing to check. */
-    if (durable_epoch == 0) {
+    if (durable_ts == 0) {
         println("Schema verify: nothing durable, no expectations to check");
         return;
     }
 
-    const uint64_t last_ckpt_ts = query_ts(conn, TS_LAST_CHECKPOINT);
-    println("Schema verify: last_checkpoint_timestamp = %" PRIu64, last_ckpt_ts);
+    if (!cfg->epoch_less)
+        println("Schema verify: last_checkpoint_timestamp = %" PRIu64, last_ckpt_ts);
 
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
+    VERIFY_STATS stats = {0};
     for (uint32_t n = 0; n < MAX_NODES; n++)
-        for (uint32_t t = 0; t < cfg->nth; t++) {
+        for (uint32_t t = 0; t < cfg->thread_count; t++) {
             char lname[128], mname[128];
             testutil_snprintf(lname, sizeof(lname), LEADER_RECORDS_FILE, n, t);
             /* The peer's follower file mirrors what node n originated on this thread. */
@@ -242,12 +282,18 @@ verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
             SLOT_STATE states[MAX_POOL_SIZE];
             memset(states, 0, sizeof(SLOT_STATE) * cfg->pool_size);
             if (have_own)
-                parse_schema_records(lname, n, t, durable_epoch, states, cfg->pool_size);
+                parse_schema_records(
+                  lname, n, t, durable_ts, cfg->epoch_less, states, cfg->pool_size);
             if (have_mirror)
-                parse_schema_records(mname, n, t, durable_epoch, states, cfg->pool_size);
-            check_schema_presence(session, states, cfg->pool_size);
-            check_data_rows(session, states, cfg->pool_size, last_ckpt_ts);
+                parse_schema_records(
+                  mname, n, t, durable_ts, cfg->epoch_less, states, cfg->pool_size);
+            check_schema_presence(session, cfg, states, cfg->pool_size, &stats);
+            check_data_rows(session, states, cfg->pool_size, last_ckpt_ts, &stats);
         }
+
+    println("Schema verify: asserted %" PRIu32 " present, %" PRIu32 " absent, %" PRIu32
+            " with rows; skipped %" PRIu32 " slots, %" PRIu32 " row checks",
+      stats.present, stats.absent, stats.rows, stats.skipped_slots, stats.skipped_rows);
 
     testutil_check(session->close(session, NULL));
 }
@@ -307,7 +353,7 @@ verify_relay_prefix(const TEST_CONFIG *cfg)
 {
     uint32_t checked = 0;
     for (uint32_t n = 0; n < MAX_NODES; n++)
-        for (uint32_t t = 0; t < cfg->nth; t++) {
+        for (uint32_t t = 0; t < cfg->thread_count; t++) {
             char follower_fname[128], leader_fname[128];
             testutil_snprintf(follower_fname, sizeof(follower_fname), FOLLOWER_RECORDS_FILE, n, t);
             testutil_snprintf(leader_fname, sizeof(leader_fname), LEADER_RECORDS_FILE, 1 - n, t);

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -9,7 +9,7 @@
 /*
  * The worker stage: N threads applying what the reader queued, exactly as the source stream fixed
  * each event, so both roles execute an identical history. Writes the verifier's record files, and
- * reports each completed operation as the thread's frontier mark.
+ * marks each completed operation in the shared frontier window.
  */
 
 #include "schema_disagg_abort.h"
@@ -40,19 +40,20 @@ record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
     int ret = 0;
 
     switch (ev->type) {
+    case EVENT_CREATE:
+    case EVENT_DROP:
     case EVENT_PUBLISH_CREATE:
     case EVENT_PUBLISH_DROP:
-        /* A schema operation is recorded when its publish fixes the epoch, not when it ran. */
+        /* Epoch mode records at publish; legacy mode records before executing the operation. */
         ret = fprintf(fp, "%s %" PRIu64 " %s\n",
-          ev->type == EVENT_PUBLISH_CREATE ? "CREATE" : "DROP", ev->event_ts, ev->uri);
+          ev->type == EVENT_CREATE || ev->type == EVENT_PUBLISH_CREATE ? "CREATE" : "DROP",
+          ev->event_ts, ev->uri);
         break;
     case EVENT_INSERT:
         ret = fprintf(fp, "INSERT %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->event_ts,
           ev->key_min, ev->key_max, ev->uri);
         break;
     case EVENT_NONE:
-    case EVENT_CREATE:
-    case EVENT_DROP:
     case EVENT_STEPDOWN:
     case EVENT_SWITCH:
         testutil_assertfmt(false, "Unexpected record event type: %d", ev->type);
@@ -91,7 +92,7 @@ schema_op_stall_report(WORKLOAD_STATE *state)
 {
     println("Node %" PRIu32 ": stable %" PRIu64 ", frontier %" PRIu64, state->cfg->node_id,
       query_ts(state->conn, TS_STABLE), __wt_atomic_load_uint64(&state->frontier_ts));
-    for (uint32_t t = 0; t < state->nth_workers; t++)
+    for (uint32_t t = 0; t < state->worker_count; t++)
         println("  worker %" PRIu32 ": %" PRIu64 " events queued", t, evq_depth(state, t));
 }
 
@@ -211,14 +212,8 @@ worker_complete(WORKLOAD_STATE *state, uint64_t value)
 /*
  * apply_event --
  *     Apply one event on this node, identically for both roles and exactly as the source stream
- *     fixed it: execute it, record it, relay it to the peer when leading, and mark its value
- *     completed. A schema operation carries no timestamp - its epoch, record and completion belong
- *     to its later publish event.
- *
- * The order within an event is load-bearing (README invariant 1): relay before record, so a record
- *     on disk implies the peer holds the event; record before publish, so no checkpoint can make an
- *     unrecorded epoch durable; relay before the completion store, so the stable frontier only ever
- *     covers already-relayed events.
+ *     fixed it. In epoch mode a schema operation's timestamp, record and completion belong to its
+ *     later publish event; in legacy mode they belong to the operation itself.
  */
 static void
 apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const SCHEMA_EVENT *ev)
@@ -239,14 +234,22 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const
         break;
     case EVENT_CREATE:
     case EVENT_DROP:
+        /* A legacy checkpoint can make the operation durable as soon as it executes. */
+        if (state->cfg->epoch_less)
+            record_event_line(ctx->record_fp, ev);
         schema_op_execute(state, ctx->session, ev);
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
-        /* No timestamp: count it applied, but the completion belongs to the publish. */
-        (void)__wt_atomic_add_uint64(&state->applied, 1);
+        if (state->cfg->epoch_less)
+            worker_complete(state, ev->event_ts);
+        else
+            /* No timestamp: count it applied, but the completion belongs to the publish. */
+            (void)__wt_atomic_add_uint64(&state->applied, 1);
         break;
     case EVENT_PUBLISH_CREATE:
     case EVENT_PUBLISH_DROP:
+        /* Legacy mode should not see these events. */
+        testutil_assert(!state->cfg->epoch_less);
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
         record_event_line(ctx->record_fp, ev);
@@ -316,7 +319,7 @@ node_workers_start(WORKLOAD_STATE *state)
     /* One argument per worker, alive for as long as its thread; the handles live in the state. */
     static THREAD_ARG worker_arg[MAX_TH];
 
-    for (uint32_t i = 0; i < state->nth_workers; i++) {
+    for (uint32_t i = 0; i < state->worker_count; i++) {
         worker_arg[i].state = state;
         worker_arg[i].thread_index = i;
         testutil_check(
@@ -337,6 +340,6 @@ node_workers_stop(WORKLOAD_STATE *state)
 
     /* Stop the current stage. */
     __wt_atomic_store_uint32(&state->stop_stage, STAGE_WORKERS);
-    for (uint32_t i = 0; i < state->nth_workers; i++)
+    for (uint32_t i = 0; i < state->worker_count; i++)
         testutil_check(__wt_thread_join(NULL, &state->workers[i].thr));
 }

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -828,6 +828,31 @@ tasks:
           # taking leadership.
           schema_args: -r f -s 30
 
+  # Legacy schema mode: no schema epochs and no publish, single node only.
+  - name: schema-disagg-abort-legacy-crash-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          # The only legacy shape that asserts drop absence: a step-up resurrects the drops a
+          # node applied while following.
+          schema_args: -e -r l -k 150
+
+  - name: schema-disagg-abort-legacy-switch-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - func: "schema disagg abort"
+        vars:
+          schema_args: -e -r l -s 30
+
   # FIXME-WT-18403: Remove these tasks once all the known create/drop/create issues are gone.
   - name: schema-disagg-abort-unique-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]


### PR DESCRIPTION
Note: This PR requires WT-18448 fix to be in the branch.

- Enable epoch-less (legacy) mode for `schema_disagg_abort` test.
- Verification after crash is limited: only tables with no schema ops after latest checkpoint can be verified reliably.