### PR TITLE
WT-18495 Verify the effective time aggregate of deleted-address cells

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1568,17 +1568,27 @@ __verify_page_content_int(
     WT_DECL_RET;
     WT_PAGE *page;
     const WT_PAGE_HEADER *dsk;
-    WT_TIME_AGGREGATE *ta;
+    WT_TIME_AGGREGATE effective_ta, *ta;
     uint32_t cell_num;
 
     page = ref->page;
     dsk = page->dsk;
-    ta = &unpack.ta;
 
     /* Walk the page, verifying overflow pages and validating timestamps. */
     cell_num = 0;
     WT_CELL_FOREACH_ADDR (session, dsk, unpack) {
         ++cell_num;
+
+        /*
+         * The aggregate in a deleted-address cell predates the truncate, so validate the effective
+         * aggregate: the unpacked one with the page deletion applied as its stop point.
+         */
+        ta = &unpack.ta;
+        if (unpack.type == WT_CELL_ADDR_DEL && F_ISSET(dsk, WT_PAGE_FT_UPDATE)) {
+            WT_TIME_AGGREGATE_COPY(&effective_ta, &unpack.ta);
+            WT_TIME_AGGREGATE_APPLY_PAGE_DEL(&effective_ta, &unpack.page_del);
+            ta = &effective_ta;
+        }
 
         __wt_verbose_debug3(session, WT_VERB_VERIFY,
           "cell num: %" PRIu32 ", cell type: %s, page type: %s", cell_num - 1,

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1586,7 +1586,7 @@ __verify_page_content_int(
         ta = &unpack.ta;
         if (unpack.type == WT_CELL_ADDR_DEL && F_ISSET(dsk, WT_PAGE_FT_UPDATE)) {
             WT_TIME_AGGREGATE_COPY(&effective_ta, &unpack.ta);
-            WT_TIME_AGGREGATE_APPLY_PAGE_DEL(&effective_ta, &unpack.page_del);
+            WT_TIME_AGGREGATE_MERGE_PAGE_DEL(&effective_ta, &unpack.page_del);
             ta = &effective_ta;
         }
 

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -224,7 +224,7 @@ __verify_dsk_addr_validity(WT_CELL_UNPACK_ADDR *unpack, WT_VERIFY_INFO *vi)
     ta = &unpack->ta;
     if (unpack->type == WT_CELL_ADDR_DEL && F_ISSET(vi->dsk, WT_PAGE_FT_UPDATE)) {
         WT_TIME_AGGREGATE_COPY(&effective_ta, &unpack->ta);
-        WT_TIME_AGGREGATE_APPLY_PAGE_DEL(&effective_ta, &unpack->page_del);
+        WT_TIME_AGGREGATE_MERGE_PAGE_DEL(&effective_ta, &unpack->page_del);
         ta = &effective_ta;
     }
 

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -213,12 +213,23 @@ __verify_dsk_addr_validity(WT_CELL_UNPACK_ADDR *unpack, WT_VERIFY_INFO *vi)
 {
     WT_ADDR *addr;
     WT_DECL_RET;
+    WT_TIME_AGGREGATE effective_ta, *ta;
 
     addr = vi->page_addr;
 
-    if ((ret = __wt_time_aggregate_validate(vi->session, &unpack->ta,
-           addr != NULL ? &addr->ta : NULL, F_ISSET(vi->session, WT_SESSION_QUIET_CORRUPT_FILE))) ==
-      0)
+    /*
+     * The aggregate in a deleted-address cell predates the truncate, so validate the effective
+     * aggregate: the unpacked one with the page deletion applied as its stop point.
+     */
+    ta = &unpack->ta;
+    if (unpack->type == WT_CELL_ADDR_DEL && F_ISSET(vi->dsk, WT_PAGE_FT_UPDATE)) {
+        WT_TIME_AGGREGATE_COPY(&effective_ta, &unpack->ta);
+        WT_TIME_AGGREGATE_APPLY_PAGE_DEL(&effective_ta, &unpack->page_del);
+        ta = &effective_ta;
+    }
+
+    if ((ret = __wt_time_aggregate_validate(vi->session, ta, addr != NULL ? &addr->ta : NULL,
+           F_ISSET(vi->session, WT_SESSION_QUIET_CORRUPT_FILE))) == 0)
         return (0);
 
     WT_RET_VRFY_RETVAL(vi->session, ret,
@@ -250,11 +261,9 @@ __verify_dsk_value_validity(WT_CELL_UNPACK_KV *unpack, WT_VERIFY_INFO *vi)
  *     Verify a deleted-page address cell's page delete information.
  */
 static int
-__verify_dsk_addr_page_del(WT_SESSION_IMPL *session, WT_CELL_UNPACK_ADDR *unpack, uint32_t cell_num,
-  WT_ADDR *addr, const char *tag)
+__verify_dsk_addr_page_del(
+  WT_SESSION_IMPL *session, WT_CELL_UNPACK_ADDR *unpack, uint32_t cell_num, const char *tag)
 {
-    WT_DECL_RET;
-    WT_TIME_AGGREGATE ta_with_delete;
     char time_string[WT_TIME_STRING_SIZE];
 
     /* The durable timestamp in the page_delete info should not be before its commit timestamp. */
@@ -265,9 +274,9 @@ __verify_dsk_addr_page_del(WT_SESSION_IMPL *session, WT_CELL_UNPACK_ADDR *unpack
           cell_num - 1, tag, unpack->page_del.pg_del_durable_ts, unpack->page_del.pg_del_start_ts);
 
     /*
-     * The timestamps in the page_delete information are a global stop time for the entire page.
-     * This is not reflected in the aggregate, but is supposed to be reflected in the parent's
-     * aggregate. First check that the aggregate is consistent with being deleted at the given time.
+     * The timestamps in the page_delete information are a global stop time for the entire page. The
+     * aggregate in the cell predates the truncate, so its stop information must not run past it.
+     * Validation of the effective aggregate against the parent happens with the validity window.
      */
     if (unpack->ta.newest_stop_durable_ts > unpack->page_del.pg_del_durable_ts)
         WT_RET_VRFY(session,
@@ -299,22 +308,6 @@ __verify_dsk_addr_page_del(WT_SESSION_IMPL *session, WT_CELL_UNPACK_ADDR *unpack
           "; time aggregate %s",
           cell_num - 1, tag, unpack->page_del.txnid,
           __wt_time_aggregate_to_string(&unpack->ta, time_string));
-
-    /*
-     * Merge this information into the aggregate and verify the results, against the parent if
-     * possible.
-     */
-    WT_TIME_AGGREGATE_COPY(&ta_with_delete, &unpack->ta);
-    ta_with_delete.newest_stop_durable_ts = unpack->page_del.pg_del_durable_ts;
-    ta_with_delete.newest_txn = unpack->page_del.txnid;
-    ta_with_delete.newest_stop_ts = unpack->page_del.pg_del_start_ts;
-    ta_with_delete.newest_stop_txn = unpack->page_del.txnid;
-    ret = __wt_time_aggregate_validate(session, &ta_with_delete, addr != NULL ? &addr->ta : NULL,
-      F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE));
-    if (ret != 0)
-        WT_RET_VRFY_RETVAL(session, ret,
-          "fast-delete cell %" PRIu32 " on page at %s failed adjusted timestamp validation",
-          cell_num - 1, tag);
 
     /*
      * The other elements of the structure are not stored on disk and are set unconditionally by the
@@ -485,8 +478,7 @@ __verify_dsk_row_int(WT_VERIFY_INFO *vi)
 
         /* Check that any fast-delete info is consistent with the validity window. */
         if (cell_type == WT_CELL_ADDR_DEL && F_ISSET(vi->dsk, WT_PAGE_FT_UPDATE))
-            WT_ERR(
-              __verify_dsk_addr_page_del(vi->session, unpack, cell_num, vi->page_addr, vi->tag));
+            WT_ERR(__verify_dsk_addr_page_del(vi->session, unpack, cell_num, vi->tag));
 
         /*
          * Remaining checks are for key order. If this cell isn't a key, we're done, move to the

--- a/src/docs/arch-fast-truncate.dox
+++ b/src/docs/arch-fast-truncate.dox
@@ -613,7 +613,7 @@ deletion information to the packing code.}
 @row{timestamp_inline.h, Macro, \c WT_TIME_AGGREGATE_UPDATE_PAGE_DEL,
 Akin to \c WT_TIME_AGGREGATE_UPDATE but for a \c WT_PAGE_DELETED; used in internal page
 reconciliation.}
-@row{timestamp_inline.h, Macro, \c WT_TIME_AGGREGATE_APPLY_PAGE_DEL,
+@row{timestamp_inline.h, Macro, \c WT_TIME_AGGREGATE_MERGE_PAGE_DEL,
 Replace the stop information in an aggregate unpacked from a \c WT_CELL_ADDR_DEL cell with the
 global stop point supplied by its \c WT_PAGE_DELETED; the unpacked stop information describes
 the child page before the truncate and cannot be used as-is.}

--- a/src/docs/arch-fast-truncate.dox
+++ b/src/docs/arch-fast-truncate.dox
@@ -613,6 +613,10 @@ deletion information to the packing code.}
 @row{timestamp_inline.h, Macro, \c WT_TIME_AGGREGATE_UPDATE_PAGE_DEL,
 Akin to \c WT_TIME_AGGREGATE_UPDATE but for a \c WT_PAGE_DELETED; used in internal page
 reconciliation.}
+@row{timestamp_inline.h, Macro, \c WT_TIME_AGGREGATE_APPLY_PAGE_DEL,
+Replace the stop information in an aggregate unpacked from a \c WT_CELL_ADDR_DEL cell with the
+global stop point supplied by its \c WT_PAGE_DELETED; the unpacked stop information describes
+the child page before the truncate and cannot be used as-is.}
 
 @row{txn_inline.h, Function, \c __wt_txn_op_delete_apply_prepare_state,
 The code for updating \c WT_PAGE_DELETED at prepare time.}
@@ -713,8 +717,12 @@ page type.}
 @row{bt_vrfy.c, Hook, in \c __verify_tree,
 Allow namespace gaps in VLCS.}
 @row{bt_vrfy.c, Hook, in \c __verify_page_content_int,
-Handle deleted-address cells.}
+Handle deleted-address cells: validate the effective aggregate\, that is\, the unpacked
+aggregate with the page deletion applied as its stop point.}
 
+@row{bt_vrfy_dsk.c, Hook, in \c __verify_dsk_addr_validity,
+Validate the effective aggregate for deleted-address cells rather than the stale stop
+information unpacked from the cell.}
 @row{bt_vrfy_dsk.c, Function, \c __verify_dsk_addr_page_del,
 Validate and crosscheck the page deletion information discovered in on-disk address
 cells.}

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -244,6 +244,21 @@
             (ta)->oldest_stop_txn = WT_MIN((page_del)->txnid, (ta)->oldest_stop_txn);     \
     } while (0)
 
+/*
+ * Apply a page deletion as the global stop point for every record in an aggregate. The aggregate
+ * unpacked from a deleted-address cell describes the child page as it was before the truncate, so
+ * its stop information is stale and must be replaced rather than merged.
+ */
+#define WT_TIME_AGGREGATE_APPLY_PAGE_DEL(ta, page_del)                                \
+    do {                                                                              \
+        (ta)->newest_stop_durable_ts = (page_del)->pg_del_durable_ts;                 \
+        (ta)->newest_txn = (page_del)->txnid;                                         \
+        (ta)->newest_stop_ts = (page_del)->pg_del_start_ts;                           \
+        (ta)->newest_stop_txn = (page_del)->txnid;                                    \
+        if ((page_del)->txnid != WT_TXN_NONE)                                         \
+            (ta)->oldest_stop_txn = WT_MIN((page_del)->txnid, (ta)->oldest_stop_txn); \
+    } while (0)
+
 /* Merge an aggregated time window into another - choosing the most conservative value from each. */
 #define WT_TIME_AGGREGATE_MERGE(session, dest, source)                                        \
     do {                                                                                      \

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -245,11 +245,11 @@
     } while (0)
 
 /*
- * Apply a page deletion as the global stop point for every record in an aggregate. The aggregate
+ * Merge a page deletion as the global stop point for every record in an aggregate. The aggregate
  * unpacked from a deleted-address cell describes the child page as it was before the truncate, so
- * its stop information is stale and must be replaced rather than merged.
+ * its stop information is stale and must be replaced.
  */
-#define WT_TIME_AGGREGATE_APPLY_PAGE_DEL(ta, page_del)                                \
+#define WT_TIME_AGGREGATE_MERGE_PAGE_DEL(ta, page_del)                                \
     do {                                                                              \
         (ta)->newest_stop_durable_ts = (page_del)->pg_del_durable_ts;                 \
         (ta)->newest_txn = (page_del)->txnid;                                         \

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -236,3 +236,57 @@ TEST_CASE("Cell Fast Truncate: prepare flag on non-fast-truncate addr cell marks
     CHECK(unpack.page_del.txnid == 0);
     CHECK(unpack.page_del.selected_for_write == false);
 }
+
+TEST_CASE("Cell Fast Truncate: effective aggregate is contained by an old wide parent",
+  "[cell][fast_truncate][time_aggregate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    build_ft_addr_del_cell(&cell, false, 10, 20, 30);
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    WT_TIME_AGGREGATE effective_ta, old_parent;
+    WT_TIME_AGGREGATE_COPY(&effective_ta, &unpack.ta);
+    WT_TIME_AGGREGATE_MERGE_PAGE_DEL(&effective_ta, &unpack.page_del);
+    WT_TIME_AGGREGATE_COPY(&old_parent, &effective_ta);
+    old_parent.newest_stop_ts = WT_TS_MAX;
+    old_parent.newest_stop_txn = WT_TXN_MAX;
+
+    CHECK(effective_ta.newest_stop_ts == 20);
+    CHECK(old_parent.newest_stop_ts == WT_TS_MAX);
+    CHECK(__wt_time_aggregate_validate(session, &effective_ta, &old_parent, true) == 0);
+}
+
+TEST_CASE("Cell Fast Truncate: effective aggregate is required by a tightened parent",
+  "[cell][fast_truncate][time_aggregate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    build_ft_addr_del_cell(&cell, false, 10, 20, 30);
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    WT_TIME_AGGREGATE effective_ta, tightened_parent;
+    WT_TIME_AGGREGATE_COPY(&effective_ta, &unpack.ta);
+    WT_TIME_AGGREGATE_MERGE_PAGE_DEL(&effective_ta, &unpack.page_del);
+    WT_TIME_AGGREGATE_COPY(&tightened_parent, &effective_ta);
+
+    CHECK(unpack.ta.newest_stop_ts == WT_TS_MAX);
+    CHECK(effective_ta.newest_stop_ts == 20);
+    CHECK(tightened_parent.newest_stop_ts == 20);
+    CHECK(__wt_time_aggregate_validate(session, &unpack.ta, &tightened_parent, true) == EINVAL);
+    CHECK(__wt_time_aggregate_validate(session, &effective_ta, &tightened_parent, true) == 0);
+}


### PR DESCRIPTION
[WT-18495](https://jira.mongodb.org/browse/WT-18495)

First of three stacked changes. Review this one first; WT-18496 (#14557) and WT-18406 stack on it.

## Problem

The time aggregate stored in a `WT_CELL_ADDR_DEL` cell predates the truncate. After truncate, the accurate stop point is the cell's `page_del` information, not the on-disk aggregate.

Verification compared that on-disk aggregate against the parent. That is the wrong check: the parent should be allowed to follow `page_del`, and the stale cell aggregate must not be used to reject it.

## Solution

Introduce `WT_TIME_AGGREGATE_APPLY_PAGE_DEL`, which replaces the stale stop information in an unpacked deleted-address aggregate with the truncate's stop point. Both verification paths (`__verify_page_content_int` and `__verify_dsk_addr_validity`) validate that effective aggregate against the parent instead of the raw cell.

The page-deletion check (`__verify_dsk_addr_page_del`) no longer repeats the parent-aggregate validation the validity-window path already performs on the same cell. It still checks that the cell's own stop information does not run past the truncate.

The packed cell is unchanged; only what verification compares against the parent changes. That is what lets WT-18496 write a tightened parent aggregate without failing verify.

## Notes

* WT-18495 (this) — verifier accepts effective aggregates.
* WT-18496 — reconciliation persists effective aggregates (#14557).
* WT-18406 — skip internal pages whose subtree is entirely deleted and visible.

## Testing

No dedicated regression test on this PR: the verifier change is not observable until a parent aggregate is actually tightened, which is WT-18496. `test_truncate33.py` on that PR fails verify without this change and passes with it.

`dist/s_all` clean; full build clean.
