### PR TITLE
WT-18474 Skip disaggregated storage scenarios in the Python suite on 9.0

### DIFF
--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -29,7 +29,7 @@
 
 import re
 import wiredtiger
-import functools, json, os, shutil, subprocess, wttest
+import functools, json, os, shutil, subprocess, unittest, wttest
 from run import wt_builddir
 
 # These routines help run the various page log sources used by disaggregated storage.
@@ -121,6 +121,13 @@ def disagg_test_class(cls):
 
     return disagg_test_case_class
 
+# Disaggregated storage is not a supported feature on this release branch, so its scenarios are
+# not run here. The dedicated disagg Evergreen tasks are already gone, but the layered and disagg
+# Python tests are still picked up by the ordinary unit-test task, which runs the whole suite.
+# Only the disaggregated scenarios are skipped: tests that also generate a non_disagg scenario
+# keep that coverage.
+DISAGG_SKIP_REASON = 'disaggregated storage is not supported on this release branch'
+
 # This mixin class provides disaggregated storage configuration methods and a few utility functions.
 class DisaggConfigMixin:
 
@@ -190,6 +197,11 @@ class DisaggConfigMixin:
 
     # Load disaggregated storage extension.
     def disagg_conn_extensions(self, extlist):
+        # Every disaggregated scenario loads the page log extension here, which makes this the one
+        # place that has to opt out of disaggregated storage on this branch.
+        if self.is_disagg_scenario():
+            raise unittest.SkipTest(DISAGG_SKIP_REASON)
+
         # Handle non_disaggregated storage scenarios.
         if not self.is_disagg_scenario():
             return ''


### PR DESCRIPTION
[WT-18474](https://jira.mongodb.org/browse/WT-18474)

### Problem

WT-18193 removed the disagg-specific Evergreen tasks from the 9.0 project (`.unit_test_disagg`, `.stress-test-disagg`, `unit-test-hook-disagg-*`, `model-test-long-disagg*`), but the ordinary `unit-test` task runs the entire Python suite with no `unit_test_ignore` list. The 179 `test_layered_*.py` / `test_disagg_*.py` files are still on the branch, so they keep running on every 9.0 variant.

[WT-18464](https://jira.mongodb.org/browse/WT-18464) is a consequence: `test_layered_stepup12` failed with `subprocess_race(palite.step_down.create)` -> `file:test_layered_stepup12_new.wt_stable stable table verification failed: No such file or directory`, a create racing a step-down. Develop has three commits on that path that were never backported to 9.0 (WT-17880, WT-17894, WT-18132).

Disaggregated storage is not a supported feature on 9.0, so the fix is to stop running its scenarios rather than backport a schema-lock ordering change into a release branch.

### Change

Skip disaggregated scenarios in `DisaggConfigMixin.disagg_conn_extensions()`, the single point every disagg scenario passes through to load the page log extension.

Only the disaggregated scenarios are skipped. Tests that also generate a `non_disagg` scenario keep that coverage, which matters for the ~20 dual-mode tests such as `test_repair01`, `test_timestamp26`, `test_cursor_bound01` and `test_cross_checkpoint_caching` that are not disagg tests but use the mixin.

### Verification

Release build with `ENABLE_PYTHON` on this branch:

- `test_layered_stepup12`: all 10 tests skipped, including the `palite.step_down.create` scenario from WT-18464.
- All `test_layered*.py`: 1230 tests, 1229 skipped.
- Mixed run confirms the split is scenario-level rather than class-level: `test_repair01(non_disagg)` and `test_timestamp26` still execute and pass while their disagg siblings skip (88 ran, 32 skipped).
- `dist/s_python` clean.
