### PR TITLE
WT-18496 Build internal page aggregates from the effective aggregate of deleted children

### DIFF
--- a/src/docs/arch-fast-truncate.dox
+++ b/src/docs/arch-fast-truncate.dox
@@ -306,6 +306,11 @@ deleted the page.
 Prepared truncations cannot be represented on disk.
 Truncations that are globally visible do not result in a cell in the parent page at all.)
 
+The time aggregate packed in the cell describes the child page as it was before the
+truncate, so its stop information is stale.
+The effective aggregate for the deleted pages is the packed one with the truncate applied as
+its global stop point, and that is what the parent page's aggregate is built from.
+
 These fields are, however, only present if the page header includes the \c
 WT_PAGE_FT_UPDATE flag, whose value is 0x20.
 Proper support for timestamped fast-truncate only appeared in WT 11.0; earlier versions
@@ -616,7 +621,8 @@ reconciliation.}
 @row{timestamp_inline.h, Macro, \c WT_TIME_AGGREGATE_MERGE_PAGE_DEL,
 Replace the stop information in an aggregate unpacked from a \c WT_CELL_ADDR_DEL cell with the
 global stop point supplied by its \c WT_PAGE_DELETED; the unpacked stop information describes
-the child page before the truncate and cannot be used as-is.}
+the child page before the truncate and cannot be used as-is. Used by internal page
+reconciliation and verification.}
 
 @row{txn_inline.h, Function, \c __wt_txn_op_delete_apply_prepare_state,
 The code for updating \c WT_PAGE_DELETED at prepare time.}

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -111,13 +111,12 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
     WT_PAGE_DELETED *page_del;
     WTI_REC_KV *val;
     WT_REF *ref;
-    WT_TIME_AGGREGATE ft_ta, ta;
+    WT_TIME_AGGREGATE ta;
 
     btree = S2BT(session);
     page = pageref->page;
     child = NULL;
     WT_TIME_AGGREGATE_INIT(&ta);
-    WT_TIME_AGGREGATE_INIT_MERGE(&ft_ta);
 
     val = &r->v;
     vpack = &_vpack;
@@ -207,8 +206,9 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
             }
             WT_TIME_AGGREGATE_COPY(&ta, &vpack->ta);
         }
+        /* A fast-truncate supplies the global stop point for every record on the child page. */
         if (page_del != NULL)
-            WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
+            WT_TIME_AGGREGATE_MERGE_PAGE_DEL(&ta, page_del);
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, val->len))
@@ -220,8 +220,6 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
          */
         __wti_rec_image_copy(session, r, val);
         WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
-        if (page_del != NULL)
-            WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
         WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
     }
     WT_INTL_FOREACH_END;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -534,7 +534,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     WT_PAGE_DELETED *page_del;
     WTI_REC_KV *key, *val;
     WT_REF *ref;
-    WT_TIME_AGGREGATE ft_ta, *source_ta, ta;
+    WT_TIME_AGGREGATE *source_ta, ta;
     size_t size;
     bool build_delta, cell_zero_tmp, prev_dirty, retain_onpage;
     const void *p;
@@ -542,7 +542,6 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     btree = S2BT(session);
     child = NULL;
     ref = NULL;
-    WT_TIME_AGGREGATE_INIT_MERGE(&ft_ta);
 
     key = &r->k;
     kpack = &_kpack;
@@ -777,12 +776,9 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         WT_TIME_AGGREGATE_COPY(&ta, source_ta);
 
-        /*
-         * Track the time window. The fast-truncate is a stop time window and has to be considered
-         * in the internal page's aggregate information for RTS to find it.
-         */
+        /* A fast-truncate supplies the global stop point for every record on the child page. */
         if (page_del != NULL)
-            WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
+            WT_TIME_AGGREGATE_MERGE_PAGE_DEL(&ta, page_del);
 
         F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);
 
@@ -809,8 +805,6 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             WT_ERR(__rec_pack_delta_row_int(session, r, key, val, &ta));
         WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
 
-        if (page_del != NULL)
-            WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
         WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
 
         /* Update compression state. */

--- a/test/suite/test_truncate33.py
+++ b/test/suite/test_truncate33.py
@@ -88,16 +88,21 @@ class test_truncate33(wttest.WiredTigerTestCase, suite_subprocess):
             stop_cursor.set_key(self.trunc_stop)
             self.session.truncate(None, start_cursor, stop_cursor, None)
 
-    def internal_page_stop_timestamps(self, dumpfile):
-        """Collect the aggregate stop timestamp of every internal page in a dump_address run."""
+    def internal_page_timestamps(self, dumpfile):
+        """Collect stop timestamps of every internal page in a dump_address run."""
         stops = []
+        durable_stops = []
         for line in open(dumpfile).readlines():
             if 'row-store internal' not in line:
                 continue
+            durable_match = re.search(r'newest_durable: \(\d+, \d+\)/\((\d+), (\d+)\)', line)
             match = re.search(r'newest_stop: \((\d+), (\d+)\)', line)
+            if durable_match:
+                durable_stops.append((int(durable_match.group(1)) << 32) +
+                    int(durable_match.group(2)))
             if match:
                 stops.append((int(match.group(1)) << 32) + int(match.group(2)))
-        return stops
+        return stops, durable_stops
 
     def test_truncate_internal_page_aggregate(self):
         self.populate()
@@ -110,10 +115,12 @@ class test_truncate33(wttest.WiredTigerTestCase, suite_subprocess):
 
         self.runWt(['verify', '-d', 'dump_address', self.uri, '-d'], outfilename='dump.out')
 
-        stops = self.internal_page_stop_timestamps('dump.out')
+        stops, durable_stops = self.internal_page_timestamps('dump.out')
         self.assertGreater(len(stops), 1, 'expected a tree with more than one internal page')
         self.assertIn(self.truncate_ts, stops,
             'no internal page aggregate records the truncate as its stop point')
+        self.assertIn(self.truncate_ts, durable_stops,
+            'no internal page aggregate records the truncate as its durable stop point')
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_truncate33.py
+++ b/test/suite/test_truncate33.py
@@ -30,7 +30,7 @@ import re
 import wttest
 from suite_subprocess import suite_subprocess
 
-# Test that an internal page whose children are all fast-truncated records the truncate's
+# Test that an internal page whose children are all fast-truncated records the truncate
 # stop point in its address aggregate. The aggregate written in a child's deleted-address
 # cell describes the child as it was before the truncate, so a parent built by merging
 # those cells unchanged claims its records never stop.

--- a/test/suite/test_truncate33.py
+++ b/test/suite/test_truncate33.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re
+import wttest
+from suite_subprocess import suite_subprocess
+
+# Test that an internal page whose children are all fast-truncated records the truncate's
+# stop point in its address aggregate. The aggregate written in a child's deleted-address
+# cell describes the child as it was before the truncate, so a parent built by merging
+# those cells unchanged claims its records never stop.
+class test_truncate33(wttest.WiredTigerTestCase, suite_subprocess):
+    conn_config = 'cache_size=50MB,statistics=(all)'
+    uri = 'table:test_truncate33'
+
+    # Small pages give a three-level tree, roughly 200 leaves under 10 internal pages, so
+    # the truncated range covers every child of several internal pages with room to spare.
+    create_cfg = ('key_format=i,value_format=S,allocation_size=512,leaf_page_max=512,'
+                  'internal_page_max=512,memory_page_max=4096')
+
+    nrows = 1000
+    value = 'a' * 50
+    trunc_start = 100
+    trunc_stop = 900
+    truncate_ts = 20
+
+    def evict_all(self):
+        with (
+            wttest.open_cursor(
+                self.session, self.uri, config='debug=(release_evict)'
+            ) as evict_cursor,
+            self.transaction(rollback=True),
+        ):
+            for key in range(1, self.nrows + 1):
+                evict_cursor.set_key(key)
+                evict_cursor.search()
+                evict_cursor.reset()
+
+    def populate(self):
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.session.create(self.uri, self.create_cfg)
+
+        with (
+            wttest.open_cursor(self.session, self.uri) as cursor,
+            self.transaction(commit_timestamp=10),
+        ):
+            for key in range(1, self.nrows + 1):
+                cursor[key] = self.value
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        # Fast-truncate only applies to children that are already on disk.
+        self.evict_all()
+
+    def fast_truncate(self):
+        with (
+            wttest.open_cursor(self.session, self.uri) as start_cursor,
+            wttest.open_cursor(self.session, self.uri) as stop_cursor,
+            self.transaction(commit_timestamp=self.truncate_ts),
+        ):
+            start_cursor.set_key(self.trunc_start)
+            stop_cursor.set_key(self.trunc_stop)
+            self.session.truncate(None, start_cursor, stop_cursor, None)
+
+    def internal_page_stop_timestamps(self, dumpfile):
+        """Collect the aggregate stop timestamp of every internal page in a dump_address run."""
+        stops = []
+        for line in open(dumpfile).readlines():
+            if 'row-store internal' not in line:
+                continue
+            match = re.search(r'newest_stop: \((\d+), (\d+)\)', line)
+            if match:
+                stops.append((int(match.group(1)) << 32) + int(match.group(2)))
+        return stops
+
+    def test_truncate_internal_page_aggregate(self):
+        self.populate()
+        self.fast_truncate()
+
+        # Leave oldest behind the truncate so the deletions are not globally visible: the
+        # children are written as deleted-address cells rather than being discarded.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(self.truncate_ts))
+        self.session.checkpoint()
+
+        self.runWt(['verify', '-d', 'dump_address', self.uri, '-d'], outfilename='dump.out')
+
+        stops = self.internal_page_stop_timestamps('dump.out')
+        self.assertGreater(len(stops), 1, 'expected a tree with more than one internal page')
+        self.assertIn(self.truncate_ts, stops,
+            'no internal page aggregate records the truncate as its stop point')
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
[WT-18496](https://jira.mongodb.org/browse/WT-18496)

Stacked on #14556 (WT-18495) — review that one first; this PR's base will be switched to `develop` once it lands.

## Problem

Internal page reconciliation merged two things into the parent aggregate for a fast-truncated child: the child's own aggregate, and separately the truncate's stop point.

The child's aggregate describes the page as it was *before* the truncate, so its stop information is stale — typically `newest_stop_ts = WT_TS_MAX`, meaning "these records never stop". Merging that keeps the parent claiming the same thing, even though the entire subtree has been deleted at a known timestamp. An internal page all of whose children were truncated ends up with an aggregate indistinguishable from one holding live data.

## Solution

Apply the page deletion to the child aggregate as its global stop point before merging it, so the parent bounds the deleted subtree:

```
WT_TIME_AGGREGATE_COPY(&ta, source_ta);
if (page_del != NULL)
    WT_TIME_AGGREGATE_APPLY_PAGE_DEL(&ta, page_del);
...
WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
```

The child's own cell has already been built at that point, so its packed aggregate is unchanged; only the parent's aggregate tightens. `WT_TIME_AGGREGATE_UPDATE_PAGE_DEL` has no remaining callers and is removed.

Verification accepts these aggregates as of WT-18495, which is why that change lands first: a build without it would fail verification on files written here.

## Notes

Second of three stacked changes.

* WT-18495 — verifier accepts effective aggregates (#14556).
* WT-18496 (this) — reconciliation persists effective aggregates.
* WT-18406 — skip internal pages whose subtree is entirely deleted and visible.

## Testing

New `test_truncate33.py` fast-truncates every child of several internal pages, checkpoints with the deletions committed but not globally visible, and reads the resulting aggregates back with `wt verify -d dump_address`. It asserts that an internal page records the truncate timestamp as its aggregate stop point.

Confirmed to fail without the change — every internal page reports `newest_stop` of `WT_TS_MAX`:

```
AssertionError: 20 not found in [18446744073709551615, ... ] :
no internal page aggregate records the truncate as its stop point
```

`dist/s_all` clean; full build clean; `truncate` (235), `verify` (36) and `rollback_to_stable` (1548) suites pass.
