### PR TITLE
WT-14995 Accept either TypeError or RuntimeError from SWIG in test_autoclose and test_cursor_compare

### DIFF
--- a/test/suite/test_autoclose.py
+++ b/test/suite/test_autoclose.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import sys, wttest
+import wttest
 
 # test_autoclose
 class test_autoclose(wttest.WiredTigerTestCase):
@@ -36,9 +36,10 @@ class test_autoclose(wttest.WiredTigerTestCase):
     handles are also closed.
     """
     uri = 'table:test_autoclose'
-    # Note: SWIG generates a TypeError instead of a RuntimeError for several cases.
-    # The same error on all platforms would be better.
-    expected_exception = TypeError if sys.platform.startswith('darwin') else RuntimeError
+    # SWIG 4.3 and later raise a TypeError where earlier versions raise a RuntimeError, and the
+    # build hosts do not all carry the same SWIG version. Accept either; the message check below
+    # is what actually pins down the failure.
+    expected_exception = (TypeError, RuntimeError)
 
     def create_table(self):
         self.session.create(self.uri,

--- a/test/suite/test_cursor_compare.py
+++ b/test/suite/test_cursor_compare.py
@@ -26,16 +26,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import sys, wiredtiger, wttest
+import wiredtiger, wttest
 from wtdataset import SimpleDataSet, ComplexDataSet, ComplexLSMDataSet
 from wtscenario import make_scenarios
 
 # Test cursor comparisons.
 class test_cursor_comparison(wttest.WiredTigerTestCase):
     name = 'test_compare'
-    # Note: SWIG generates a TypeError instead of a RuntimeError for several cases.
-    # The same error on all platforms would be better.
-    expected_exception = TypeError if sys.platform.startswith('darwin') else RuntimeError
+    # SWIG 4.3 and later raise a TypeError where earlier versions raise a RuntimeError, and the
+    # build hosts do not all carry the same SWIG version. Accept either; the message check below
+    # is what actually pins down the failure.
+    expected_exception = (TypeError, RuntimeError)
 
     types = [
         ('file', dict(type='file:', lsm=False, dataset=SimpleDataSet)),


### PR DESCRIPTION
`test_autoclose` and `test_cursor_compare` picked the expected exception type by
platform, assuming every macOS host runs SWIG 4.3 or later. The `macos-1100`
builder still ships an older SWIG that raises `RuntimeError`, so all 25 affected
cases fail there. Accept either type; the message pattern check still identifies
the failure.
