### PR TITLE
WT-18508 Parallelize coverage analysis and upgrade gcovr

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,6 @@ RUN python -m venv /home/wiredtiger/venv
 ENV PATH="/home/wiredtiger/venv/bin:$PATH"
 
 RUN pip install --no-cache-dir \
-    find_libpython==0.4.0 gcovr==5.0 psutil==5.9.4 ruff==0.4.5 uv==0.11.18
+    find_libpython==0.4.0 gcovr==8.6 psutil==5.9.4 ruff==0.4.5 uv==0.11.18
 
 WORKDIR /workdir

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1164,8 +1164,11 @@ fwrite
 gb
 gc
 gcc
+gcda
+gcno
 gcov
 gcovr
+gcovr's
 gcp
 gdb
 gdb's
@@ -1936,6 +1939,8 @@ topologies
 totalsec
 tp
 traceapi
+tracefile
+tracefiles
 tracepat
 transactional
 transactionally

--- a/test/evergreen/code_change_report/code_change_info.py
+++ b/test/evergreen/code_change_report/code_change_info.py
@@ -127,7 +127,9 @@ def get_function_coverage(function_file: str, start_line_number: int, end_line_n
         if file_data['file'] == function_file:
             for line_info in file_data['lines']:
                 if start_line_number <= line_info['line_number'] <= end_line_number:
-                    if not line_info['gcovr/noncode']:
+                    # gcovr 6.0+ omits non-code lines from the report entirely; older
+                    # versions included them with a flag.
+                    if not line_info.get('gcovr/noncode', False):
                         num_lines_in_function += 1
                         if int(line_info['count']) > 0:
                             num_covered_lines_in_function += 1

--- a/test/evergreen/code_coverage/README.md
+++ b/test/evergreen/code_coverage/README.md
@@ -70,9 +70,11 @@ The configuration of the setup operations and the test tasks is defined in
 directory in parallel, and the test tasks are put into buckets (one for each build tree) and then each bucket
 is executed in parallel.
 
-`gcovr` searches a directory (in this case the `wiredtiger` directory) and all subdirectories (ie including all the
-`build_` directories) for code coverage data. This means that it is not necessary to tell `gcovr` how many build 
-directories there are.
+To generate the reports, [parallel_gcovr.py](parallel_gcovr.py) searches the `wiredtiger` directory and all
+subdirectories (ie including all the `build_` directories) for code coverage data, and splits the data files across
+multiple parallel `gcovr` processes, each producing a JSON tracefile. A single `gcovr` process cannot use multiple
+cores for this work because its `-j` option only creates threads, which are GIL-bound while parsing gcov output.
+The tracefiles are then merged with `gcovr --add-tracefile` to produce the combined report.
 
 
 ## Potential areas for improvement

--- a/test/evergreen/code_coverage/coverage-report-per-test.sh
+++ b/test/evergreen/code_coverage/coverage-report-per-test.sh
@@ -26,7 +26,7 @@ mkdir -p coverage_report
 # Setup the Python environment
 virtualenv -p python3 venv
 source venv/bin/activate
-pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0 pygit2==1.10.1 requests
+pip3 install gcovr==8.6 pygit2==1.10.1 requests
 
 ######################################################
 # Obtain the complexity metrics for the 'current' code

--- a/test/evergreen/code_coverage/parallel_gcovr.py
+++ b/test/evergreen/code_coverage/parallel_gcovr.py
@@ -35,6 +35,7 @@
 import argparse
 import logging
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -78,6 +79,17 @@ def split_into_groups(data_files, num_groups):
     return [group for group in groups if group]
 
 
+def gcov_major_version():
+    # Version of the gcov resolved from PATH, which is the one gcovr will run.
+    try:
+        output = subprocess.run(["gcov", "--version"], capture_output=True,
+                                text=True, check=True).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    match = re.search(r"\s(\d+)\.\d+\.\d+", output)
+    return int(match.group(1)) if match else None
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-j', '--jobs', default=os.cpu_count(), type=int,
@@ -95,6 +107,18 @@ def main():
 
     if args.jobs < 1:
         sys.exit("Number of jobs must be >= 1")
+
+    # Only gcov 12 and newer name their intermediate files uniquely per data
+    # file; older versions hash the source path, so concurrent gcovr
+    # processes handling the same sources clobber each other's files, and gcovr's
+    # directory lock only guards against its own threads.
+    if args.jobs > 1:
+        gcov_version = gcov_major_version()
+        if gcov_version is None or gcov_version < 12:
+            logging.warning(
+                "gcov major version is %s; parallel gcovr processes require >= 12, "
+                "falling back to a single process", gcov_version)
+            args.jobs = 1
 
     data_files = find_coverage_data(args.search_dir)
     if not data_files:

--- a/test/evergreen/code_coverage/parallel_gcovr.py
+++ b/test/evergreen/code_coverage/parallel_gcovr.py
@@ -104,7 +104,13 @@ def main():
     logging.info("Converting %d coverage data files using %d gcovr processes",
                  len(data_files), len(groups))
 
+    # Remove tracefiles left by a previous run: the merge step globs every JSON
+    # file in this directory, so stale ones would be double-counted.
     os.makedirs(args.output_dir, exist_ok=True)
+    for name in os.listdir(args.output_dir):
+        if name.endswith(".json"):
+            os.remove(os.path.join(args.output_dir, name))
+
     start_time = datetime.now()
     processes = list()
     for index, group in enumerate(groups):

--- a/test/evergreen/code_coverage/parallel_gcovr.py
+++ b/test/evergreen/code_coverage/parallel_gcovr.py
@@ -92,7 +92,7 @@ def gcov_major_version():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-j', '--jobs', default=os.cpu_count(), type=int,
+    parser.add_argument('-j', '--jobs', default=os.cpu_count() or 1, type=int,
                         help='How many gcovr processes to run in parallel')
     parser.add_argument('-f', '--filter', default='src',
                         help='gcovr filter for source files to report on')

--- a/test/evergreen/code_coverage/parallel_gcovr.py
+++ b/test/evergreen/code_coverage/parallel_gcovr.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Convert raw coverage data (.gcda/.gcno) into gcovr JSON tracefiles using multiple
+# gcovr processes. gcovr's own -j option only creates threads, which are GIL-bound
+# while parsing gcov output, so process-level parallelism is required to use more
+# than one core. The tracefiles this script produces are meant to be combined with
+# 'gcovr --add-tracefile' afterwards.
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+# Flags shared by every gcovr invocation that parses raw gcov data.
+# - WiredTiger's internal functions are prefixed with '__' which gcovr would
+#   otherwise treat as compiler-generated symbols and silently exclude.
+# - Negative and suspicious counter values are expected when profiling
+#   multi-threaded programs (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080);
+#   they are recorded as zero hits.
+GCOV_PARSE_FLAGS = [
+    "--include-internal-functions",
+    "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
+    "--gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file",
+]
+
+
+def find_coverage_data(search_dir):
+    # Collect .gcda files, plus .gcno files of objects that never ran so they
+    # still show up as uncovered in the report.
+    data_files = list()
+    for root, _, files in os.walk(search_dir):
+        names = set(files)
+        for name in names:
+            if name.endswith(".gcda"):
+                data_files.append(os.path.join(root, name))
+            elif name.endswith(".gcno") and name[:-len(".gcno")] + ".gcda" not in names:
+                data_files.append(os.path.join(root, name))
+    return data_files
+
+
+def split_into_groups(data_files, num_groups):
+    # Greedily assign the largest files first to the least-loaded group so the
+    # parallel gcovr processes finish at roughly the same time.
+    groups = [list() for _ in range(num_groups)]
+    loads = [0] * num_groups
+    for path in sorted(data_files, key=os.path.getsize, reverse=True):
+        index = loads.index(min(loads))
+        groups[index].append(path)
+        loads[index] += os.path.getsize(path)
+    return [group for group in groups if group]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-j', '--jobs', default=os.cpu_count(), type=int,
+                        help='How many gcovr processes to run in parallel')
+    parser.add_argument('-f', '--filter', default='src',
+                        help='gcovr filter for source files to report on')
+    parser.add_argument('-o', '--output_dir', required=True,
+                        help='Directory to write the JSON tracefiles to')
+    parser.add_argument('-s', '--search_dir', default='.',
+                        help='Directory to search for coverage data files')
+    parser.add_argument('-v', '--verbose', action="store_true", help='Be verbose')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    if args.jobs < 1:
+        sys.exit("Number of jobs must be >= 1")
+
+    data_files = find_coverage_data(args.search_dir)
+    if not data_files:
+        sys.exit(f"No coverage data files found under {args.search_dir}")
+
+    groups = split_into_groups(data_files, args.jobs)
+    logging.info("Converting %d coverage data files using %d gcovr processes",
+                 len(data_files), len(groups))
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    start_time = datetime.now()
+    processes = list()
+    for index, group in enumerate(groups):
+        tracefile = os.path.join(args.output_dir, f"tracefile_{index:03d}.json")
+        command = ["gcovr", *GCOV_PARSE_FLAGS, "-f", args.filter,
+                   "--json", tracefile, *group]
+        logging.debug("Starting gcovr for %d data files -> %s", len(group), tracefile)
+        processes.append(subprocess.Popen(command))
+
+    failed = 0
+    for process in processes:
+        if process.wait() != 0:
+            logging.error("gcovr failed with exit code %d: %s",
+                          process.returncode, ' '.join(process.args[:20]))
+            failed += 1
+
+    elapsed = (datetime.now() - start_time).total_seconds()
+    logging.info("Finished converting coverage data in %.1f seconds", elapsed)
+
+    if failed:
+        sys.exit(f"{failed} of {len(processes)} gcovr processes failed")
+
+
+if __name__ == '__main__':
+    main()

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -106,7 +106,11 @@ def run_gcovr(build_dir_base: str, gcovr_dir: str):
                 f"task_info_path = {task_info_path}, coverage_output_dir = {coverage_output_dir}")
             os.mkdir(coverage_output_dir)
             shutil.copy(src=task_info_path, dst=coverage_output_dir)
-            gcovr_command = (f"gcovr {build_copy_name} --gcov-ignore-parse-errors -f src -j 16 "
+            gcovr_command = (f"gcovr {build_copy_name} "
+                             "--include-internal-functions "
+                             "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file "
+                             "--gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file "
+                             "-f src -j 16 "
                              "--html-self-contained --html-details "
                              f"{coverage_output_dir}/2_coverage_report.html --json-summary-pretty "
                              f"--json-summary {coverage_output_dir}/1_coverage_report_summary.json "

--- a/test/evergreen/code_coverage_analysis.sh
+++ b/test/evergreen/code_coverage_analysis.sh
@@ -30,13 +30,17 @@ fi
 
 virtualenv -p python3 venv
 source venv/bin/activate
-pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
+pip3 install gcovr==8.6
 mkdir -p coverage_report
 output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json"
 if [ ! -z $combine_coverage_report ]; then
-  gcovr --gcov-ignore-parse-errors -f $coverage_filter --add-tracefile $first_coverage_file_path --add-tracefile $second_coverage_file_path -j $num_jobs $output_flags
+  gcovr -f $coverage_filter --add-tracefile $first_coverage_file_path --add-tracefile $second_coverage_file_path -j $num_jobs $output_flags
 else
-  gcovr --gcov-ignore-parse-errors -f $coverage_filter -j $num_jobs $output_flags
+  # Convert the raw coverage data with parallel gcovr processes, then merge the
+  # resulting tracefiles into the report. A single gcovr process cannot do this:
+  # its -j option only creates threads, which are GIL-bound during parsing.
+  $python_binary test/evergreen/code_coverage/parallel_gcovr.py -j $num_jobs -f $coverage_filter -o coverage_tracefiles -v
+  gcovr -f $coverage_filter --add-tracefile 'coverage_tracefiles/*.json' $output_flags
   $python_binary test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
 fi
 


### PR DESCRIPTION
> This PR was created by an automated coding agent.

The two big coverage tasks on the code-statistics variant each spend ~45 minutes inside gcovr, which is most of the variant's runtime. Two causes: our pinned gcovr 5.0 predates the gcov 14 output format of the current toolchain, and gcovr's `-j` only spawns threads, which are GIL-bound while parsing, so one process crawls all 16 build directories serially.

The version mismatch is also a correctness bug: gcovr 5.0 emits ~11 million parse warnings per task (hence the 2.5 GB task logs) and silently drops the branch records it can't parse — about a third of them — so reported branch coverage is overstated (43.5% vs a real 31%). Expect the number to step down when this lands.

This upgrades gcovr to 8.6 and converts the raw coverage data with one gcovr process per group of data files, merging the JSON tracefiles afterwards. One gotcha handled: gcovr 8 silently excludes functions starting with `__` — i.e. nearly all of WiredTiger — unless `--include-internal-functions` is passed.

## Testing
- End-to-end run of `code_coverage_analysis.sh` on a 16-core ARM64 host with toolchain gcc/gcov 14.2: 79 s total, vs 3m15s for the old gcovr invocation alone; merged totals identical to a single-process gcovr run. Combine path and code-change-report consumers verified against the new JSON format.
- Single-process fallback for gcov < 12 exercised on a gcov 11 host.
- `cd dist && ./s_fast`

Made with [Cursor](https://cursor.com)