### PR TITLE
WT-16494 Ensure checkpoint order is strictly increasing across nodes in disagg

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3276,6 +3276,13 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
 
         fake_ckpt = true;
         __wt_checkpoint_update_generation(session, btree);
+
+        if (__wt_conn_is_disagg(session)) {
+            /* Disaggregated storage requires fake checkpoints to be resolved. */
+            WT_ERR(bm->checkpoint_start(bm, session));
+            resolve_bm = true;
+        }
+
         goto fake;
     }
 

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -73,6 +73,7 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
     checkpoint_order = checkpoint_order_new = 0;
     checkpoint_time = checkpoint_time_new = 0;
     *checkpoint_name = checkpoint_name_new = NULL;
+    *discardp = false;
 
     WT_ERR_NOTFOUND_OK(__wt_ckpt_last_name(session, cfg_current, checkpoint_name, &checkpoint_order,
                          &checkpoint_time),
@@ -80,7 +81,6 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
     /* Early exit if we can't find the configuration of last checkpoint. */
     if (ret == WT_NOTFOUND) {
         WT_ASSERT(session, *checkpoint_name == NULL);
-        *discardp = false;
         return (0);
     }
 
@@ -93,16 +93,31 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
       true);
     if (ret == WT_NOTFOUND) {
         WT_ASSERT(session, checkpoint_name_new == NULL);
-        *discardp = false;
         return (0);
     }
 
-    /*
-     * Treat the checkpoint order and time configurations as the source of truth when determining
-     * whether the checkpoint has changed.
-     */
-    *discardp =
-      !(checkpoint_order == checkpoint_order_new && checkpoint_time == checkpoint_time_new);
+    if (checkpoint_order == checkpoint_order_new) {
+        /*
+         * Checkpoint orders are strictly increasing if the checkpoints are written by different
+         * nodes.
+         */
+        if (checkpoint_time != checkpoint_time_new) {
+            /* FIXME-WT-17599: escalate the warning to an error. */
+            __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
+              "Checkpoint order should be strictly increasing. "
+              "Current checkpoint order: %" PRId64 ", time: %" PRIu64
+              ". New checkpoint order: %" PRId64 ", time: %" PRIu64
+              ". Current configuration: '%s'. New configuration: '%s'.",
+              checkpoint_order, checkpoint_time, checkpoint_order_new, checkpoint_time_new,
+              cfg_current, cfg_new);
+            *discardp = true;
+        }
+    } else
+        /*
+         * Treat the checkpoint order configurations as the source of truth when determining whether
+         * the checkpoint has changed.
+         */
+        *discardp = true;
 
 #ifdef HAVE_DIAGNOSTIC
     if (!*discardp)
@@ -707,9 +722,6 @@ __disagg_update_file_meta(
     /*
      * Mark any matching data handles associated with the previous checkpoint to be out of date. Any
      * new opens will get the new metadata.
-     *
-     * FIXME-WT-16494: How to decide two checkpoints are different if they are written by different
-     * nodes?
      */
     WT_ERR(__disagg_discard_old_checkpoint_check(
       session, current_value_copy, cfg_ret, &checkpoint_name, &discard));

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -57,6 +57,33 @@ err:
 }
 
 /*
+ * __disagg_ckpt_addr --
+ *     Return the address of the named checkpoint in the given metadata config string. Return
+ *     WT_NOTFOUND if there is no such checkpoint, or if it has no address.
+ */
+static int
+__disagg_ckpt_addr(WT_SESSION_IMPL *session, const char *config, const char *name, char **addrp)
+{
+    WT_CONFIG ckptconf;
+    WT_CONFIG_ITEM a, k, v;
+
+    *addrp = NULL;
+
+    WT_RET(__wt_config_getones(session, config, "checkpoint", &v));
+    __wt_config_subinit(session, &ckptconf, &v);
+
+    /* There is never more than a single checkpoint of any name, so take the first match. */
+    while (__wt_config_next(&ckptconf, &k, &v) == 0) {
+        if (!WT_CONFIG_MATCH(name, k))
+            continue;
+        WT_RET(__wt_config_subgets(session, &v, "addr", &a));
+        return (__wt_strndup(session, a.str, a.len, addrp));
+    }
+
+    return (WT_NOTFOUND);
+}
+
+/*
  * __disagg_discard_old_checkpoint_check --
  *     Compare the checkpoint name in the old and new metadata config strings. Check if they are the
  *     same checkpoint. If the checkpoint has advanced, the old one can be discarded.
@@ -66,18 +93,17 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
   const char *cfg_new, const char **checkpoint_name, bool *discardp)
 {
     WT_DECL_RET;
-    uint64_t checkpoint_time, checkpoint_time_new;
     int64_t checkpoint_order, checkpoint_order_new;
+    char *checkpoint_addr, *checkpoint_addr_new;
     const char *checkpoint_name_new;
 
     checkpoint_order = checkpoint_order_new = 0;
-    checkpoint_time = checkpoint_time_new = 0;
+    checkpoint_addr = checkpoint_addr_new = NULL;
     *checkpoint_name = checkpoint_name_new = NULL;
     *discardp = false;
 
-    WT_ERR_NOTFOUND_OK(__wt_ckpt_last_name(session, cfg_current, checkpoint_name, &checkpoint_order,
-                         &checkpoint_time),
-      true);
+    WT_ERR_NOTFOUND_OK(
+      __wt_ckpt_last_name(session, cfg_current, checkpoint_name, &checkpoint_order, NULL), true);
     /* Early exit if we can't find the configuration of last checkpoint. */
     if (ret == WT_NOTFOUND) {
         WT_ASSERT(session, *checkpoint_name == NULL);
@@ -88,8 +114,8 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
      * It is possible that the new checkpoint is empty (e.g. all disagg tables were dropped). The
      * state has still advanced, so discard the old checkpoint.
      */
-    WT_ERR_NOTFOUND_OK(__wt_ckpt_last_name(session, cfg_new, &checkpoint_name_new,
-                         &checkpoint_order_new, &checkpoint_time_new),
+    WT_ERR_NOTFOUND_OK(
+      __wt_ckpt_last_name(session, cfg_new, &checkpoint_name_new, &checkpoint_order_new, NULL),
       true);
     if (ret == WT_NOTFOUND) {
         WT_ASSERT(session, checkpoint_name_new == NULL);
@@ -97,18 +123,24 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
     }
 
     if (checkpoint_order == checkpoint_order_new) {
+        WT_ERR(__disagg_ckpt_addr(session, cfg_current, *checkpoint_name, &checkpoint_addr));
+        WT_ERR(__disagg_ckpt_addr(session, cfg_new, checkpoint_name_new, &checkpoint_addr_new));
+        WT_ASSERT(session, checkpoint_addr != NULL && checkpoint_addr_new != NULL);
+
         /*
          * Checkpoint orders are strictly increasing if the checkpoints are written by different
-         * nodes.
+         * nodes, so the same order must specify the same checkpoint address.
          */
-        if (checkpoint_time != checkpoint_time_new) {
+        if (strcmp(checkpoint_addr, checkpoint_addr_new) != 0) {
             /* FIXME-WT-17599: escalate the warning to an error. */
             __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Checkpoint order should be strictly increasing. "
-              "Current checkpoint order: %" PRId64 ", time: %" PRIu64
-              ". New checkpoint order: %" PRId64 ", time: %" PRIu64
-              ". Current configuration: '%s'. New configuration: '%s'.",
-              checkpoint_order, checkpoint_time, checkpoint_order_new, checkpoint_time_new,
+              "Current checkpoint order: %" PRId64
+              ", address: '%s'. "
+              "New checkpoint order: %" PRId64
+              ", address: '%s'. "
+              "Current configuration: '%s'. New configuration: '%s'.",
+              checkpoint_order, checkpoint_addr, checkpoint_order_new, checkpoint_addr_new,
               cfg_current, cfg_new);
             *discardp = true;
         }
@@ -124,6 +156,8 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *cfg_
         WT_ASSERT(session, strcmp(*checkpoint_name, checkpoint_name_new) == 0);
 #endif
 err:
+    __wt_free(session, checkpoint_addr);
+    __wt_free(session, checkpoint_addr_new);
     __wt_free(session, checkpoint_name_new);
     return (ret);
 }

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -66,6 +66,7 @@ __disagg_ckpt_addr(WT_SESSION_IMPL *session, const char *config, const char *nam
 {
     WT_CONFIG ckptconf;
     WT_CONFIG_ITEM a, k, v;
+    WT_DECL_RET;
 
     *addrp = NULL;
 
@@ -73,14 +74,14 @@ __disagg_ckpt_addr(WT_SESSION_IMPL *session, const char *config, const char *nam
     __wt_config_subinit(session, &ckptconf, &v);
 
     /* There is never more than a single checkpoint of any name, so take the first match. */
-    while (__wt_config_next(&ckptconf, &k, &v) == 0) {
+    while ((ret = __wt_config_next(&ckptconf, &k, &v)) == 0) {
         if (!WT_CONFIG_MATCH(name, k))
             continue;
         WT_RET(__wt_config_subgets(session, &v, "addr", &a));
         return (__wt_strndup(session, a.str, a.len, addrp));
     }
 
-    return (WT_NOTFOUND);
+    return (ret);
 }
 
 /*

--- a/test/suite/test_key_provider_disagg02.py
+++ b/test/suite/test_key_provider_disagg02.py
@@ -75,7 +75,7 @@ class test_key_provider_disagg02(KeyProviderBase, suite_subprocess):
         self.session.checkpoint(f"debug=(checkpoint_crash_trigger_point={self.crash_point})") # Expected to fail
 
     def test_key_provider_disagg02(self):
-        self.conn.close()
+        self.conn.close('debug=(skip_checkpoint=true)')
 
         subdir = 'SUBPROCESS'
         new_home_dir = self.crash_in_subprocess(subdir,

--- a/test/suite/test_key_provider_disagg04.py
+++ b/test/suite/test_key_provider_disagg04.py
@@ -101,6 +101,10 @@ class test_key_provider_disagg04(KeyProviderBase):
         self.key_provider_version = self.start_version
         self.reopen_conn()
 
+        # The first checkpoint persists a key even though nothing has been written yet, so this
+        # reopen loads one back at timestamp zero. The restarts below assert on the message.
+        self.ignoreStdoutPatternIfExists(r'Loading persisted crypt key: lsn=\d+, timestamp=0')
+
         ds1 = SimpleDataSet(self, self.uri, self.nentries)
         ds1.populate()
         self.write_and_checkpoint()

--- a/test/suite/test_layered_checkpoint16.py
+++ b/test/suite/test_layered_checkpoint16.py
@@ -92,22 +92,32 @@ class test_layered_checkpoint16(wttest.WiredTigerTestCase):
         self.assertGreater(value, expected_value)
 
     def test_layered_checkpoint16(self):
-        self.session.create(self.uri, 'key_format=S,value_format=S')
-        self.insert_data(self.session, 'v1-', 10)
-        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
-        self.session.checkpoint()
-
+        # Open the follower.
         conn_follow = self.wiredtiger_open(
             'follower',
             self.extensionsConfig() + ',create,' + self.conn_base_config +
             'disaggregated=(role="follower")')
         session_follow = conn_follow.open_session('')
 
-        # First pick-up: Entries are new to the follower's local metadata, so they are inserted.
+        # Create an initial checkpoint on the leader and pick it up on the follower to establish
+        # the baseline metadata state, e.g., picking up the shared history store.
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+        initial_meta_inserted = self.get_stat(session_follow, stat.conn.disagg_pick_up_file_meta_inserted)
+        initial_meta_updated = self.get_stat(session_follow, stat.conn.disagg_pick_up_file_meta_updated)
+
+        # Create the table on the leader and insert some data.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.insert_data(self.session, 'v1-', 10)
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
+        self.session.checkpoint()
+
+        # First pick-up after create: Entries are new to the follower's local metadata, so they are inserted.
         self.disagg_advance_checkpoint(conn_follow)
         self.check_data(session_follow, 'v1-')
-        self.assertStatGreater(session_follow, stat.conn.disagg_pick_up_file_meta_inserted, 0)
-        self.assertStatEqual(session_follow, stat.conn.disagg_pick_up_file_meta_updated, 0)
+        self.assertStatGreater(session_follow, stat.conn.disagg_pick_up_file_meta_inserted, initial_meta_inserted)
+        self.assertStatEqual(session_follow, stat.conn.disagg_pick_up_file_meta_updated, initial_meta_updated)
         inserted_after_first = self.get_stat(session_follow, stat.conn.disagg_pick_up_file_meta_inserted)
 
         # Create a new checkpoint without changing the table data, then pick it up.
@@ -116,7 +126,7 @@ class test_layered_checkpoint16(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
         self.check_data(session_follow, 'v1-')
         self.assertStatEqual(session_follow, stat.conn.disagg_pick_up_file_meta_inserted, inserted_after_first)
-        self.assertStatEqual(session_follow, stat.conn.disagg_pick_up_file_meta_updated, 0)
+        self.assertStatEqual(session_follow, stat.conn.disagg_pick_up_file_meta_updated, initial_meta_updated)
 
         # Now change the table, create a checkpoint, and pick it up. The metadata must be updated.
         self.insert_data(self.session, 'v2-', 20)
@@ -125,7 +135,7 @@ class test_layered_checkpoint16(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
         self.check_data(session_follow, 'v2-')
         self.assertStatEqual(session_follow, stat.conn.disagg_pick_up_file_meta_inserted, inserted_after_first)
-        self.assertStatGreater(session_follow, stat.conn.disagg_pick_up_file_meta_updated, 0)
+        self.assertStatGreater(session_follow, stat.conn.disagg_pick_up_file_meta_updated, initial_meta_updated)
 
         session_follow.close()
         conn_follow.close()

--- a/test/suite/test_layered_checkpoint17.py
+++ b/test/suite/test_layered_checkpoint17.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# A node that checkpoints a table while it is still empty records a checkpoint for it without
+# writing any pages. Hand leadership to a second node, have it write the table's first real
+# checkpoint, and hand leadership back. Every node has to see the data throughout: a node that
+# treats the new checkpoint as one it already has drops the data while believing it holds it, and
+# leading again then makes the loss permanent.
+
+@disagg_test_class
+class test_layered_checkpoint17(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    num_items = 100
+
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, [
+        ('layered-prefix', dict(prefix='layered:', table_config='')),
+        ('shared', dict(prefix='table:',
+                        table_config=',block_manager=disagg,log=(enabled=false)')),
+    ])
+
+    def insert_data(self, session, uri, value_prefix, ts):
+        session.begin_transaction()
+        cursor = session.open_cursor(uri)
+        for i in range(self.num_items):
+            cursor[str(i)] = value_prefix + str(i)
+        cursor.close()
+        session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts)}')
+
+    def check_data(self, session, uri, value_prefix):
+        cursor = session.open_cursor(uri)
+        for i in range(self.num_items):
+            self.assertEqual(cursor[str(i)], value_prefix + str(i))
+        cursor.close()
+
+    def test_layered_checkpoint17(self):
+        uri = self.prefix + self.test_name
+
+        # Node 2 starts out following node 1.
+        conn2 = self.wiredtiger_open(
+            'follower',
+            self.extensionsConfig() + ',create,' + self.conn_base_config +
+            'disaggregated=(role="follower")')
+        session2 = conn2.open_session('')
+
+        # Node 1 creates the table and checkpoints it while it is still empty, so the checkpoint it
+        # records for the table has no address behind it.
+        self.session.create(uri, 'key_format=S,value_format=S' + self.table_config)
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
+        self.session.checkpoint()
+
+        # Node 2 picks up that checkpoint, then node 1 hands over to it.
+        self.disagg_advance_checkpoint_and_wait(conn2)
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        conn2.reconfigure('disaggregated=(role="leader")')
+
+        # Node 2 writes the table's first real checkpoint.
+        self.insert_data(session2, uri, 'v1-', 20)
+        conn2.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+        session2.checkpoint()
+
+        # Node 1 picks up node 2's checkpoint and must see the data it carries.
+        self.disagg_advance_checkpoint_and_wait(self.conn, conn2)
+        self.check_data(self.session, uri, 'v1-')
+
+        # The same has to hold once node 1 leads again: an ignored checkpoint would make the loss
+        # permanent by checkpointing the table without node 2's data.
+        conn2.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.check_data(self.session, uri, 'v1-')
+
+        self.insert_data(self.session, uri, 'v2-', 30)
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(30)}')
+        self.session.checkpoint()
+
+        self.disagg_advance_checkpoint_and_wait(conn2)
+        self.check_data(session2, uri, 'v2-')
+
+        session2.close()
+        conn2.close()

--- a/test/suite/test_layered_delta06.py
+++ b/test/suite/test_layered_delta06.py
@@ -68,6 +68,12 @@ class test_layered_delta06(wttest.WiredTigerTestCase):
             cfg += ',block_manager=disagg'
         return cfg
 
+    def stable_uri(self):
+        # Only the stable constituent of a layered table is checkpointed to disaggregated storage.
+        if self.uri.startswith('file'):
+            return self.uri
+        return 'file:{}.wt_stable'.format(self.test_name)
+
     def conn_config(self):
         enc_conf = 'encryption=(name={0},{1})'.format(self.encryptor, self.encrypt_args)
         return self.conn_base_config + 'disaggregated=(role="leader"),' + enc_conf
@@ -98,8 +104,13 @@ class test_layered_delta06(wttest.WiredTigerTestCase):
         cursor[str(1)] = value2
         self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(10))
 
-        # We should skip writing the page
+        # The update is above the stable timestamp, so this checkpoint has nothing stable to write
+        # for the table and must skip writing the page.
         self.session.checkpoint()
+
+        # Assert that we have written no leaf page delta for the table. Read the statistic before
+        # switching roles: a follower does not allow access to the stable table's handle.
+        self.assertEqual(self.get_stat(stat.dsrc.rec_page_delta_leaf, uri=self.stable_uri()), 0)
 
         self.conn.reconfigure('disaggregated=(role="follower")')
 
@@ -107,6 +118,3 @@ class test_layered_delta06(wttest.WiredTigerTestCase):
         for i in range(self.nitems):
             self.assertEqual(cursor[str(i)], value1)
         self.session.rollback_transaction()
-
-        # Assert that we have written no leaf page delta.
-        self.assertEqual(self.get_stat(stat.conn.rec_page_delta_leaf), 0)

--- a/test/suite/test_layered_schema07.py
+++ b/test/suite/test_layered_schema07.py
@@ -642,16 +642,18 @@ class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
 
         # Checkpoint with stable schema epoch lower than the published epoch: the operation is
         # counted as unstable and deferred to the next checkpoint.
+        before_apply = self.get_stat(stat.conn.checkpoint_disagg_metadata_apply)
         self.set_stable_epoch(5)
         self.leader_checkpoint(1)
         self.assertStatEqualSoon(stat.conn.checkpoint_disagg_metadata_unstable, 1)
-        self.assertStatEqualSoon(stat.conn.checkpoint_disagg_metadata_apply, 0)
+        self.assertStatGreaterSoon(stat.conn.checkpoint_disagg_metadata_apply, before_apply)
 
         # Checkpoint with stable schema epoch matching the published epoch: the operation is applied.
+        before_apply = self.get_stat(stat.conn.checkpoint_disagg_metadata_apply)
         self.set_stable_epoch(10)
         self.leader_checkpoint(2)
         self.assertStatEqualSoon(stat.conn.checkpoint_disagg_metadata_unstable, 1)
-        self.assertStatEqualSoon(stat.conn.checkpoint_disagg_metadata_apply, 1)
+        self.assertStatGreaterSoon(stat.conn.checkpoint_disagg_metadata_apply, before_apply)
 
         # Publish drop with a valid epoch: success stat increments.
         self.session.drop(self.uri)

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -332,7 +332,9 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        # Open the follower and set an initial stable epoch, so that we enable the epoch-based
+        # semantics when we create missing stable tables during step up.
+        conn_follow, session_follow = self.open_follower_epoch(10)
 
         # Create uri but do not call publish.
         session_follow.create(self.uri, self.table_config)

--- a/test/suite/test_layered_schema13.py
+++ b/test/suite/test_layered_schema13.py
@@ -136,7 +136,7 @@ class test_layered_schema13(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch(10)
 
         session_follow.create(self.uri, self.table_config)
         # No schema_epoch in the config: returns success without publishing anything.


### PR DESCRIPTION
__checkpoint_tree() now resolves fake checkpoints through the block manager when the connection is disaggregated, so they take a global order like any other checkpoint. As a backstop, the checkpoint pick-up check no longer decides that two same-order checkpoints are identical by comparing their wall-clock times, which are only second-granular; it compares the checkpoint addresses instead and discards the local checkpoint when they differ. test_layered_checkpoint17 covers the handover sequence from the ticket across two nodes, for both layered and shared tables.