### PR TITLE
WT-18324 Panic when a checkpoint schema epoch refers to a dropped and recreated table

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -798,17 +798,21 @@ __disagg_remove_is_checkpoint_violation(WT_SESSION_IMPL *session, WT_CONNECTION_
     WT_DISAGGREGATED_STORAGE *disagg = &conn->disaggregated_storage;
     WT_ASSERT_SPINLOCK_OWNED(session, &disagg->shared_metadata_queue_lock);
 
-    /* Check whether the final operation after the REMOVE recreates the table. */
+    /* Check whether a recreated table exists after considering all later operations. */
     WT_DISAGG_METADATA_OP *op;
     bool recreated = false;
 
     for (op = TAILQ_NEXT(entry, q); op != NULL; op = TAILQ_NEXT(op, q)) {
         if (op->deferred || strcmp(op->stable_uri, entry->stable_uri) != 0)
             continue;
+        /*
+         * Overwrite `recreated` each loop so a later REMOVE can cancel an earlier CREATE. Only the
+         * final value matters.
+         */
         recreated = op->metadata_op == WT_SHARED_METADATA_CREATE;
     }
 
-    /* No recreate means no API violation. */
+    /* No recreated table exists, so there is no API violation. */
     if (!recreated)
         return (false);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -781,6 +781,48 @@ __disagg_handle_create_remove_pairing(WT_SESSION_IMPL *session, WT_CONNECTION_IM
 }
 
 /*
+ * __disagg_remove_is_checkpoint_violation --
+ *     Return whether a table visible at the checkpoint epoch is dropped and recreated at a future
+ *     epoch. This is an API violation because the checkpoint refers to the dropped table, while the
+ *     later CREATE refers to a different table with the same name.
+ */
+static bool
+__disagg_remove_is_checkpoint_violation(WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn,
+  WT_DISAGG_METADATA_OP *entry, wt_timestamp_t schema_epoch)
+{
+    /* Only a published drop can invalidate the checkpoint. */
+    if (entry->metadata_op != WT_SHARED_METADATA_REMOVE ||
+      entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED)
+        return (false);
+
+    WT_DISAGGREGATED_STORAGE *disagg = &conn->disaggregated_storage;
+    WT_ASSERT_SPINLOCK_OWNED(session, &disagg->shared_metadata_queue_lock);
+
+    /* Check whether the final operation after the REMOVE recreates the table. */
+    WT_DISAGG_METADATA_OP *op;
+    bool recreated = false;
+
+    for (op = TAILQ_NEXT(entry, q); op != NULL; op = TAILQ_NEXT(op, q)) {
+        if (op->deferred || strcmp(op->stable_uri, entry->stable_uri) != 0)
+            continue;
+        recreated = op->metadata_op == WT_SHARED_METADATA_CREATE;
+    }
+
+    /* No recreate means no API violation. */
+    if (!recreated)
+        return (false);
+
+    /* Exempt a table created and dropped entirely after the checkpoint epoch. */
+    for (op = TAILQ_FIRST(&disagg->shared_metadata_qh); op != entry; op = TAILQ_NEXT(op, q)) {
+        if (op->metadata_op == WT_SHARED_METADATA_CREATE && op->schema_epoch > schema_epoch &&
+          strcmp(op->stable_uri, entry->stable_uri) == 0)
+            return (false);
+    }
+
+    return (true);
+}
+
+/*
  * __disagg_requeue_skipped_creates --
  *     Return parked create entries to the head of the shared metadata queue, restoring their
  *     original order, so a later checkpoint revisits them.
@@ -844,6 +886,15 @@ __wt_disagg_shared_metadata_queue_process(
 
         /* Defer entries based on the schema epoch. */
         if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE && entry->schema_epoch > cur_schema_epoch) {
+            if (__disagg_remove_is_checkpoint_violation(session, conn, entry, cur_schema_epoch)) {
+                __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+                  "API violation: table \"%s\" was dropped at schema epoch %" PRIu64
+                  " and recreated, above the checkpoint's schema epoch %" PRIu64
+                  ": the checkpoint refers to the dropped generation",
+                  entry->table_name, entry->schema_epoch, cur_schema_epoch);
+                WT_ERR_PANIC(session, EINVAL,
+                  "API violation: checkpoint schema epoch refers to a dropped and recreated table");
+            }
             __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Defer metadata operation %s for table \"%s\" with schema epoch %" PRIu64,
               __wti_disagg_shared_metadata_op_to_string(entry->metadata_op), entry->table_name,

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1461,6 +1461,9 @@ struct __wt_session {
      * before they are published are not visible to other connections until they are published.
      * A client is not allowed to have any stable updates in an unpublished table.
      *
+     * Once a dropped table has been recreated, a checkpoint must not run with a schema epoch below
+     * the drop's published epoch.
+     *
      * @exclusive
      *
      * @not_transactional

--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -14,6 +14,8 @@ the durable state against per-operation record files.
 - In epoch mode, creates and drops have separate operation and publish events, allowing checkpoints
   and crashes to land between the two. In legacy mode each schema operation is complete without a
   publish event. Inserts are generated only after the create is complete.
+- A slot freed by a published drop is not recreated until the stable schema epoch passes the drop's
+  epoch; WiredTiger panics otherwise.
 - Leaders write checkpoints to the shared page log; followers adopt them. Role changes are events in
   the same stream, so all earlier work is drained before the connection is reconfigured.
 

--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -14,8 +14,8 @@ the durable state against per-operation record files.
 - In epoch mode, creates and drops have separate operation and publish events, allowing checkpoints
   and crashes to land between the two. In legacy mode each schema operation is complete without a
   publish event. Inserts are generated only after the create is complete.
-- A slot freed by a published drop is not recreated until the stable schema epoch passes the drop's
-  epoch; WiredTiger panics otherwise.
+- A published drop parks the slot in REMOVED until the stable schema epoch passes the drop's epoch;
+  recreating the name earlier is an API violation WiredTiger panics on.
 - Leaders write checkpoints to the shared page log; followers adopt them. Role changes are events in
   the same stream, so all earlier work is drained before the connection is reconfigured.
 
@@ -52,6 +52,7 @@ stateDiagram-v2
     state "CREATED - create publish pending" as CREATED
     state "PUBLISHED - create published" as PUBLISHED
     state "DROPPED - drop publish pending" as DROPPED
+    state "REMOVED - drop published, coverage pending" as REMOVED
 
     [*] --> NONE
     NONE --> CREATED : create
@@ -61,7 +62,9 @@ stateDiagram-v2
     PUBLISHED --> PUBLISHED : insert or linger
     PUBLISHED --> DROPPED : drop
     DROPPED --> DROPPED : linger
-    DROPPED --> NONE : publish drop
+    DROPPED --> REMOVED : publish drop
+    REMOVED --> REMOVED : await coverage
+    REMOVED --> NONE : stable epoch covers the drop
 ```
 
 ## Threads

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -207,7 +207,7 @@ thread_ts_run(void *arg)
              */
             const uint64_t stable_ts = query_ts(state->conn, TS_STABLE);
             if (frontier_ts >= stable_ts)
-                set_ts(state->cfg, state->conn, TS_FRONTIER, frontier_ts);
+                workload_set_frontier(state, frontier_ts);
         }
         __wt_atomic_store_bool(&state->ts_busy, false);
 

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -114,6 +114,7 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         return (false);
 
     ev.thread_id = t;
+    ev.slot = slot;
     testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot,
       state->workers[t].table[slot].gen);
     if (ev.type == EVENT_INSERT) {
@@ -212,6 +213,7 @@ generator_flush_publishes(WORKLOAD_STATE *state)
             SCHEMA_EVENT ev = {0};
             ev.type = *slot_state == TABLE_CREATED ? EVENT_PUBLISH_CREATE : EVENT_PUBLISH_DROP;
             ev.thread_id = t;
+            ev.slot = slot;
             testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t,
               slot, state->workers[t].table[slot].gen);
 

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -58,22 +58,13 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
 
     SCHEMA_EVENT ev = {0}; /* EVENT_NONE until a move is taken */
     switch (*slot_state) {
-    case TABLE_NONE: {
-        /* Linger: recreating before the stable epoch passes the published drop is a violation. */
-        const uint64_t published_drop = __wt_atomic_load_uint64(drop_epoch);
-        if (published_drop != 0) {
-            if (published_drop == UINT64_MAX ||
-              query_ts(state->conn, TS_STABLE_SCHEMA_EPOCH) < published_drop)
-                break;
-            __wt_atomic_store_uint64(drop_epoch, 0);
-        }
+    case TABLE_NONE:
         /* A legacy create is complete immediately; epoch mode publishes it in a later event. */
         ev.type = EVENT_CREATE;
         *slot_state = state->cfg->epoch_less ? TABLE_PUBLISHED : TABLE_CREATED;
         if (state->cfg->unique_tables)
             ++state->workers[t].table[slot].gen;
         break;
-    }
     case TABLE_CREATED:
         testutil_assert(!state->cfg->epoch_less);
         switch (__wt_random(rnd) % 3) {
@@ -103,12 +94,23 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         break;
     case TABLE_DROPPED:
         testutil_assert(!state->cfg->epoch_less);
-        /* Publish the drop, which frees the slot, or linger in the window. */
+        /* Publish the drop, or linger in the window. */
         if (__wt_random(rnd) % 2 == 0) {
             ev.type = EVENT_PUBLISH_DROP;
+            *slot_state = TABLE_REMOVED;
+        }
+        break;
+    case TABLE_REMOVED: {
+        /* Free the slot once the stable epoch passes the published drop; zero is not applied yet.
+         */
+        const uint64_t published_drop = __wt_atomic_load_uint64(drop_epoch);
+        if (published_drop != 0 &&
+          __wt_atomic_load_uint64(&state->stable_epoch) >= published_drop) {
+            __wt_atomic_store_uint64(drop_epoch, 0);
             *slot_state = TABLE_NONE;
         }
         break;
+    }
     }
     if (ev.type == EVENT_NONE)
         return (false);
@@ -121,9 +123,6 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         ev.key_min = DATA_KEY_MIN;
         ev.key_max = DATA_KEY_MAX;
     }
-    /* The worker assigns the epoch when it applies the publish. */
-    if (ev.type == EVENT_PUBLISH_DROP && !state->cfg->unique_tables)
-        __wt_atomic_store_uint64(drop_epoch, UINT64_MAX);
 
     generator_emit(state, &ev);
     return (true);
@@ -217,9 +216,7 @@ generator_flush_publishes(WORKLOAD_STATE *state)
             testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t,
               slot, state->workers[t].table[slot].gen);
 
-            *slot_state = *slot_state == TABLE_CREATED ? TABLE_PUBLISHED : TABLE_NONE;
-            if (ev.type == EVENT_PUBLISH_DROP && !state->cfg->unique_tables)
-                __wt_atomic_store_uint64(&state->workers[t].table[slot].drop_epoch, UINT64_MAX);
+            *slot_state = *slot_state == TABLE_CREATED ? TABLE_PUBLISHED : TABLE_REMOVED;
             generator_emit(state, &ev);
         }
 }

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -42,6 +42,8 @@ generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
  *     Advance one slot of the given worker thread through the table lifecycle, taking one of its
  *     state's valid moves at random. Reports whether an event was emitted; taking no move is valid,
  *     and lingering widens the window a checkpoint can land in.
+ *
+ * A recreate waits until the stable schema epoch passes the slot's published drop.
  */
 static bool
 generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
@@ -50,18 +52,28 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
     WT_RAND_STATE *rnd = &state->gen_rnd[t];
     const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
     TABLE_STATE *slot_state = &state->workers[t].table[slot].state;
+    uint64_t *drop_epoch = &state->workers[t].table[slot].drop_epoch;
     /* Set when no checkpoint of this phase can cover the insert; such a slot is not droppable. */
     bool *uncovered_insert = &state->workers[t].table[slot].uncovered_insert;
 
     SCHEMA_EVENT ev = {0}; /* EVENT_NONE until a move is taken */
     switch (*slot_state) {
-    case TABLE_NONE:
+    case TABLE_NONE: {
+        /* Linger: recreating before the stable epoch passes the published drop is a violation. */
+        const uint64_t published_drop = __wt_atomic_load_uint64(drop_epoch);
+        if (published_drop != 0) {
+            if (published_drop == UINT64_MAX ||
+              query_ts(state->conn, TS_STABLE_SCHEMA_EPOCH) < published_drop)
+                break;
+            __wt_atomic_store_uint64(drop_epoch, 0);
+        }
         /* A legacy create is complete immediately; epoch mode publishes it in a later event. */
         ev.type = EVENT_CREATE;
         *slot_state = state->cfg->epoch_less ? TABLE_PUBLISHED : TABLE_CREATED;
         if (state->cfg->unique_tables)
             ++state->workers[t].table[slot].gen;
         break;
+    }
     case TABLE_CREATED:
         testutil_assert(!state->cfg->epoch_less);
         switch (__wt_random(rnd) % 3) {
@@ -108,6 +120,9 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         ev.key_min = DATA_KEY_MIN;
         ev.key_max = DATA_KEY_MAX;
     }
+    /* The worker assigns the epoch when it applies the publish. */
+    if (ev.type == EVENT_PUBLISH_DROP && !state->cfg->unique_tables)
+        __wt_atomic_store_uint64(drop_epoch, UINT64_MAX);
 
     generator_emit(state, &ev);
     return (true);
@@ -201,6 +216,8 @@ generator_flush_publishes(WORKLOAD_STATE *state)
               slot, state->workers[t].table[slot].gen);
 
             *slot_state = *slot_state == TABLE_CREATED ? TABLE_PUBLISHED : TABLE_NONE;
+            if (ev.type == EVENT_PUBLISH_DROP && !state->cfg->unique_tables)
+                __wt_atomic_store_uint64(&state->workers[t].table[slot].drop_epoch, UINT64_MAX);
             generator_emit(state, &ev);
         }
 }

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -61,6 +61,18 @@ workload_counter_advance(WORKLOAD_STATE *state, uint64_t v)
 }
 
 /*
+ * workload_set_frontier --
+ *     Set the frontier timestamps on the connection and mirror the stable schema epoch, so the
+ *     generator can free slots whose published drops the epoch has covered.
+ */
+void
+workload_set_frontier(WORKLOAD_STATE *state, uint64_t ts)
+{
+    set_ts(state->cfg, state->conn, TS_FRONTIER, ts);
+    __wt_atomic_store_uint64(&state->stable_epoch, ts);
+}
+
+/*
  * workload_active --
  *     The condition a phase loop runs on: true until the shutdown has reached the caller's stage.
  */
@@ -347,7 +359,7 @@ node_step_up(WORKLOAD_STATE *state, uint64_t final_ts)
 
     /* Restore the timestamps on the new leader's connection. */
     if (final_ts != 0)
-        set_ts(state->cfg, state->conn, TS_FRONTIER, final_ts);
+        workload_set_frontier(state, final_ts);
 }
 
 /*
@@ -437,7 +449,7 @@ node_main(TEST_CONFIG *cfg)
     node_open(state, role->name);
     /* Seed the timestamp sequence; epoch mode also enters the schema epoch world at this value. */
     workload_seed_counter(state, TS_BOOTSTRAP);
-    set_ts(cfg, state->conn, TS_FRONTIER, TS_BOOTSTRAP);
+    workload_set_frontier(state, TS_BOOTSTRAP);
     println("Node %" PRIu32 ": starting as %s", cfg->node_id, role->name);
 
     return (node_run(cfg, state, role));

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -47,7 +47,7 @@ reader_step_down(WORKLOAD_STATE *state, uint64_t ts)
      * switches becomes illegal.
      */
     set_ts(state->cfg, conn, TS_STEPDOWN, ts);
-    set_ts(state->cfg, conn, TS_FRONTIER, ts);
+    workload_set_frontier(state, ts);
 
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -254,6 +254,8 @@ typedef struct {
             TABLE_STATE state;
             /* Advanced by every create under -q, so a slot's table name is never reused. */
             uint32_t gen;
+            /* Published drop's epoch, or UINT64_MAX while its publish is queued; atomic access. */
+            uint64_t drop_epoch;
             /* Inserted data is uncovered yet. Not droppable until a checkpoint. */
             bool uncovered_insert;
         } table[MAX_POOL_SIZE];

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -131,6 +131,7 @@ typedef enum {
 typedef struct {
     EVENT_TYPE type;
     uint32_t thread_id;
+    uint32_t slot;
     /*-
      * The completion timestamp for this event:
      *   - a publish epoch,

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -154,7 +154,8 @@ typedef enum {
     TABLE_NONE = 0,  /* slot free: no local table, nothing unpublished */
     TABLE_CREATED,   /* created; the publish may be delayed */
     TABLE_PUBLISHED, /* create published; may take data, and is droppable */
-    TABLE_DROPPED    /* dropped; the publish may be delayed */
+    TABLE_DROPPED,   /* dropped; the publish may be delayed */
+    TABLE_REMOVED    /* drop published; the slot frees once the stable epoch covers it */
 } TABLE_STATE;
 
 /* Test-wide configuration, built from the command line by every role independently. */
@@ -238,7 +239,8 @@ typedef struct {
 
     /* Single monotonic value for schema operations and commit timestamps. */
     uint64_t current_ts;
-    uint64_t frontier_ts; /* every timestamp at or below it is applied; atomic access */
+    uint64_t frontier_ts;  /* every timestamp at or below it is applied; atomic access */
+    uint64_t stable_epoch; /* the stable schema epoch this node last set; atomic access */
     /* Circular buffer for completed timestamps of all workers; atomic access. */
     uint8_t completed_ts[FRONTIER_WINDOW];
     uint64_t emitted;      /* generator: how many events have been emitted */
@@ -255,7 +257,7 @@ typedef struct {
             TABLE_STATE state;
             /* Advanced by every create under -q, so a slot's table name is never reused. */
             uint32_t gen;
-            /* Published drop's epoch, or UINT64_MAX while its publish is queued; atomic access. */
+            /* Published drop's epoch once its publish applies, else 0; atomic access. */
             uint64_t drop_epoch;
             /* Inserted data is uncovered yet. Not droppable until a checkpoint. */
             bool uncovered_insert;
@@ -310,6 +312,7 @@ bool node_switch_request_consume(void);
 bool workload_active(WORKLOAD_STATE *state, uint32_t stage);
 bool node_stage_stopped(WORKLOAD_STATE *state, uint32_t stage);
 void workload_counter_advance(WORKLOAD_STATE *state, uint64_t v);
+void workload_set_frontier(WORKLOAD_STATE *state, uint64_t ts);
 
 /* evq.c: the per-worker event queues - the reader produces, its worker consumes. */
 void evq_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev);

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -305,7 +305,7 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, SCHEM
         testutil_assert(!state->cfg->epoch_less);
         ev->event_ts = worker_ts(state, ev);
         schema_op_publish(ctx->session, ev->uri, ev->event_ts);
-        if (state->generates && ev->type == EVENT_PUBLISH_DROP && !state->cfg->unique_tables) {
+        if (state->generates && ev->type == EVENT_PUBLISH_DROP) {
             testutil_assert(ev->slot < state->cfg->pool_size);
             __wt_atomic_store_uint64(
               &state->workers[thread_index].table[ev->slot].drop_epoch, ev->event_ts);

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -305,6 +305,11 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, SCHEM
         testutil_assert(!state->cfg->epoch_less);
         ev->event_ts = worker_ts(state, ev);
         schema_op_publish(ctx->session, ev->uri, ev->event_ts);
+        if (state->generates && ev->type == EVENT_PUBLISH_DROP && !state->cfg->unique_tables) {
+            testutil_assert(ev->slot < state->cfg->pool_size);
+            __wt_atomic_store_uint64(
+              &state->workers[thread_index].table[ev->slot].drop_epoch, ev->event_ts);
+        }
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
         record_event_line(ctx->record_fp, ev);

--- a/test/suite/test_layered_schema11.py
+++ b/test/suite/test_layered_schema11.py
@@ -151,10 +151,9 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
     def test_recreate_after_drop_then_create(self):
         """
-        When the queue contains REMOVE followed by CREATE for the same table, a checkpoint
-        below the CREATE's epoch must not resurrect the dropped incarnation's stable
-        constituent, and a checkpoint covering the CREATE must pick the table up (not
-        blocked by the REMOVE).
+        A checkpoint below a published drop is legal while no recreate is queued; once a
+        checkpoint covers the drop, the table leaves shared metadata, and a later recreate is
+        picked up with its own stable constituent.
         """
         # Step 1: Leader creates uri and checkpoints at epoch 10.
         self.set_stable_epoch(1)
@@ -167,20 +166,18 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         conn_follow, session_follow = self.open_follower_epoch()
         self.assertTrue(self.uri_stable_exists(conn_follow, self.uri))
 
-        # Step 3: Both follower and leader drop uri at epoch 25 (REMOVE(25) queued), then
-        # re-create it at epoch 40 (CREATE(40) queued). The latest queue entry for uri is now
-        # CREATE.
+        # Step 3: Both nodes drop uri at epoch 25; the follower also re-creates it at epoch 40.
+        # The leader publishes the drop but cannot re-create yet: a checkpoint below the
+        # published drop with the recreate queued behind it panics.
         session_follow.drop(self.uri)
         self.publish(self.uri, 25, session_follow)
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 40, session_follow)
         self.session.drop(self.uri)
         self.publish(self.uri, 25)
-        self.session.create(self.uri, self.table_config)
-        self.publish(self.uri, 40)
 
-        # Step 4: Leader checkpoints at epoch 10; both ops deferred. Shared metadata still has
-        # the original entry from step 1.
+        # Step 4: Leader checkpoints at epoch 10; the published REMOVE(25) defers - legal with
+        # no recreate queued. Shared metadata still has the original entry from step 1.
         self.set_stable_epoch(10)
         self.leader_checkpoint(2)
 
@@ -190,10 +187,18 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.disagg_advance_checkpoint(conn_follow)
         self.assertFalse(self.uri_stable_exists(conn_follow, self.uri))
 
-        # Step 6: A checkpoint covering CREATE(40) supplies the recreated table's own
-        # constituent; the pending REMOVE(25) does not block it.
-        self.set_stable_epoch(40)
+        # Step 6: A checkpoint covering the drop applies the REMOVE(25); the first generation
+        # leaves shared metadata.
+        self.set_stable_epoch(25)
         self.leader_checkpoint(3)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Step 7: With the drop drained, the leader re-creates the table at epoch 40; a
+        # checkpoint covering the CREATE supplies the recreated table's own constituent.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 40)
+        self.set_stable_epoch(40)
+        self.leader_checkpoint(4)
         self.disagg_advance_checkpoint(conn_follow)
         self.assertTrue(self.uri_stable_exists(conn_follow, self.uri))
 

--- a/test/suite/test_layered_schema16.py
+++ b/test/suite/test_layered_schema16.py
@@ -62,8 +62,8 @@ class test_layered_schema16(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
             ',oldest_timestamp=' + self.timestamp_str(1))
         self.set_stable_epoch(1)
 
-        # Create the table and make it and a row durable, so the checkpoint under test refers
-        # to a generation whose data the drop then destroys.
+        # Checkpoint the original table and its row so later checkpoints can refer to this
+        # generation.
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 2)
         cursor = self.session.open_cursor(self.uri)
@@ -111,7 +111,8 @@ class test_layered_schema16(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
             ',oldest_timestamp=' + self.timestamp_str(1))
         self.set_stable_epoch(1)
 
-        # Create the table and make it and a row durable.
+        # Checkpoint the original table and its row so later checkpoints can refer to this
+        # generation.
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 2)
         cursor = self.session.open_cursor(self.uri)

--- a/test/suite/test_layered_schema16.py
+++ b/test/suite/test_layered_schema16.py
@@ -32,10 +32,11 @@
 
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema16(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+class test_layered_schema16(wttest.WiredTigerTestCase, suite_subprocess, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
@@ -53,6 +54,121 @@ class test_layered_schema16(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         cursor[1] = 'value'
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
         cursor.close()
+
+    def subprocess_checkpoint_below_published_recreated_drop_panics(self):
+        """Subprocess body: a checkpoint below a published drop with a recreate pending panics."""
+        self.conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+
+        # Create the table and make it and a row durable, so the checkpoint under test refers
+        # to a generation whose data the drop then destroys.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 2)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'value'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+        cursor.close()
+        self.set_stable_epoch(2)
+        self.leader_checkpoint(2)
+
+        # Drop the table and recreate it, publishing both above the next checkpoint's epoch.
+        self.session.drop(self.uri)
+        self.publish(self.uri, 4)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+
+        # The checkpoint at epoch 3 refers to the dropped generation while the recreate is
+        # queued behind the drop: an API violation.
+        self.set_stable_epoch(3)
+        self.leader_checkpoint(3)  # Expected to panic.
+
+    def test_checkpoint_below_published_recreated_drop_panics(self):
+        """
+        A checkpoint whose schema epoch is below a table's published drop cannot be satisfied once
+        the table has been recreated: the epoch refers to a generation whose data the drop
+        destroyed while a new generation exists. WiredTiger panics rather than emit a checkpoint
+        with missing durable rows. A checkpoint below a published drop with no recreate is legal.
+        """
+        # Set timestamps so the fixture can close the parent connection cleanly; the real test
+        # runs in a subprocess so that the panic/abort does not kill the test runner.
+        self.conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.run_panic_subprocess('checkpoint_below_published_recreated_drop_panics',
+            'checkpoint schema epoch refers to a dropped and recreated table')
+
+    def test_recreate_redropped_before_checkpoint_is_legal(self):
+        """
+        A recreated generation dropped again before the checkpoint runs leaves nothing for the
+        checkpoint to resolve: a checkpoint below the original published drop carries the first
+        generation forward, exactly as a plain drop does.
+        """
+        self.conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+
+        # Create the table and make it and a row durable.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 2)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'value'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+        cursor.close()
+        self.set_stable_epoch(2)
+        self.leader_checkpoint(2)
+
+        # Drop, re-create, and drop again, all published above the next checkpoint's epoch.
+        self.session.drop(self.uri)
+        self.publish(self.uri, 4)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+        self.session.drop(self.uri)
+        self.publish(self.uri, 6)
+
+        # The checkpoint at epoch 3 still refers to the first generation: legal, no panic.
+        self.set_stable_epoch(3)
+        self.leader_checkpoint(3)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Once the epoch covers all three operations, the table leaves shared metadata.
+        self.set_stable_epoch(6)
+        self.leader_checkpoint(6)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+    def test_create_drop_recreate_above_checkpoint_epoch(self):
+        """
+        A table created, dropped and recreated entirely above the checkpoint's schema epoch never
+        existed at that epoch: all three entries defer without a violation, and the recreated
+        table appears once the epoch covers it.
+        """
+        self.conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+
+        # Create, drop, re-create and publish all three, all above the next checkpoint's epoch.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+        self.session.drop(self.uri)
+        self.publish(self.uri, 6)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 7)
+
+        # The checkpoint at epoch 3 predates the table entirely: no violation.
+        self.set_stable_epoch(3)
+        self.leader_checkpoint(3)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Once the epoch covers all three operations they apply in order: the create/drop pair
+        # cancels and the recreated table appears.
+        self.set_stable_epoch(7)
+        self.leader_checkpoint(7)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
 
     def test_recreate_above_stable_epoch_not_resurrected(self):
         """

--- a/test/suite/test_layered_schema28.py
+++ b/test/suite/test_layered_schema28.py
@@ -83,25 +83,17 @@ class test_layered_schema28(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin, s
         self.set_stable_epoch(10, conn_follow)
         self.assertEqual(self.stable_id(conn_follow, self.uri), first_id)
 
-        # Both nodes drop and recreate the table; the publishes sit above the stable epoch.
-        # The follower's recreate has no stable constituent, only the queued create intent.
+        # Both nodes drop the table; the publishes sit above the stable epoch. The leader
+        # cannot recreate yet: a checkpoint below its published drop with the recreate queued
+        # behind it panics.
         self.session.drop(self.uri)
         self.publish(self.uri, 20)
-        self.session.create(self.uri, self.table_config)
-        self.publish(self.uri, 30)
 
         session_follow.drop(self.uri)
         self.publish(self.uri, 20, session_follow)
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 30, session_follow)
         self.assertFalse(self.uri_stable_exists(conn_follow, self.uri))
-
-        # A row the recreated table carries into the next era.
-        cursor = self.session.open_cursor(self.uri)
-        self.session.begin_transaction()
-        cursor[1] = 'second'
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
-        cursor.close()
 
         # A checkpoint cut below the REMOVE's epoch: the shared metadata still carries the
         # first incarnation, while the follower's local state is already the second.
@@ -111,6 +103,18 @@ class test_layered_schema28(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin, s
 
         # The stale pickup must not resurrect the first incarnation's stable constituent.
         self.assertFalse(self.uri_stable_exists(conn_follow, self.uri))
+
+        # The leader recreates only now: the next checkpoint covers the drop, so no checkpoint
+        # below the drop's epoch ever meets the recreate queued behind it.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 30)
+
+        # A row the recreated table carries into the next era.
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'second'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor.close()
 
         # A checkpoint covering the recreate supplies the right constituent.
         self.set_stable_epoch(30)


### PR DESCRIPTION
A checkpoint below a table's published drop is legal on its own: the drop's data was already checkpointed, so this checkpoint carries the same entries. But if the table was recreated, the epoch refers to a generation whose data the drop destroyed while a new one can contribute to the checkpoint, and satisfying it would emit missing durable rows. Panic instead.

Update the tests that exercised the now-fatal sequence; the schema-abort generator no longer recreates a slot before a completed checkpoint covers its published drop.