### PR TITLE
WT-18334 Step-down's btree marking loop races the sweep server on stable dhandle flags

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1405,7 +1405,7 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
          * prepared cell before the drain resolves it, which reconciliation cannot represent (leaked
          * prepared update).
          */
-        F_SET(dhandle, WT_DHANDLE_OUTDATED);
+        FLD_SET_ATOMIC_16(session->dhandle->flags, WT_DHANDLE_OUTDATED);
 
         WT_WITH_BTREE(session, btree, __wt_evict_file_exclusive_off(session));
     }


### PR DESCRIPTION
Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
