### PR TITLE
WT-18415 Schema Disagg Abort failure: EBUSY for 30 seconds

### DIFF
--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -241,8 +241,8 @@ leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
     /* The timestamp thread owns the frontier; just checkpoint. */
     testutil_check(session->checkpoint(session, "use_timestamp=true"));
 
-    println(
-      "Node %" PRIu32 ": checkpoint %" PRIu32 " complete", state->cfg->node_id, ++ckpt->produced);
+    println("Node %" PRIu32 ": checkpoint %" PRIu32 " complete; stable timestamp = %" PRIu64,
+      state->cfg->node_id, ++ckpt->produced, stable_ts);
 
     /* A stable frontier implies every worker completed an operation this phase. */
     if (ckpt->produced == 1u)

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -113,11 +113,6 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         ev.key_min = DATA_KEY_MIN;
         ev.key_max = DATA_KEY_MAX;
     }
-    /* Only an epoch-mode schema operation defers its timestamp to its publish event. */
-    const bool deferred_ts =
-      !state->cfg->epoch_less && (ev.type == EVENT_CREATE || ev.type == EVENT_DROP);
-    if (!deferred_ts)
-        ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
 
     generator_emit(state, &ev);
     return (true);
@@ -207,7 +202,6 @@ generator_flush_publishes(WORKLOAD_STATE *state)
             SCHEMA_EVENT ev = {0};
             ev.type = *slot_state == TABLE_CREATED ? EVENT_PUBLISH_CREATE : EVENT_PUBLISH_DROP;
             ev.thread_id = t;
-            ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
             testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t,
               slot, state->workers[t].table[slot].gen);
 
@@ -268,14 +262,13 @@ generator_stepdown_ended(WORKLOAD_STATE *state, GENERATOR_PACING *pacing)
 
 /*
  * generator_transition_emit --
- *     Emit a transition event (stepdown or switch) stamped with the current counter.
+ *     Emit a transition event (stepdown or switch).
  */
 static void
 generator_transition_emit(WORKLOAD_STATE *state, EVENT_TYPE type)
 {
     SCHEMA_EVENT ev = {0};
     ev.type = type;
-    ev.event_ts = __wt_atomic_load_uint64(&state->current_ts);
     generator_emit(state, &ev);
 }
 
@@ -311,8 +304,7 @@ thread_generator_run(void *arg)
             break;
         case GEN_BEGIN_STEPDOWN:
             /*
-             * Tell the reader to start the step-down work, then generate a limited workload until
-             * the step-down ends.
+             * Start the step-down work, then generate a limited workload until the step-down ends.
              */
             generator_transition_emit(state, EVENT_STEPDOWN);
             __wt_epoch(NULL, &pacing.stepdown_start);
@@ -330,7 +322,7 @@ thread_generator_run(void *arg)
             }
             break;
         case GEN_SWITCH:
-            /* The stream's last event, carrying the counter the next leader continues from. */
+            /* The stream's last event. */
             generator_transition_emit(state, EVENT_SWITCH);
             phase = GEN_STOP;
             break;

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -16,8 +16,7 @@
 
 /*
  * frontier_assert --
- *     Assert the frontier has not passed a drained stream's final timestamp: nothing above it was
- *     delivered, so nothing above it can be complete.
+ *     Assert the frontier has not passed the final counter.
  */
 static void
 frontier_assert(WORKLOAD_STATE *state, uint64_t timestamp)
@@ -25,7 +24,8 @@ frontier_assert(WORKLOAD_STATE *state, uint64_t timestamp)
     const uint64_t frontier_ts = __wt_atomic_load_uint64(&state->frontier_ts);
 
     testutil_assertfmt(frontier_ts <= timestamp,
-      "step-down: the frontier %" PRIu64 " passed the marker's %" PRIu64, frontier_ts, timestamp);
+      "step-down: the frontier %" PRIu64 " passed the final counter %" PRIu64, frontier_ts,
+      timestamp);
 }
 
 /*
@@ -79,6 +79,7 @@ thread_reader_run(void *arg)
     const int src_fd = state->generates ? cfg->self_pipe_read_fd : cfg->pipe_read_fd;
 
     SCHEMA_EVENT ev;
+    uint64_t final_ts;
     bool running = true;
     while (running && workload_active(state, STAGE_READER)) {
         if (!pipe_wait_readable(src_fd))
@@ -107,27 +108,26 @@ thread_reader_run(void *arg)
              * step-down timestamp.
              */
             evq_drain_barrier(state);
-            frontier_assert(state, ev.event_ts);
-            reader_step_down(state, ev.event_ts);
+            final_ts = __wt_atomic_load_uint64(&state->current_ts);
+            frontier_assert(state, final_ts);
+            reader_step_down(state, final_ts);
             break;
         case EVENT_SWITCH:
-            /* The final event of the term's stream: this node must step up. */
+            /* The final event of the term's stream. */
             evq_drain_barrier(state);
-            /*
-             * Relay-integrity check: the drained counter must equal the sender's final counter.
-             * Every counter value the term allocated rides an event that precedes the switch in the
-             * stream, so after the drain nothing may be missing.
-             */
-            testutil_assertfmt(__wt_atomic_load_uint64(&state->current_ts) == ev.event_ts,
-              "hand-over: drained counter %" PRIu64 " != sender's final counter %" PRIu64,
-              __wt_atomic_load_uint64(&state->current_ts), ev.event_ts);
+
+            if (!state->generates)
+                testutil_assertfmt(__wt_atomic_load_uint64(&state->current_ts) == ev.event_ts,
+                  "hand-over: local final counter %" PRIu64 " != sender's final counter %" PRIu64,
+                  __wt_atomic_load_uint64(&state->current_ts), ev.event_ts);
             __wt_atomic_store_bool(&state->handover_received, true);
             running = false;
             break;
         case EVENT_NONE:
-            /* Never emitted; a zeroed event means the framing lost its way. */
+        case EVENT_PENDING:
+            /* Never emitted; the framing lost its way. */
             testutil_die(
-              EINVAL, "Node %" PRIu32 ": empty event read from the source pipe", cfg->node_id);
+              EINVAL, "Node %" PRIu32 ": invalid event read from the source pipe", cfg->node_id);
         }
     }
 

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -123,6 +123,7 @@ typedef enum {
     EVENT_INSERT,
     EVENT_PUBLISH_CREATE,
     EVENT_PUBLISH_DROP,
+    EVENT_PENDING,
     EVENT_STEPDOWN,
     EVENT_SWITCH
 } EVENT_TYPE;
@@ -130,11 +131,11 @@ typedef enum {
 typedef struct {
     EVENT_TYPE type;
     uint32_t thread_id;
-    /*
-     * The timestamp whose completion this event represents: a publish epoch, an insert's commit
-     * timestamp (which the rows also hold), a legacy schema operation's timestamp, or a term's
-     * final timestamp. CREATE/DROP carry none when schema epochs are in use - a schema operation
-     * then completes with its publish.
+    /*-
+     * The completion timestamp for this event:
+     *   - a publish epoch,
+     *   - an insert's commit timestamp,
+     *   - a legacy schema op's timestamp (epoch-less mode).
      */
     uint64_t event_ts;
     uint32_t key_min;

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -27,6 +27,7 @@ typedef struct {
     bool is_create;
     bool valid;
     bool newer_schema_op; /* legacy schema record above the checkpoint timestamp */
+    bool pending;         /* legacy operation begun whose outcome was never recorded */
     char uri[64];         /* filled when valid, so the checks need not rebuild it */
 } SLOT_STATE;
 
@@ -38,6 +39,24 @@ typedef struct {
     uint32_t skipped_slots;
     uint32_t skipped_rows;
 } VERIFY_STATS;
+
+/*
+ * record_op_type --
+ *     Parse an event type from a record file.
+ */
+static EVENT_TYPE
+record_op_type(const char *op)
+{
+    if (strcmp(op, "CREATE") == 0)
+        return (EVENT_CREATE);
+    if (strcmp(op, "DROP") == 0)
+        return (EVENT_DROP);
+    if (strcmp(op, "INSERT") == 0)
+        return (EVENT_INSERT);
+    if (strcmp(op, "PENDING") == 0)
+        return (EVENT_PENDING);
+    return (EVENT_NONE); /* unrecognized operation */
+}
 
 /*
  * parse_record_uri --
@@ -77,61 +96,61 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
         /* A worker killed mid-write leaves a partial line, which can only be the file's last. */
         const bool torn = strchr(line, '\n') == NULL;
 
-        char op[16];
+        char op[16], rec_uri[128];
+        uint64_t op_ts; /* publish epoch, legacy schema timestamp, or insert commit timestamp */
+        uint32_t key_max = 0, key_min = 0;
 
-        if (sscanf(line, "%15s", op) != 1) {
+        /* Every record is "<op> <op_ts> <uri>"; only an insert appends its key range. */
+        const int fields = sscanf(line, "%15s %" SCNu64 " %127s %" SCNu32 " %" SCNu32, op, &op_ts,
+          rec_uri, &key_min, &key_max);
+        if (fields < 3) {
             testutil_assertfmt(torn, "%s: unreadable record \"%s\"", fname, line);
             continue;
         }
 
-        char rec_uri[128];
-        uint64_t op_ts; /* publish epoch, legacy schema timestamp, or insert commit timestamp */
-        uint32_t key_max = 0, key_min = 0, s;
-        bool parsed = false;
+        const EVENT_TYPE op_type = record_op_type(op);
 
-        /* Every record is "<op> <op_ts> [<key range>] <uri>". */
-        if (strcmp(op, "CREATE") == 0 || strcmp(op, "DROP") == 0)
-            parsed = sscanf(line, "%*s %" SCNu64 " %127s", &op_ts, rec_uri) == 2;
-        else if (strcmp(op, "INSERT") == 0)
-            parsed = sscanf(line, "%*s %" SCNu64 " %" SCNu32 " %" SCNu32 " %127s", &op_ts, &key_min,
-                       &key_max, rec_uri) == 4;
-        else
-            testutil_assertfmt(false, "%s: unknown record op \"%s\"", fname, op);
-
-        if (!parsed) {
+        if (fields != (op_type == EVENT_INSERT ? 5 : 3)) {
             testutil_assertfmt(torn, "%s: malformed record \"%s\"", fname, line);
             continue;
         }
 
+        uint32_t s;
         if (!parse_record_uri(rec_uri, node, t, pool_size, &s))
             continue;
-        /* Legacy schema entries above the checkpoint timestamp may or may not have been drained. */
-        if (op_ts > durable_ts) {
-            if (epoch_less && (strcmp(op, "CREATE") == 0 || strcmp(op, "DROP") == 0))
-                states[s].newer_schema_op = true;
-            continue;
-        }
 
-        if (strcmp(op, "INSERT") == 0) {
-            /*
-             * Each CREATE may be followed by several rounds of INSERT's, keep only the latest one
-             * because earlier values are overwritten.
-             */
-            const bool latest_insert = states[s].valid && states[s].is_create &&
-              op_ts > states[s].schema_ts && op_ts > states[s].commit_ts;
+        SLOT_STATE *slot = &states[s];
 
-            if (latest_insert) {
-                states[s].commit_ts = op_ts;
-                states[s].key_min = key_min;
-                states[s].key_max = key_max;
+        if (op_type == EVENT_PENDING) {
+            /* Epoch-less operation began. */
+            slot->pending = true;
+        } else if (op_type == EVENT_CREATE || op_type == EVENT_DROP) {
+            slot->pending = false;
+            if (op_ts > durable_ts) {
+                if (epoch_less)
+                    /* Epoch-less schema op is above the last checkpoint. */
+                    slot->newer_schema_op = true;
+            } else if (op_ts > slot->schema_ts) {
+                /* Apply new schema operation and update the slot state. */
+                slot->schema_ts = op_ts;
+                slot->commit_ts = DATA_COMMIT_TS_NONE;
+                slot->is_create = op_type == EVENT_CREATE;
+                slot->valid = true;
+                testutil_snprintf(slot->uri, sizeof(slot->uri), "%s", rec_uri);
             }
-        } else if (op_ts > states[s].schema_ts) { /* most recent CREATE or DROP */
-            states[s].schema_ts = op_ts;
-            states[s].commit_ts = DATA_COMMIT_TS_NONE;
-            states[s].is_create = strcmp(op, "CREATE") == 0;
-            states[s].valid = true;
-            testutil_snprintf(states[s].uri, sizeof(states[s].uri), "%s", rec_uri);
-        }
+        } else if (op_type == EVENT_INSERT) {
+            /*
+             * Keep only the newest durable insert into the slot's current create: earlier values
+             * are overwritten, and one below the create belongs to a past generation.
+             */
+            if (op_ts <= durable_ts && slot->valid && slot->is_create && op_ts > slot->schema_ts &&
+              op_ts > slot->commit_ts) {
+                slot->commit_ts = op_ts;
+                slot->key_min = key_min;
+                slot->key_max = key_max;
+            }
+        } else
+            testutil_assertfmt(false, "%s: unknown record op \"%s\"", fname, op);
     }
     (void)fclose(fp);
 }
@@ -156,7 +175,8 @@ check_schema_presence(WT_SESSION *session, const TEST_CONFIG *cfg,
         const int ret = md_cursor->search(md_cursor);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
-        const bool uncertain_tail = cfg->epoch_less && states[s].newer_schema_op;
+        const bool uncertain_tail =
+          cfg->epoch_less && (states[s].newer_schema_op || states[s].pending);
         /* A legacy step-up rebuilds shared metadata from local metadata, and enqueue creates
          * only, so a drop applied while following is resurrected. */
         const bool switched_legacy_drop =
@@ -195,7 +215,7 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
             continue;
         if (last_ckpt_ts > 0 && states[s].commit_ts > last_ckpt_ts)
             continue;
-        if (states[s].newer_schema_op) {
+        if (states[s].newer_schema_op || states[s].pending) {
             ++stats->skipped_rows;
             continue;
         }

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -106,8 +106,11 @@ worker_record_open(const WORKLOAD_STATE *state, uint32_t thread_index)
 static void
 schema_op_stall_report(WORKLOAD_STATE *state)
 {
-    println("Node %" PRIu32 ": stable %" PRIu64 ", frontier %" PRIu64, state->cfg->node_id,
-      query_ts(state->conn, TS_STABLE), __wt_atomic_load_uint64(&state->frontier_ts));
+    println("Node %" PRIu32 ": stable %" PRIu64 ", frontier %" PRIu64 ", last checkpoint %" PRIu64
+            ", step-down %" PRIu64,
+      state->cfg->node_id, query_ts(state->conn, TS_STABLE),
+      __wt_atomic_load_uint64(&state->frontier_ts), query_ts(state->conn, TS_LAST_CHECKPOINT),
+      __wt_atomic_load_uint64(&state->stepdown_ts));
     for (uint32_t t = 0; t < state->worker_count; t++)
         println("  worker %" PRIu32 ": %" PRIu64 " events queued", t, evq_depth(state, t));
 }

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -7,9 +7,8 @@
  */
 
 /*
- * The worker stage: N threads applying what the reader queued, exactly as the source stream fixed
- * each event, so both roles execute an identical history. Writes the verifier's record files, and
- * marks each completed operation in the shared frontier window.
+ * The worker stage: N threads applying what the reader queued, in the order the source stream
+ * fixed, so both roles execute an identical history.
  */
 
 #include "schema_disagg_abort.h"
@@ -44,14 +43,17 @@ record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
     case EVENT_DROP:
     case EVENT_PUBLISH_CREATE:
     case EVENT_PUBLISH_DROP:
-        /* Epoch mode records at publish; legacy mode records before executing the operation. */
+        /* Epoch mode records at publish; legacy mode records once the operation has executed. */
         ret = fprintf(fp, "%s %" PRIu64 " %s\n",
           ev->type == EVENT_CREATE || ev->type == EVENT_PUBLISH_CREATE ? "CREATE" : "DROP",
           ev->event_ts, ev->uri);
         break;
     case EVENT_INSERT:
-        ret = fprintf(fp, "INSERT %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->event_ts,
-          ev->key_min, ev->key_max, ev->uri);
+        ret = fprintf(fp, "INSERT %" PRIu64 " %s %" PRIu32 " %" PRIu32 "\n", ev->event_ts, ev->uri,
+          ev->key_min, ev->key_max);
+        break;
+    case EVENT_PENDING:
+        ret = fprintf(fp, "PENDING %" PRIu64 " %s\n", ev->event_ts, ev->uri);
         break;
     case EVENT_NONE:
     case EVENT_STEPDOWN:
@@ -60,6 +62,20 @@ record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
     }
     if (ret < 0)
         testutil_die(EIO, "fprintf event record");
+}
+
+/*
+ * record_pending_line --
+ *     Mark a legacy schema operation as begun but not yet recorded.
+ */
+static void
+record_pending_line(FILE *fp, const SCHEMA_EVENT *ev)
+{
+    SCHEMA_EVENT pending = *ev;
+
+    pending.type = EVENT_PENDING;
+    pending.event_ts = 0;
+    record_event_line(fp, &pending);
 }
 
 /*
@@ -199,7 +215,6 @@ static void
 worker_complete(WORKLOAD_STATE *state, uint64_t value)
 {
     workload_counter_advance(state, value);
-    (void)__wt_atomic_add_uint64(&state->applied, 1);
 
     /* One writer per timestamp, so the mark needs no read-modify-write. */
     const uint64_t frontier_ts = __wt_atomic_load_uint64(&state->frontier_ts);
@@ -210,13 +225,22 @@ worker_complete(WORKLOAD_STATE *state, uint64_t value)
 }
 
 /*
+ * worker_ts --
+ *     Take the timestamp for an event the worker is about to apply. A generating node allocates on
+ *     apply; a peer-fed follower adopts what the leader stamped.
+ */
+static uint64_t
+worker_ts(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
+{
+    return (state->generates ? __wt_atomic_add_uint64(&state->current_ts, 1) : ev->event_ts);
+}
+
+/*
  * apply_event --
- *     Apply one event on this node, identically for both roles and exactly as the source stream
- *     fixed it. In epoch mode a schema operation's timestamp, record and completion belong to its
- *     later publish event; in legacy mode they belong to the operation itself.
+ *     Apply one event on this node.
  */
 static void
-apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const SCHEMA_EVENT *ev)
+apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, SCHEMA_EVENT *ev)
 {
     /* The role is fixed for the phase, step-down window included: a leader relays throughout. */
     const bool relay = state->leads;
@@ -226,6 +250,7 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const
 
     switch (ev->type) {
     case EVENT_INSERT:
+        ev->event_ts = worker_ts(state, ev);
         insert_data(ctx->session, ev->uri, ev->event_ts, ev->key_min, ev->key_max);
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
@@ -234,22 +259,32 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const
         break;
     case EVENT_CREATE:
     case EVENT_DROP:
-        /* A legacy checkpoint can make the operation durable as soon as it executes. */
         if (state->cfg->epoch_less)
-            record_event_line(ctx->record_fp, ev);
+            /*
+             * Epoch-less schema ops do not have corresponding PUBLISH events. Record them as
+             * pending now, so validation can check them later.
+             */
+            record_pending_line(ctx->record_fp, ev);
+
         schema_op_execute(state, ctx->session, ev);
+
+        if (state->cfg->epoch_less)
+            ev->event_ts = worker_ts(state, ev);
+
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
-        if (state->cfg->epoch_less)
+
+        /* In epoch mode the record and the completion belong to the later publish event. */
+        if (state->cfg->epoch_less) {
+            record_event_line(ctx->record_fp, ev);
             worker_complete(state, ev->event_ts);
-        else
-            /* No timestamp: count it applied, but the completion belongs to the publish. */
-            (void)__wt_atomic_add_uint64(&state->applied, 1);
+        }
         break;
     case EVENT_PUBLISH_CREATE:
     case EVENT_PUBLISH_DROP:
         /* Legacy mode should not see these events. */
         testutil_assert(!state->cfg->epoch_less);
+        ev->event_ts = worker_ts(state, ev);
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
         record_event_line(ctx->record_fp, ev);
@@ -257,10 +292,14 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const
         worker_complete(state, ev->event_ts);
         break;
     case EVENT_NONE:
+    case EVENT_PENDING:
     case EVENT_STEPDOWN:
     case EVENT_SWITCH:
         testutil_assertfmt(false, "Unexpected apply event type: %d", ev->type);
     }
+
+    /* The generator paces itself on how far its emissions lead the workers. */
+    (void)__wt_atomic_add_uint64(&state->applied, 1);
 }
 
 /*

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -285,10 +285,10 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, SCHEM
         /* Legacy mode should not see these events. */
         testutil_assert(!state->cfg->epoch_less);
         ev->event_ts = worker_ts(state, ev);
+        schema_op_publish(ctx->session, ev->uri, ev->event_ts);
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);
         record_event_line(ctx->record_fp, ev);
-        schema_op_publish(ctx->session, ev->uri, ev->event_ts);
         worker_complete(state, ev->event_ts);
         break;
     case EVENT_NONE:


### PR DESCRIPTION
Previously, the generator of events assigned their timestamps upfront. This way the slowest thread could prevent others from proceeding by pinning the completed timestamp for entire test.

This PR changes this:
- leader worker threads increment the global counter at the pace of completed operations, independently of each other,
- follower receives timestamped events via the oplog pipeline, as before.

In addition, minor changes to `parse_schema_records` function to improve readability.