### PR TITLE
WT-18472 Enable prefetch for the checkpoint pick-up metadata scan

### DIFF
--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -753,6 +753,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *latest_entry;
     WT_DISAGG_STABLE_BTREE_IDS stable_btree_ids;
+    WT_PREFETCH_SCAN prefetch_scan;
     WT_SHARED_METADATA_OP latest_op;
     WT_TIMER apply_timer;
     wt_timestamp_t latest_epoch;
@@ -764,8 +765,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
     const char *cfg[2], *metadata_checkpoint_name, *metadata_value;
     const char *md_keys[WT_DISAGG_CURSOR_COUNT], *sh_keys[WT_DISAGG_CURSOR_COUNT];
     const char *current;
-    bool md_has[WT_DISAGG_CURSOR_COUNT], sh_has[WT_DISAGG_CURSOR_COUNT];
-    bool prefetch_set, scan_hint_set, strict;
+    bool md_has[WT_DISAGG_CURSOR_COUNT], sh_has[WT_DISAGG_CURSOR_COUNT], strict;
 
     for (i = 0; i < WT_DISAGG_CURSOR_COUNT; i++)
         md_cursors[i] = sh_cursors[i] = NULL;
@@ -783,21 +783,11 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
 
     /*
      * The walk below is a bounded, forward-only scan of the shared metadata, where crossing a page
-     * boundary costs a page log round trip. Declare it, so pre-fetch does not have to infer it: the
-     * scan runs on an internal session, and it interleaves cache-resident local metadata with pages
-     * that must be fetched, so neither of the prefetch heuristics recognizes it.
-     *
-     * The startup pick-up runs before the pre-fetch server threads are created, so test that they
-     * are running rather than that pre-fetch is configured: queueing a page with no server to read
-     * it signals a condition variable that does not exist yet.
+     * boundary costs a page log round trip. Declare it: the scan runs on an internal session, and
+     * it interleaves cache-resident local metadata with pages that must be fetched, so neither of
+     * the prefetch heuristics recognizes it.
      */
-    prefetch_set = scan_hint_set = false;
-    if (__wti_prefetch_server_running(session)) {
-        prefetch_set = !F_ISSET(session, WT_SESSION_PREFETCH_ENABLED);
-        scan_hint_set = !session->pf.scan_hint;
-        F_SET(session, WT_SESSION_PREFETCH_ENABLED);
-        session->pf.scan_hint = true;
-    }
+    __wt_prefetch_scan_begin(session, &prefetch_scan);
 
     __wt_timer_start(session, &apply_timer);
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
@@ -1197,10 +1187,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
 
 done:
 err:
-    if (scan_hint_set)
-        session->pf.scan_hint = false;
-    if (prefetch_set)
-        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
+    __wt_prefetch_scan_end(session, &prefetch_scan);
 
     __wt_free(session, stable_btree_ids.ids);
     __wt_free(session, first_uri);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -770,6 +770,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
     for (i = 0; i < WT_DISAGG_CURSOR_COUNT; i++)
         md_cursors[i] = sh_cursors[i] = NULL;
     md_write_cursor = NULL;
+    WT_CLEAR(prefetch_scan);
     WT_CLEAR(stable_btree_ids);
 
     metadata_checkpoint_name = NULL;

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -786,9 +786,13 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
      * boundary costs a page log round trip. Declare it, so pre-fetch does not have to infer it: the
      * scan runs on an internal session, and it interleaves cache-resident local metadata with pages
      * that must be fetched, so neither of the prefetch heuristics recognizes it.
+     *
+     * The startup pick-up runs before the pre-fetch server threads are created, so test that they
+     * are running rather than that pre-fetch is configured: queueing a page with no server to read
+     * it signals a condition variable that does not exist yet.
      */
     prefetch_set = scan_hint_set = false;
-    if (S2C(session)->prefetch.available) {
+    if (__wti_prefetch_server_running(session)) {
         prefetch_set = !F_ISSET(session, WT_SESSION_PREFETCH_ENABLED);
         scan_hint_set = !session->pf.scan_hint;
         F_SET(session, WT_SESSION_PREFETCH_ENABLED);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -787,7 +787,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
      * it interleaves cache-resident local metadata with pages that must be fetched, so neither of
      * the prefetch heuristics recognizes it.
      */
-    __wt_prefetch_scan_begin(session, &prefetch_scan);
+    __wti_prefetch_scan_begin(session, &prefetch_scan);
 
     __wt_timer_start(session, &apply_timer);
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
@@ -1187,7 +1187,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
 
 done:
 err:
-    __wt_prefetch_scan_end(session, &prefetch_scan);
+    __wti_prefetch_scan_end(session, &prefetch_scan);
 
     __wt_free(session, stable_btree_ids.ids);
     __wt_free(session, first_uri);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -785,7 +785,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
      * The walk below is a bounded, forward-only scan of the shared metadata, where crossing a page
      * boundary costs a page log round trip. Declare it, so pre-fetch does not have to infer it: the
      * scan runs on an internal session, and it interleaves cache-resident local metadata with pages
-     * that must be fetched, so neither of pre-fetch's heuristics recognises it.
+     * that must be fetched, so neither of the prefetch heuristics recognizes it.
      */
     prefetch_set = scan_hint_set = false;
     if (S2C(session)->prefetch.available) {

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -764,7 +764,8 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
     const char *cfg[2], *metadata_checkpoint_name, *metadata_value;
     const char *md_keys[WT_DISAGG_CURSOR_COUNT], *sh_keys[WT_DISAGG_CURSOR_COUNT];
     const char *current;
-    bool md_has[WT_DISAGG_CURSOR_COUNT], sh_has[WT_DISAGG_CURSOR_COUNT], strict;
+    bool md_has[WT_DISAGG_CURSOR_COUNT], sh_has[WT_DISAGG_CURSOR_COUNT];
+    bool prefetch_set, scan_hint_set, strict;
 
     for (i = 0; i < WT_DISAGG_CURSOR_COUNT; i++)
         md_cursors[i] = sh_cursors[i] = NULL;
@@ -779,6 +780,20 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
     strict = F_ISSET(&S2C(session)->disaggregated_storage, WT_DISAGG_STRICT_CHECKPOINT_METADATA);
 
     WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+
+    /*
+     * The walk below is a bounded, forward-only scan of the shared metadata, where crossing a page
+     * boundary costs a page log round trip. Declare it, so pre-fetch does not have to infer it: the
+     * scan runs on an internal session, and it interleaves cache-resident local metadata with pages
+     * that must be fetched, so neither of pre-fetch's heuristics recognises it.
+     */
+    prefetch_set = scan_hint_set = false;
+    if (S2C(session)->prefetch.available) {
+        prefetch_set = !F_ISSET(session, WT_SESSION_PREFETCH_ENABLED);
+        scan_hint_set = !session->pf.scan_hint;
+        F_SET(session, WT_SESSION_PREFETCH_ENABLED);
+        session->pf.scan_hint = true;
+    }
 
     __wt_timer_start(session, &apply_timer);
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
@@ -1178,6 +1193,11 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
 
 done:
 err:
+    if (scan_hint_set)
+        session->pf.scan_hint = false;
+    if (prefetch_set)
+        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
+
     __wt_free(session, stable_btree_ids.ids);
     __wt_free(session, first_uri);
     __wt_free(session, second_uri);

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -47,12 +47,12 @@ __prefetch_server_running(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_prefetch_scan_begin --
+ * __wti_prefetch_scan_begin --
  *     Declare that the session is about to traverse a btree end to end, so pre-fetch does not have
  *     to infer it from the session's recent reads.
  */
 void
-__wt_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
+__wti_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
 {
     scan->prefetch_set = scan->scan_hint_set = false;
 
@@ -66,11 +66,11 @@ __wt_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
 }
 
 /*
- * __wt_prefetch_scan_end --
+ * __wti_prefetch_scan_end --
  *     End a declared scan.
  */
 void
-__wt_prefetch_scan_end(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
+__wti_prefetch_scan_end(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
 {
     if (scan->scan_hint_set)
         session->pf.scan_hint = false;

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -37,11 +37,11 @@ __wti_conn_prefetch_destroy(WT_SESSION_IMPL *session)
 }
 
 /*
- * __prefetch_thread_chk --
- *     Check to decide if the pre-fetch thread should continue running.
+ * __wti_prefetch_server_running --
+ *     Check whether the pre-fetch server threads are running.
  */
-static bool
-__prefetch_thread_chk(WT_SESSION_IMPL *session)
+bool
+__wti_prefetch_server_running(WT_SESSION_IMPL *session)
 {
     return (FLD_ISSET(S2C(session)->server_flags, WT_CONN_SERVER_PREFETCH));
 }
@@ -178,8 +178,8 @@ __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
 
     session_flags = WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL;
     WT_ERR(__wt_thread_group_create(session, &conn->prefetch.threads, "prefetch-server",
-      WT_PREFETCH_THREAD_COUNT, WT_PREFETCH_THREAD_COUNT, session_flags, __prefetch_thread_chk,
-      __prefetch_thread_run, NULL));
+      WT_PREFETCH_THREAD_COUNT, WT_PREFETCH_THREAD_COUNT, session_flags,
+      __wti_prefetch_server_running, __prefetch_thread_run, NULL));
     return (0);
 
 err:

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -37,13 +37,45 @@ __wti_conn_prefetch_destroy(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wti_prefetch_server_running --
+ * __prefetch_server_running --
  *     Check whether the pre-fetch server threads are running.
  */
-bool
-__wti_prefetch_server_running(WT_SESSION_IMPL *session)
+static bool
+__prefetch_server_running(WT_SESSION_IMPL *session)
 {
     return (FLD_ISSET(S2C(session)->server_flags, WT_CONN_SERVER_PREFETCH));
+}
+
+/*
+ * __wt_prefetch_scan_begin --
+ *     Declare that the session is about to traverse a btree end to end, so pre-fetch does not have
+ *     to infer it from the session's recent reads.
+ */
+void
+__wt_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
+{
+    scan->prefetch_set = scan->scan_hint_set = false;
+
+    if (!__prefetch_server_running(session))
+        return;
+
+    scan->prefetch_set = !F_ISSET(session, WT_SESSION_PREFETCH_ENABLED);
+    scan->scan_hint_set = !session->pf.scan_hint;
+    F_SET(session, WT_SESSION_PREFETCH_ENABLED);
+    session->pf.scan_hint = true;
+}
+
+/*
+ * __wt_prefetch_scan_end --
+ *     End a declared scan.
+ */
+void
+__wt_prefetch_scan_end(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan)
+{
+    if (scan->scan_hint_set)
+        session->pf.scan_hint = false;
+    if (scan->prefetch_set)
+        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
 }
 
 /*
@@ -178,8 +210,8 @@ __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
 
     session_flags = WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL;
     WT_ERR(__wt_thread_group_create(session, &conn->prefetch.threads, "prefetch-server",
-      WT_PREFETCH_THREAD_COUNT, WT_PREFETCH_THREAD_COUNT, session_flags,
-      __wti_prefetch_server_running, __prefetch_thread_run, NULL));
+      WT_PREFETCH_THREAD_COUNT, WT_PREFETCH_THREAD_COUNT, session_flags, __prefetch_server_running,
+      __prefetch_thread_run, NULL));
     return (0);
 
 err:

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1895,8 +1895,6 @@ extern void __wt_optrack_record_funcid(
 extern void __wt_os_stdio(WT_SESSION_IMPL *session);
 extern void __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta);
 extern void __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep);
-extern void __wt_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan);
-extern void __wt_prefetch_scan_end(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan);
 extern void __wt_random_init(WT_SESSION_IMPL *session, WT_RAND_STATE *rnd_state)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_random_init_default(WT_RAND_STATE *rnd_state)
@@ -2032,6 +2030,8 @@ extern void __wti_layered_table_truncate_rollback_apply(
 extern void __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 extern void __wti_mark_committed_truncate_table_apply(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op);
+extern void __wti_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan);
+extern void __wti_prefetch_scan_end(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan);
 extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -57,8 +57,6 @@ extern bool __wti_cell_type_check(uint8_t cell_type, uint8_t dsk_type)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __wti_prefetch_server_running(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_has_stable_update(WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_page_needs_abort(WT_SESSION_IMPL *session, WT_REF *ref,
@@ -1897,6 +1895,8 @@ extern void __wt_optrack_record_funcid(
 extern void __wt_os_stdio(WT_SESSION_IMPL *session);
 extern void __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta);
 extern void __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep);
+extern void __wt_prefetch_scan_begin(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan);
+extern void __wt_prefetch_scan_end(WT_SESSION_IMPL *session, WT_PREFETCH_SCAN *scan);
 extern void __wt_random_init(WT_SESSION_IMPL *session, WT_RAND_STATE *rnd_state)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_random_init_default(WT_RAND_STATE *rnd_state)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -57,6 +57,8 @@ extern bool __wti_cell_type_check(uint8_t cell_type, uint8_t dsk_type)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wti_prefetch_server_running(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_has_stable_update(WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_page_needs_abort(WT_SESSION_IMPL *session, WT_REF *ref,

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -63,6 +63,15 @@ struct __wt_prefetch {
 };
 
 /*
+ * WT_PREFETCH_SCAN --
+ *	The session pre-fetch state a declared scan replaced, so it can be put back.
+ */
+struct __wt_prefetch_scan {
+    bool prefetch_set;  /* The scan set WT_SESSION_PREFETCH_ENABLED */
+    bool scan_hint_set; /* The scan set the hint */
+};
+
+/*
  * WT_ERROR_INFO --
  *  An error structure containing verbose information about an error from a session API call.
  */

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -57,6 +57,9 @@ struct __wt_prefetch {
     WT_PAGE *prefetch_prev_ref_home;
     uint64_t prefetch_disk_read_count; /* Sequential cache requests that caused a leaf read */
     uint64_t prefetch_skipped_with_parent;
+
+    /* Set by a caller that knows pre-fetch should be triggered. */
+    bool scan_hint;
 };
 
 /*

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -377,6 +377,8 @@ struct __wt_prefetch;
 typedef struct __wt_prefetch WT_PREFETCH;
 struct __wt_prefetch_queue_entry;
 typedef struct __wt_prefetch_queue_entry WT_PREFETCH_QUEUE_ENTRY;
+struct __wt_prefetch_scan;
+typedef struct __wt_prefetch_scan WT_PREFETCH_SCAN;
 struct __wt_process;
 typedef struct __wt_process WT_PROCESS;
 struct __wt_reconcile_timeline;

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -14,13 +14,18 @@
  *     internal sessions, internal pages, tiered tables, special btree handles, an overwhelmed
  *     prefetch queue, and sessions that have not yet read enough pages from disk to justify it.
  *     Internal pages are excluded because identifying which leaf pages to preload from an internal
- *     page traversal is non-trivial.
+ *     page traversal is non-trivial. A session that has declared a scan skips the two checks that
+ *     only exist to guess at what it has already stated.
  */
 bool
 __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
 {
+    bool scan;
+
     if (!F_ISSET(session, WT_SESSION_PREFETCH_ENABLED))
         return (false);
+
+    scan = session->pf.scan_hint;
 
     WT_STAT_CONN_INCR(session, prefetch_attempts);
 
@@ -34,7 +39,7 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
         return (false);
     }
 
-    if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+    if (F_ISSET(session, WT_SESSION_INTERNAL) && !scan) {
         WT_STAT_CONN_INCR(session, prefetch_skipped_internal_session);
         return (false);
     }
@@ -53,7 +58,7 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
     if (session->pf.prefetch_disk_read_count == 1)
         WT_STAT_CONN_INCR(session, prefetch_disk_one);
 
-    if (session->pf.prefetch_disk_read_count < 2) {
+    if (session->pf.prefetch_disk_read_count < 2 && !scan) {
         WT_STAT_CONN_INCR(session, prefetch_skipped_disk_read_count);
         return (false);
     }


### PR DESCRIPTION
The metadata merge in `__disagg_apply_checkpoint_meta` is a bounded, forward-only walk of the shared metadata, where every page crossing is a page log round trip. Pre-fetch refused it on two counts: it runs on an internal session, and its disk-read warm-up counter resets on every cache hit, which the walk produces constantly by interleaving cache-resident local metadata with remote shared metadata.

Add a scan hint to `WT_PREFETCH` that a caller sets when it knows it is about to do such a walk, and have `__wt_session_prefetch_check` skip the two checks that only exist to infer what the caller has stated.

See ticket for perf measurements