### PR TITLE
WT-18505 Use relaxed ordering for the log tmp_fileid atomic counter

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1555,7 +1555,7 @@ __wti_log_allocfile(WT_SESSION_IMPL *session, uint32_t lognum, const char *dest)
      */
     WT_RET(__wt_scr_alloc(session, 0, &from_path));
     WT_ERR(__wt_scr_alloc(session, 0, &to_path));
-    tmp_id = __wt_atomic_add_uint32(&log->tmp_fileid, 1);
+    tmp_id = __wt_atomic_add_uint32_relaxed(&log->tmp_fileid, 1);
     WT_ERR(__wt_log_filename(session, tmp_id, WTI_LOG_TMPNAME, from_path));
     WT_ERR(__wt_log_filename(session, lognum, dest, to_path));
     __wt_spin_lock(session, &log->log_fs_lock);


### PR DESCRIPTION
## Summary
- Switch the `log->tmp_fileid` increment in `__wti_log_allocfile` to `__wt_atomic_add_uint32_relaxed`.
- Uniqueness comes from the atomic RMW being indivisible, which holds at any memory order; the counter gates no other memory, so relaxed ordering is sufficient.
- Matches the `log->fileid` counter made relaxed in WT-16301. No functional or behavioral change.