### PR TITLE
WT-18490 Refuse a disaggregated btree with no page log

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -373,7 +373,8 @@ file_config = format_meta + file_runtime_config + tiered_config + file_disaggreg
         these names are also available. See @ref compression for more information'''),
     Config('block_manager', 'default', r'''
         configure a manager for file blocks. Permitted values are \c "default" or the
-        disaggregated storage block manager backed by \c PALI.''',
+        disaggregated storage block manager backed by \c PALI, which requires a page log
+        service to be configured.''',
         choices=['default', 'disagg']),
     Config('checksum', 'on', r'''
         configure block checksums; the permitted values are \c on, \c off, \c uncompressed and

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -608,8 +608,19 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
             WT_RET(
               __wt_schema_page_log_from_config(session, btree->dhandle->cfg, &btree->page_log));
 
-            /* A page log service and a storage source cannot both be enabled. */
-            WT_ASSERT(session, btree->page_log == NULL || btree->bstorage == NULL);
+            /*
+             * A page log service and a storage source cannot both be enabled. Without a page log
+             * the disaggregated block manager declines the object and the tree is handed to the
+             * local one, leaving a tree flagged disaggregated whose blocks live in a local file.
+             * Nothing downstream can reconcile the two, so refuse the open rather than fail once
+             * the tree is written out.
+             */
+            if (btree->page_log == NULL)
+                WT_RET_MSG(session, EINVAL,
+                  "%s: the disaggregated block manager requires a page log, none is configured for "
+                  "this table or connection",
+                  btree->dhandle->name);
+            WT_ASSERT(session, btree->bstorage == NULL);
         }
     }
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -609,17 +609,18 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
               __wt_schema_page_log_from_config(session, btree->dhandle->cfg, &btree->page_log));
 
             /*
-             * A page log service and a storage source cannot both be enabled. Without a page log
-             * the disaggregated block manager declines the object and the tree is handed to the
-             * local one, leaving a tree flagged disaggregated whose blocks live in a local file.
-             * Nothing downstream can reconcile the two, so refuse the open rather than fail once
-             * the tree is written out.
+             * Without a page log the disaggregated block manager declines the object and the tree
+             * is handed to the local one, leaving a tree flagged disaggregated whose blocks live in
+             * a local file. Nothing downstream can reconcile the two, so refuse the open rather
+             * than fail once the tree is written out.
              */
             if (btree->page_log == NULL)
                 WT_RET_MSG(session, EINVAL,
                   "%s: the disaggregated block manager requires a page log, none is configured for "
                   "this table or connection",
                   btree->dhandle->name);
+
+            /* A page log service and a storage source cannot both be enabled. */
             WT_ASSERT(session, btree->bstorage == NULL);
         }
     }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -608,12 +608,6 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
             WT_RET(
               __wt_schema_page_log_from_config(session, btree->dhandle->cfg, &btree->page_log));
 
-            /*
-             * Without a page log the disaggregated block manager declines the object and the tree
-             * is handed to the local one, leaving a tree flagged disaggregated whose blocks live in
-             * a local file. Nothing downstream can reconcile the two, so refuse the open rather
-             * than fail once the tree is written out.
-             */
             if (btree->page_log == NULL)
                 WT_RET_MSG(session, EINVAL,
                   "%s: the disaggregated block manager requires a page log, none is configured for "

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1186,8 +1186,9 @@ struct __wt_session {
      * compression\, these names are also available.  See @ref compression for more information., a
      * string; default \c none.}
      * @config{block_manager, configure a manager for file blocks.  Permitted values are \c
-     * "default" or the disaggregated storage block manager backed by \c PALI., a string\, chosen
-     * from the following options: \c "default"\, \c "disagg"; default \c default.}
+     * "default" or the disaggregated storage block manager backed by \c PALI\, which requires a
+     * page log service to be configured., a string\, chosen from the following options: \c
+     * "default"\, \c "disagg"; default \c default.}
      * @config{cache_resident, do not ever evict the object's pages from cache\, see @ref
      * tuning_cache_resident for more information., a boolean flag; default \c false.}
      * @config{checksum, configure block checksums; the permitted values are \c on\, \c off\, \c

--- a/test/suite/test_disagg_block_manager01.py
+++ b/test/suite/test_disagg_block_manager01.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wiredtiger, wttest
+from helper_disagg import disagg_test_class
 
 # A table using the disaggregated block manager needs a page log to read or write anything. A
 # connection that never configured disaggregated storage has none, in which case the disaggregated
@@ -91,20 +92,38 @@ class test_disagg_block_manager01(wttest.WiredTigerTestCase):
         self.assertEqual(cursor[str(self.nrows - 1)], self.value)
         cursor.close()
 
+# The same combination reached from the other direction: a table created while a page log was
+# configured, opened later by a connection that has none. The configuration outlives the connection
+# that accepted it, so the refusal has to happen on every open of the tree, not only on create.
+@disagg_test_class
+class test_disagg_block_manager01_reopen(wttest.WiredTigerTestCase):
+    conn_config = 'disaggregated=(role="leader")'
+
+    no_page_log = test_disagg_block_manager01.no_page_log
+
+    # Set before the reopen, so the connection comes back with no page log to resolve the table's
+    # configuration against. Dropping the page log from the connection configuration alone is not
+    # enough: the name is recorded in the base configuration and in the table's own metadata, and a
+    # reopened connection finds it again through either.
+    drop_page_log = False
+
+    def conn_extensions(self, extlist):
+        if self.drop_page_log:
+            return
+        self.add_scenario_config()
+        return self.disagg_conn_extensions(extlist)
+
     def test_reopen_rejected(self):
-        # The configuration outlives the connection that accepted it, so a database already carrying
-        # a disaggregated table must refuse to open it too. Create the file normally and edit the
-        # metadata afterwards, since create refuses the disaggregated configuration. Editing the entry
-        # in place keeps the file version this build writes, which differs between builds.
-        uri = 'file:disagg.wt'
-        self.session.create(uri, 'key_format=S,value_format=S')
+        uri = 'table:disagg'
+        self.session.create(uri, 'key_format=S,value_format=S,block_manager=disagg')
+        cursor = self.session.open_cursor(uri)
+        cursor['key'] = 'value'
+        cursor.close()
+        self.session.checkpoint()
 
-        # Drop the handle opened by the create, so the edited configuration is the one read back.
-        self.reopen_conn()
-
-        meta = self.session.open_cursor('metadata:', None, 'readonly=false')
-        meta[uri] = meta[uri] + ',block_manager=disagg'
-        meta.close()
+        # The connection itself has no reason to fail: only the tables that need the page log do.
+        self.drop_page_log = True
+        self.reopen_conn(config='create,config_base=false')
 
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor(uri), '/Invalid argument/')

--- a/test/suite/test_disagg_block_manager01.py
+++ b/test/suite/test_disagg_block_manager01.py
@@ -86,7 +86,7 @@ class test_disagg_block_manager01(wttest.WiredTigerTestCase):
 
         # The surviving table proves the walk ran; the rejected one must be absent.
         self.assertIn(plain, uris)
-        self.assertFalse([u for u in uris if 'disagg' in u], 'stale metadata: %s' % uris)
+        self.assertEqual([u for u in uris if 'disagg' in u], [], 'stale metadata: %s' % uris)
 
         cursor = self.session.open_cursor(plain)
         self.assertEqual(cursor[str(self.nrows - 1)], self.value)

--- a/test/suite/test_disagg_block_manager01.py
+++ b/test/suite/test_disagg_block_manager01.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# A table using the disaggregated block manager needs a page log to read or write anything. A
+# connection that never configured disaggregated storage has none, in which case the disaggregated
+# block manager declines the object and the tree is handed to the local one, leaving a tree flagged
+# disaggregated whose blocks live in a local file. Nothing downstream reconciles the two, so the
+# combination has to be refused when the handle is opened rather than once the tree is written out.
+class test_disagg_block_manager01(wttest.WiredTigerTestCase):
+    nrows = 5000
+    value = 'a' * 512
+
+    # The refusal is reported on the error stream as well as through the return code.
+    no_page_log = 'requires a page log'
+
+    def populate(self, uri):
+        cursor = self.session.open_cursor(uri)
+        for i in range(self.nrows):
+            cursor[str(i)] = self.value
+        cursor.close()
+
+    def test_create_rejected(self):
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.create('table:disagg',
+                'key_format=S,value_format=S,block_manager=disagg'),
+            '/Invalid argument/')
+        self.ignoreStderrPatternIfExists(self.no_page_log)
+
+    def test_connection_survives_rejected_create(self):
+        # A table that does not ask for the disaggregated block manager is unaffected, and stays
+        # usable across the rejected create.
+        plain = 'table:plain'
+        self.session.create(plain, 'key_format=S,value_format=S')
+        self.populate(plain)
+
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.create('table:disagg',
+                'key_format=S,value_format=S,block_manager=disagg'))
+
+        # Writing out the trees is what used to abort the process.
+        self.session.checkpoint()
+
+        cursor = self.session.open_cursor(plain)
+        self.assertEqual(cursor[str(self.nrows - 1)], self.value)
+        cursor.close()
+
+        self.ignoreStderrPatternIfExists(self.no_page_log)
+
+        # The rejected create must not leave anything behind that a later open trips over, so the
+        # database has to come back cleanly and the table must not be in the metadata.
+        self.reopen_conn()
+
+        uris = []
+        meta = self.session.open_cursor('metadata:create')
+        while meta.next() == 0:
+            uris.append(meta.get_key())
+        meta.close()
+
+        # The surviving table proves the walk ran; the rejected one must be absent.
+        self.assertIn(plain, uris)
+        self.assertFalse([u for u in uris if 'disagg' in u], 'stale metadata: %s' % uris)
+
+        cursor = self.session.open_cursor(plain)
+        self.assertEqual(cursor[str(self.nrows - 1)], self.value)
+        cursor.close()
+
+    def test_reopen_rejected(self):
+        # The configuration outlives the connection that accepted it, so a database already carrying
+        # a disaggregated table must refuse to open it too. Write the configuration straight into
+        # the metadata, since create refuses it.
+        uri = 'file:disagg.wt'
+        meta = self.session.open_cursor('metadata:create', None, 'readonly=false')
+        meta[uri] = 'key_format=S,value_format=S,block_manager=disagg,' + \
+            'version=(major=2,minor=1)'
+        meta.close()
+
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(uri), '/Invalid argument/')
+        self.ignoreStderrPatternIfExists(self.no_page_log)

--- a/test/suite/test_disagg_block_manager01.py
+++ b/test/suite/test_disagg_block_manager01.py
@@ -93,12 +93,17 @@ class test_disagg_block_manager01(wttest.WiredTigerTestCase):
 
     def test_reopen_rejected(self):
         # The configuration outlives the connection that accepted it, so a database already carrying
-        # a disaggregated table must refuse to open it too. Write the configuration straight into
-        # the metadata, since create refuses it.
+        # a disaggregated table must refuse to open it too. Create the file normally and edit the
+        # metadata afterwards, since create refuses the disaggregated configuration. Editing the entry
+        # in place keeps the file version this build writes, which differs between builds.
         uri = 'file:disagg.wt'
-        meta = self.session.open_cursor('metadata:create', None, 'readonly=false')
-        meta[uri] = 'key_format=S,value_format=S,block_manager=disagg,' + \
-            'version=(major=2,minor=1)'
+        self.session.create(uri, 'key_format=S,value_format=S')
+
+        # Drop the handle opened by the create, so the edited configuration is the one read back.
+        self.reopen_conn()
+
+        meta = self.session.open_cursor('metadata:', None, 'readonly=false')
+        meta[uri] = meta[uri] + ',block_manager=disagg'
         meta.close()
 
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,


### PR DESCRIPTION
block_manager=disagg is a per-table create option with no dependency on the connection having configured disaggregated storage. When it is set without a page log, __wt_block_disagg_manager_owns_object declines the object and the tree is handed to the local block manager, leaving a tree flagged disaggregated whose blocks live in a local file. Nothing downstream reconciles the two, and the process aborts on the first write of the tree: a diagnostic build on the layered-leader assertion in __wt_page_modify_set or the size assertion in __wt_meta_ckptlist_set, a release build on a WT_PANIC out of the checkpoint.

Refuse the combination when the handle is configured, so the caller gets EINVAL from session.create instead of an abort later on.
