### PR TITLE
WT-18467 Fix broken printf format string in testutil_timeout_wait

### DIFF
--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -443,7 +443,7 @@ testutil_timeout_wait(uint32_t timeout_seconds, pid_t pid)
     }
     testutil_assert_errno(kill(pid, SIGKILL) == 0);
     testutil_assert_errno(waitpid(pid, &status, 0) != -1);
-    testutil_die(EINVAL, "child process %d killed, timed out after " PRIu32 " seconds\n", (int)pid,
+    testutil_die(EINVAL, "child process %d killed, timed out after %" PRIu32 " seconds\n", (int)pid,
       timeout_seconds);
 }
 


### PR DESCRIPTION
The format string in `testutil_timeout_wait()` was missing the `%` before `PRIu32`, so the literal text `PRIu32` was printed instead of the timeout value and the `timeout_seconds` argument was silently ignored.

Jira: https://jira.mongodb.org/browse/WT-18467