### PR TITLE
WT-18395 Repair triggers verify with fix_btree_size

### DIFF
--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -193,6 +193,7 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
                 continue;
             /*
              * The shared metadata and history store files are always open and cannot be verified.
+             * FIXME-WT-18548: Investigate ways to fix HS btree size issue.
              */
             if (strcmp(key, WT_DISAGG_METADATA_URI) == 0 || strcmp(key, WT_HS_URI_SHARED) == 0)
                 continue;

--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -156,6 +156,18 @@ err:
 }
 
 /*
+ * __verify_fix_btree_size_one --
+ *     Verify a single URI with fix_btree_size=true and append a line to the report.
+ */
+static int
+__verify_fix_btree_size_one(WT_SESSION_IMPL *session, WT_ITEM *report, const char *uri)
+{
+    WT_RET(__wt_buf_catfmt(session, report, "fix_btree_size: verifying %s\n", uri));
+    WT_RET(session->iface.verify(&session->iface, uri, "fix_btree_size=true"));
+    return (0);
+}
+
+/*
  * __repair_fix_btree_size --
  *     Run verify with fix_btree_size=true on the given URI (or all stable files if NULL), then
  *     checkpoint to persist the corrected metadata and recompute the database size.
@@ -169,10 +181,9 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
 
     cursor = NULL;
 
-    if (uri != NULL) {
-        WT_ERR(__wt_buf_catfmt(session, report, "fix_btree_size: verifying %s\n", uri));
-        WT_ERR(session->iface.verify(&session->iface, uri, "fix_btree_size=true"));
-    } else {
+    if (uri != NULL)
+        WT_ERR(__verify_fix_btree_size_one(session, report, uri));
+    else {
         /* Walk the metadata and verify every stable file. */
         WT_ERR(__wt_metadata_cursor(session, &cursor));
         while ((ret = cursor->next(cursor)) == 0) {
@@ -184,12 +195,10 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
              */
             if (strcmp(key, WT_DISAGG_METADATA_URI) == 0 || strcmp(key, WT_HS_URI_SHARED) == 0)
                 continue;
-            WT_ERR(__wt_buf_catfmt(session, report, "fix_btree_size: verifying %s\n", key));
-            WT_ERR(session->iface.verify(&session->iface, key, "fix_btree_size=true"));
+            WT_ERR(__verify_fix_btree_size_one(session, report, key));
         }
         WT_ERR_NOTFOUND_OK(ret, false);
         WT_TRET(__wt_metadata_cursor_release(session, &cursor));
-        cursor = NULL;
     }
 
     /* Checkpoint to persist the corrected metadata and recompute the database size. */

--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -179,6 +179,10 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
             WT_ERR(cursor->get_key(cursor, &key));
             if (!WT_PREFIX_MATCH(key, "file:") || !WT_SUFFIX_MATCH(key, ".wt_stable"))
                 continue;
+            /* The shared metadata and history store files are always open and cannot be verified.
+             */
+            if (strcmp(key, WT_DISAGG_METADATA_URI) == 0 || strcmp(key, WT_HS_URI_SHARED) == 0)
+                continue;
             WT_ERR(__wt_buf_catfmt(session, report, "fix_btree_size: verifying %s\n", key));
             WT_ERR(session->iface.verify(&session->iface, key, "fix_btree_size=true"));
         }
@@ -188,8 +192,8 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
     }
 
     /* Checkpoint to persist the corrected metadata and recompute the database size. */
-    WT_ERR(__wt_buf_catfmt(
-      session, report, "fix_btree_size: checkpointing to persist corrections\n"));
+    WT_ERR(
+      __wt_buf_catfmt(session, report, "fix_btree_size: checkpointing to persist corrections\n"));
     WT_ERR(session->iface.checkpoint(&session->iface, "debug=(database_size_fix=true)"));
 
 err:

--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -157,7 +157,8 @@ err:
 
 /*
  * __verify_fix_btree_size_one --
- *     Verify a single URI with fix_btree_size=true and append a line to the report.
+ *     Append verify info to the report and run the verify command with fix_btree_size=true on given
+ *     URI.
  */
 static int
 __verify_fix_btree_size_one(WT_SESSION_IMPL *session, WT_ITEM *report, const char *uri)
@@ -170,7 +171,7 @@ __verify_fix_btree_size_one(WT_SESSION_IMPL *session, WT_ITEM *report, const cha
 /*
  * __repair_fix_btree_size --
  *     Run verify with fix_btree_size=true on the given URI (or all stable files if NULL), then
- *     checkpoint to persist the corrected metadata and recompute the database size.
+ *     checkpoint to persist the corrected metadata.
  */
 static int
 __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *uri)
@@ -201,10 +202,10 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
         WT_TRET(__wt_metadata_cursor_release(session, &cursor));
     }
 
-    /* Checkpoint to persist the corrected metadata and recompute the database size. */
+    /* Checkpoint to persist the corrected metadata. */
     WT_ERR(
       __wt_buf_catfmt(session, report, "fix_btree_size: checkpointing to persist corrections\n"));
-    WT_ERR(session->iface.checkpoint(&session->iface, "debug=(database_size_fix=true)"));
+    WT_ERR(session->iface.checkpoint(&session->iface, NULL));
 
 err:
     if (cursor != NULL)

--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -15,6 +15,7 @@ struct __wt_repair_config {
 #define WT_REPAIR_COMMAND_NONE 0
 #define WT_REPAIR_COMMAND_FETCH_DATABASE_SIZE 1
 #define WT_REPAIR_COMMAND_FETCH_METADATA 2
+#define WT_REPAIR_COMMAND_FIX_BTREE_SIZE 3
     int command;
 
     struct {
@@ -22,6 +23,11 @@ struct __wt_repair_config {
          */
         bool local;
     } fetch_database_size;
+
+    struct {
+        /* Target URI for the command, or NULL for all stable files. */
+        const char *uri;
+    } fix_btree_size;
 
     struct {
         /* Fetch metadata from the local cursor, not the shared page-server checkpoint. */
@@ -39,6 +45,7 @@ static int __repair_config_set_command(
 
 static int __repair_fetch_database_size(WT_SESSION_IMPL *, WT_ITEM *, bool);
 static int __repair_fetch_metadata(WT_SESSION_IMPL *, WT_ITEM *, const char *, const char *, bool);
+static int __repair_fix_btree_size(WT_SESSION_IMPL *, WT_ITEM *, const char *);
 
 /*
  * WT_ERR_REPORT --
@@ -149,6 +156,49 @@ err:
 }
 
 /*
+ * __repair_fix_btree_size --
+ *     Run verify with fix_btree_size=true on the given URI (or all stable files if NULL), then
+ *     checkpoint to persist the corrected metadata and recompute the database size.
+ */
+static int
+__repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *uri)
+{
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    const char *key;
+
+    cursor = NULL;
+
+    if (uri != NULL) {
+        WT_ERR(__wt_buf_catfmt(session, report, "fix_btree_size: verifying %s\n", uri));
+        WT_ERR(session->iface.verify(&session->iface, uri, "fix_btree_size=true"));
+    } else {
+        /* Walk the metadata and verify every stable file. */
+        WT_ERR(__wt_metadata_cursor(session, &cursor));
+        while ((ret = cursor->next(cursor)) == 0) {
+            WT_ERR(cursor->get_key(cursor, &key));
+            if (!WT_PREFIX_MATCH(key, "file:") || !WT_SUFFIX_MATCH(key, ".wt_stable"))
+                continue;
+            WT_ERR(__wt_buf_catfmt(session, report, "fix_btree_size: verifying %s\n", key));
+            WT_ERR(session->iface.verify(&session->iface, key, "fix_btree_size=true"));
+        }
+        WT_ERR_NOTFOUND_OK(ret, false);
+        WT_TRET(__wt_metadata_cursor_release(session, &cursor));
+        cursor = NULL;
+    }
+
+    /* Checkpoint to persist the corrected metadata and recompute the database size. */
+    WT_ERR(__wt_buf_catfmt(
+      session, report, "fix_btree_size: checkpointing to persist corrections\n"));
+    WT_ERR(session->iface.checkpoint(&session->iface, "debug=(database_size_fix=true)"));
+
+err:
+    if (cursor != NULL)
+        WT_TRET(__wt_metadata_cursor_release(session, &cursor));
+    return (ret);
+}
+
+/*
  * __repair_config_set_command --
  *     Set the command in the repair_config based on the parsed config item.
  */
@@ -196,6 +246,12 @@ __repair_config_set_command(WT_SESSION_IMPL *session, WT_ITEM *report, WT_CONFIG
             WT_ERR(__wt_strndup(session, item.str, item.len, &repair_config->fetch_metadata.key));
 
         require_disagg = !repair_config->fetch_metadata.local;
+    } else if (repair_config->command == WT_REPAIR_COMMAND_FIX_BTREE_SIZE) {
+        WT_ERR_NOTFOUND_OK(__wt_config_subgets(session, config_item, "uri", &item), true);
+        if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND) && item.len != 0)
+            WT_ERR(__wt_strndup(session, item.str, item.len, &repair_config->fix_btree_size.uri));
+
+        require_disagg = true;
     }
 
     if (require_disagg && !__wt_disagg_has_picked_up_checkpoint(session))
@@ -242,6 +298,11 @@ __repair_config_decode(
     if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND))
         WT_ERR(__repair_config_set_command(
           session, report, &item, repair_config, WT_REPAIR_COMMAND_FETCH_METADATA));
+
+    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, config, "fix_btree_size", &item), true);
+    if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND))
+        WT_ERR(__repair_config_set_command(
+          session, report, &item, repair_config, WT_REPAIR_COMMAND_FIX_BTREE_SIZE));
 
     if (repair_config->command == WT_REPAIR_COMMAND_NONE)
         WT_ERR_REPORT(session, EINVAL, "No command found in the config");
@@ -300,6 +361,9 @@ wiredtiger_repair(WT_CONNECTION *connection, const char *config)
         WT_ERR(__repair_fetch_metadata(session, report, repair_config.fetch_metadata.uri,
           repair_config.fetch_metadata.key, repair_config.fetch_metadata.local));
         break;
+    case WT_REPAIR_COMMAND_FIX_BTREE_SIZE:
+        WT_ERR(__repair_fix_btree_size(session, report, repair_config.fix_btree_size.uri));
+        break;
     default:
         WT_ERR(__wt_illegal_value(session, repair_config.command));
     }
@@ -311,6 +375,7 @@ err:
 
     __wt_free(default_session, repair_config.fetch_metadata.uri);
     __wt_free(default_session, repair_config.fetch_metadata.key);
+    __wt_free(default_session, repair_config.fix_btree_size.uri);
 
     if (session != NULL)
         WT_IGNORE_RET(((WT_SESSION *)session)->close((WT_SESSION *)session, NULL));

--- a/src/conn/api_repair.c
+++ b/src/conn/api_repair.c
@@ -179,7 +179,8 @@ __repair_fix_btree_size(WT_SESSION_IMPL *session, WT_ITEM *report, const char *u
             WT_ERR(cursor->get_key(cursor, &key));
             if (!WT_PREFIX_MATCH(key, "file:") || !WT_SUFFIX_MATCH(key, ".wt_stable"))
                 continue;
-            /* The shared metadata and history store files are always open and cannot be verified.
+            /*
+             * The shared metadata and history store files are always open and cannot be verified.
              */
             if (strcmp(key, WT_DISAGG_METADATA_URI) == 0 || strcmp(key, WT_HS_URI_SHARED) == 0)
                 continue;

--- a/test/suite/test_verify_btree_size.py
+++ b/test/suite/test_verify_btree_size.py
@@ -49,37 +49,39 @@ class test_verify_btree_size(wttest.WiredTigerTestCase):
 
     nentries = 5000
 
-    def populate(self):
-        cursor = self.session.open_cursor(self.uri, None)
+    # Printed to stdout when verify with fix_btree_size corrects a size.
+    correcting_pattern = r'WT_VERB_VERIFY.*size mismatch detected.*correcting'
+
+    def populate(self, uri=None):
+        cursor = self.session.open_cursor(uri or self.uri, None)
         for i in range(self.nentries):
             cursor[str(i)] = str(i) * 100
         cursor.close()
         self.session.checkpoint()
 
-    def get_ckpt_size(self):
+    def get_ckpt_size(self, stable_uri=None):
         # Return the size= value from the stable file's most recent checkpoint metadata.
+        stable_uri = stable_uri or self.stable_uri
         cursor = self.session.open_cursor('metadata:', None)
-        cursor.set_key(self.stable_uri)
+        cursor.set_key(stable_uri)
         self.assertEqual(cursor.search(), 0)
         value = cursor.get_value()
         cursor.close()
         sizes = re.findall(r',size=(\d+),', value)
-        self.assertGreater(len(sizes), 0, f"no checkpoint size in metadata for {self.stable_uri}")
+        self.assertGreater(len(sizes), 0, f"no checkpoint size in metadata for {stable_uri}")
         return int(sizes[0])
 
-    def set_ckpt_size(self, new_size):
+    def set_ckpt_size(self, new_size, stable_uri=None):
         # Overwrite the size= value in the stable file's checkpoint metadata.
+        stable_uri = stable_uri or self.stable_uri
         cursor = self.session.open_cursor('metadata:', None, 'readonly=0')
-        cursor.set_key(self.stable_uri)
+        cursor.set_key(stable_uri)
         self.assertEqual(cursor.search(), 0)
         value = cursor.get_value()
-        cursor.close()
 
         new_value = re.sub(r',size=\d+,', f',size={new_size},', value, count=1)
         self.assertNotEqual(new_value, value, "metadata had no size= field to replace")
 
-        cursor = self.session.open_cursor('metadata:', None, 'readonly=0')
-        cursor.set_key(self.stable_uri)
         cursor.set_value(new_value)
         cursor.update()
         cursor.close()
@@ -113,8 +115,8 @@ class test_verify_btree_size(wttest.WiredTigerTestCase):
             "verify without fix_btree_size must not correct the metadata")
 
         # Verify with fix_btree_size on corrects the metadata size.
-        str_pattern = r'WT_VERB_VERIFY.*size mismatch detected.*correcting'
-        with self.customStdoutPattern(lambda output: self.assertRegex(output, str_pattern)):
+        with self.customStdoutPattern(
+                lambda output: self.assertRegex(output, self.correcting_pattern)):
             self.verifyUntilSuccess(self.session, self.uri, config='strict=true,fix_btree_size=true')
         corrected_size = self.get_ckpt_size()
         self.assertEqual(corrected_size, real_size,
@@ -126,9 +128,56 @@ class test_verify_btree_size(wttest.WiredTigerTestCase):
             self.conn, f'fetch_metadata=(local=true,uri="{self.stable_uri}")')
         sizes = re.findall(r',size=(\d+),', meta)
         self.assertGreater(len(sizes), 0, f"no size in fetch_metadata output: {meta}")
-        # The last size= value is the most recent checkpoint's size.
+        # The first size= value is the checkpoint size, consistent with get_ckpt_size.
         self.assertEqual(int(sizes[0]), corrected_size,
             f"fetch_metadata size {sizes[0]} != corrected size {corrected_size}")
+
+    def test_fix_btree_size_via_repair(self):
+        # The wiredtiger_repair fix_btree_size command runs the same verify-and-correct flow,
+        # then checkpoints to persist the corrected metadata.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.populate()
+
+        real_size = self.get_ckpt_size()
+        self.set_ckpt_size(1)
+
+        with self.customStdoutPattern(
+                lambda output: self.assertRegex(output, self.correcting_pattern)):
+            report = wiredtiger.wiredtiger_repair(
+                self.conn, f'fix_btree_size=(uri="{self.stable_uri}")')
+        self.assertIn(f'fix_btree_size: verifying {self.stable_uri}', report)
+        self.assertIn('checkpointing to persist corrections', report)
+        self.assertNotIn('Failed', report)
+        self.assertEqual(self.get_ckpt_size(), real_size,
+            "repair fix_btree_size should restore the size derived from the tree")
+
+    def test_fix_btree_size_no_uri_all_files(self):
+        # With no uri, repair must walk the metadata and verify every stable file, not just
+        # the first one. Create several tables, corrupt each checkpoint size differently, and
+        # confirm all of them are verified and corrected.
+        ntables = 3
+        uris = [f'layered:{self.uri_base}_{i}' for i in range(ntables)]
+        stable_uris = [f'file:{self.uri_base}_{i}.wt_stable' for i in range(ntables)]
+
+        real_sizes = []
+        for uri, stable_uri in zip(uris, stable_uris):
+            self.session.create(uri, 'key_format=S,value_format=S')
+            self.populate(uri)
+            real_sizes.append(self.get_ckpt_size(stable_uri))
+
+        # Corrupt each table with a distinct bogus size.
+        for i, stable_uri in enumerate(stable_uris):
+            self.set_ckpt_size(1 + i, stable_uri)
+
+        with self.customStdoutPattern(
+                lambda output: self.assertRegex(output, self.correcting_pattern)):
+            report = wiredtiger.wiredtiger_repair(self.conn, 'fix_btree_size=()')
+
+        # Every stable file must appear in the report and get its size corrected.
+        for i, stable_uri in enumerate(stable_uris):
+            self.assertIn(f'fix_btree_size: verifying {stable_uri}', report)
+            self.assertEqual(self.get_ckpt_size(stable_uri), real_sizes[i],
+                f"no-uri repair should correct {stable_uri}")
 
     def test_fix_btree_size_requires_leader(self):
         # fix_btree_size is rejected on a follower. The follower skips verify until it has picked


### PR DESCRIPTION
Add repair function to call verify with `fix_btree_size=true` in order to fix btree size issue. It takes in an uri, if it's not given we walk the metadata, verify and fix all stable files. 
