### PR TITLE
WT-17842 Add transaction test coverage for layered tables

### DIFF
--- a/test/suite/test_eviction04.py
+++ b/test/suite/test_eviction04.py
@@ -32,7 +32,6 @@ from wiredtiger import stat
 #
 # Test that reconciliation is performing in-memory restoration due to invisible updates
 # during eviction.
-@wttest.skip_for_hook("disagg", "Fails due to evict a page.")
 class test_eviction04(wttest.WiredTigerTestCase):
 
     test_name = __qualname__

--- a/test/suite/test_eviction05.py
+++ b/test/suite/test_eviction05.py
@@ -31,7 +31,6 @@ from wiredtiger import stat
 
 #
 # Test that eviction max page size stats for clean, dirty, and updates are set properly and eviction max stats per database run are not reset after a checkpoint.
-@wttest.skip_for_hook("disagg", "Fails due to evict a page.")
 class test_eviction05(wttest.WiredTigerTestCase):
 
     test_name = __qualname__

--- a/test/suite/test_layered_txn01.py
+++ b/test/suite/test_layered_txn01.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_txn01.py
+#   Durability of an ordinary committed transaction that spans several layered tables. Each table
+#   is a separate pair of btrees, so a transaction covering all of them must survive a restart
+#   all-or-nothing: after picking the checkpoint back up, either every table holds the write or
+#   none does. Whether it survives at all depends on the scenario, which either does or does not
+#   advance the stable timestamp past the commit before checkpointing.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_txn01(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+
+    # Whether the stable timestamp is advanced past the cross-table commit before the checkpoint
+    # that the restart picks up.
+    durability = [
+        ('stable_advanced', dict(durable=True)),
+        ('stable_behind', dict(durable=False)),
+    ]
+    table_counts = [
+        ('two_tables', dict(ntables=2)),
+        ('three_tables', dict(ntables=3)),
+    ]
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, durability, table_counts)
+
+    def conn_config(self):
+        return self.extensionsConfig() + ',create,statistics=(all),precise_checkpoint=true,' \
+            + 'disaggregated=(role="leader")'
+
+    def uris(self):
+        return [f'layered:{self.test_name}_{i}' for i in range(self.ntables)]
+
+    # Commit one transaction that writes the key to every table.
+    def put_all(self, key, value, ts):
+        cursors = [self.session.open_cursor(uri) for uri in self.uris()]
+        self.session.begin_transaction()
+        for cursor in cursors:
+            cursor[key] = value
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        for cursor in cursors:
+            cursor.close()
+
+    # The value each table holds for the key, or None where it is absent.
+    def read_all(self, key):
+        values = []
+        for uri in self.uris():
+            cursor = self.session.open_cursor(uri)
+            cursor.set_key(key)
+            values.append(cursor.get_value() if cursor.search() == 0 else None)
+            cursor.close()
+        return values
+
+    def test_cross_table_commit_survives_restart(self):
+        for uri in self.uris():
+            self.session.create(uri, 'key_format=S,value_format=S')
+
+        # A baseline that is stable and checkpointed before the transaction under test, so the
+        # restart has something to come back to in every scenario.
+        self.put_all('baseline', 'v0', 10)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        self.put_all('spanning', 'v1', 20)
+        if self.durable:
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        self.session.checkpoint()
+
+        self.restart_without_local_files(step_up=True)
+
+        # The restart resets the stable timestamp, which a precise checkpoint requires.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
+
+        self.assertEqual(self.read_all('baseline'), ['v0'] * self.ntables)
+
+        # The point of the test: the tables must agree with each other, whichever way it went.
+        expected = 'v1' if self.durable else None
+        self.assertEqual(self.read_all('spanning'), [expected] * self.ntables)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_layered_txn02.py
+++ b/test/suite/test_layered_txn02.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_txn02.py
+#   Rolling back an ordinary, non-prepared write to a layered table. The rolled-back update must
+#   leave no trace: the key keeps whatever the last committed transaction gave it, and a key the
+#   rolled-back transaction created stays absent.
+#
+#   Each test runs against a key seeded into the ingest constituent, the stable constituent, or
+#   both (the 'place' scenario), since the rollback has to reach whichever constituent the write
+#   landed in. Writes and reads both go through the follower, where the two constituents coexist.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_txn02(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    uri = f'layered:{test_name}'
+
+    # Which constituent(s) hold the key before the transaction under test.
+    placement = [
+        ('ingest', dict(place='ingest')),
+        ('stable', dict(place='stable')),
+        ('both',   dict(place='both')),
+    ]
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, placement)
+
+    def conn_config(self):
+        return self.extensionsConfig() + ',create,statistics=(all),disaggregated=(role="leader")'
+
+    def setUp(self):
+        super().setUp()
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.conn_follow = self.wiredtiger_open('follower',
+            self.extensionsConfig() + ',create,statistics=(all),disaggregated=(role="follower")')
+        self.session_follow = self.conn_follow.open_session('')
+        self.session_follow.create(self.uri, 'key_format=S,value_format=S')
+
+    # Write on the follower, so the items live in the ingest constituent.
+    def write_to_ingest(self, items):
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        for key, value in items.items():
+            cursor[key] = value
+        self.session_follow.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+        cursor.close()
+
+    # Write on the leader and pull the result into the follower through a checkpoint, so the items
+    # live in the stable constituent.
+    def write_to_stable(self, items):
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for key, value in items.items():
+            cursor[key] = value
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
+        cursor.close()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint_and_wait(self.conn_follow)
+
+    # Seed the items into the constituent(s) the scenario selects.
+    def seed(self, items):
+        if self.place in ('stable', 'both'):
+            self.write_to_stable(items)
+        if self.place in ('ingest', 'both'):
+            self.write_to_ingest(items)
+
+    # The value the follower sees for a key, or None if it is absent.
+    def read_value(self, key):
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction('read_timestamp=' + self.timestamp_str(50))
+        cursor.set_key(key)
+        value = cursor.get_value() if cursor.search() == 0 else None
+        self.session_follow.rollback_transaction()
+        cursor.close()
+        return value
+
+    # The keys the follower can reach in order, so a rolled-back write cannot hide from a scan.
+    def scan(self):
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction('read_timestamp=' + self.timestamp_str(50))
+        keys = []
+        while cursor.next() == 0:
+            keys.append(cursor.get_key())
+        self.session_follow.rollback_transaction()
+        cursor.close()
+        return keys
+
+    # Run ops against a follower cursor and roll the transaction back.
+    def rollback(self, ops):
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        ops(cursor)
+        self.session_follow.rollback_transaction()
+        cursor.close()
+
+    # An update rolled back leaves the previously committed value in place.
+    def test_rollback_update(self):
+        self.seed({'k': 'seeded'})
+        self.rollback(lambda cursor: cursor.__setitem__('k', 'discarded'))
+        self.assertEqual(self.read_value('k'), 'seeded')
+        self.assertEqual(self.scan(), ['k'])
+
+    # An insert of a brand new key rolled back leaves the key absent.
+    def test_rollback_insert(self):
+        self.seed({'k': 'seeded'})
+        self.rollback(lambda cursor: cursor.__setitem__('new', 'discarded'))
+        self.assertEqual(self.read_value('new'), None)
+        self.assertEqual(self.scan(), ['k'])
+
+    # A remove rolled back leaves the key readable.
+    def test_rollback_remove(self):
+        self.seed({'k': 'seeded'})
+        def remove(cursor):
+            cursor.set_key('k')
+            self.assertEqual(cursor.remove(), 0)
+        self.rollback(remove)
+        self.assertEqual(self.read_value('k'), 'seeded')
+        self.assertEqual(self.scan(), ['k'])
+
+    # Several writes to the same key in one rolled-back transaction all disappear together.
+    def test_rollback_repeated_update(self):
+        self.seed({'k': 'seeded'})
+        def update_thrice(cursor):
+            for value in ('one', 'two', 'three'):
+                cursor['k'] = value
+        self.rollback(update_thrice)
+        self.assertEqual(self.read_value('k'), 'seeded')
+
+    # A rollback does not disturb keys the transaction did not touch.
+    def test_rollback_leaves_other_keys(self):
+        self.seed({'k': 'seeded', 'other': 'untouched'})
+        self.rollback(lambda cursor: cursor.__setitem__('k', 'discarded'))
+        self.assertEqual(self.read_value('k'), 'seeded')
+        self.assertEqual(self.read_value('other'), 'untouched')
+        self.assertEqual(self.scan(), ['k', 'other'])
+
+    # A committed write after a rolled-back one is unaffected by the rollback.
+    def test_commit_after_rollback(self):
+        self.seed({'k': 'seeded'})
+        self.rollback(lambda cursor: cursor.__setitem__('k', 'discarded'))
+        self.assertEqual(self.read_value('k'), 'seeded')
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        cursor['k'] = 'committed'
+        self.session_follow.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        cursor.close()
+        self.assertEqual(self.read_value('k'), 'committed')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_layered_txn03.py
+++ b/test/suite/test_layered_txn03.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_txn03.py
+#   Timestamp boundaries on a layered table, checked on the leader and on a follower that reached
+#   the same data through a checkpoint. Reads below the oldest timestamp are refused rather than
+#   served a version garbage collection may already have discarded, reads at or above it keep
+#   returning the right version as the oldest timestamp advances, and a commit timestamp at or
+#   below the stable timestamp is refused.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_txn03(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    uri = f'layered:{test_name}'
+
+    # The node the reads and the refused commits are issued against.
+    nodes = [
+        ('leader', dict(node='leader')),
+        ('follower', dict(node='follower')),
+    ]
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, nodes)
+
+    def conn_config(self):
+        return self.extensionsConfig() + ',create,statistics=(all),' \
+            + 'disaggregated=(role="leader")'
+
+    def setUp(self):
+        super().setUp()
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.conn_follow = self.wiredtiger_open('follower',
+            self.extensionsConfig() + ',create,statistics=(all),' \
+            + 'disaggregated=(role="follower")')
+        self.session_follow = self.conn_follow.open_session('')
+        self.session_follow.create(self.uri, 'key_format=S,value_format=S')
+
+    # The connection and session the scenario reads through.
+    def target(self):
+        if self.node == 'leader':
+            return self.conn, self.session
+        return self.conn_follow, self.session_follow
+
+    # Commit one version of the key per timestamp on the leader, then checkpoint at the newest and
+    # let the follower pick the result up, so both nodes hold the same version history.
+    def seed_versions(self, key, timestamps):
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        cursor = self.session.open_cursor(self.uri)
+        for ts in timestamps:
+            self.session.begin_transaction()
+            cursor[key] = f'v{ts}'
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+        # Both nodes track the stable timestamp, and the follower needs it to police commits too.
+        for conn in (self.conn, self.conn_follow):
+            conn.set_timestamp('stable_timestamp=' + self.timestamp_str(timestamps[-1]))
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint_and_wait(self.conn_follow)
+
+    # Advance the oldest timestamp on both nodes; each connection tracks its own.
+    def set_oldest(self, ts):
+        for conn in (self.conn, self.conn_follow):
+            conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(ts))
+
+    # The value read at a timestamp. Any extra begin_transaction configuration goes ahead of the
+    # read timestamp, which is validated as it is parsed.
+    def read_at(self, key, ts, config=''):
+        _, session = self.target()
+        cursor = session.open_cursor(self.uri)
+        session.begin_transaction(config + 'read_timestamp=' + self.timestamp_str(ts))
+        cursor.set_key(key)
+        value = cursor.get_value() if cursor.search() == 0 else None
+        session.rollback_transaction()
+        cursor.close()
+        return value
+
+    # A read timestamp below the oldest timestamp is refused, so a reader can never silently see a
+    # version that garbage collection is entitled to have discarded.
+    def test_read_before_oldest_is_refused(self):
+        self.seed_versions('k', [10, 20, 30])
+        self.set_oldest(20)
+
+        # The refusal is reported through the return value alone, so match on the exception rather
+        # than on the error output.
+        _, session = self.target()
+        session.begin_transaction()
+        with self.assertRaises(wiredtiger.WiredTigerError) as caught:
+            session.timestamp_transaction('read_timestamp=' + self.timestamp_str(10))
+        self.assertIn('Invalid argument', str(caught.exception))
+        session.rollback_transaction()
+
+    # Rounding the read timestamp up moves it to the oldest timestamp, giving the version visible
+    # there rather than the one the discarded timestamp asked for.
+    def test_read_before_oldest_rounds_up(self):
+        self.seed_versions('k', [10, 20, 30])
+        self.set_oldest(20)
+
+        self.assertEqual(self.read_at('k', 10, 'roundup_timestamps=(read=true),'), 'v20')
+
+    # Advancing the oldest timestamp leaves every version at or above it readable.
+    def test_oldest_advance_preserves_visible_versions(self):
+        self.seed_versions('k', [10, 20, 30])
+
+        self.assertEqual(self.read_at('k', 10), 'v10')
+        self.assertEqual(self.read_at('k', 20), 'v20')
+        self.assertEqual(self.read_at('k', 30), 'v30')
+
+        # Advance past the first version and checkpoint, giving garbage collection both the licence
+        # and the occasion to discard it.
+        self.set_oldest(20)
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint_and_wait(self.conn_follow)
+
+        self.assertEqual(self.read_at('k', 20), 'v20')
+        self.assertEqual(self.read_at('k', 30), 'v30')
+
+    # A commit timestamp at or below the stable timestamp is refused; the stable timestamp is the
+    # boundary a checkpoint has already committed to, so writing under it would change the past.
+    def test_commit_at_or_before_stable_is_refused(self):
+        self.seed_versions('k', [10, 20, 30])
+
+        _, session = self.target()
+        for ts in (20, 30):
+            cursor = session.open_cursor(self.uri)
+            session.begin_transaction()
+            cursor['k'] = 'too-old'
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: session.commit_transaction(
+                    'commit_timestamp=' + self.timestamp_str(ts)), '/Invalid argument/')
+            # The refused commit already resolved the transaction.
+            cursor.close()
+
+        # The refused commits left nothing behind.
+        self.assertEqual(self.read_at('k', 30), 'v30')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_layered_txn03.py
+++ b/test/suite/test_layered_txn03.py
@@ -108,13 +108,23 @@ class test_layered_txn03(wttest.WiredTigerTestCase):
         self.seed_versions('k', [10, 20, 30])
         self.set_oldest(20)
 
-        # The refusal is reported through the return value alone, so match on the exception rather
-        # than on the error output.
         _, session = self.target()
         session.begin_transaction()
-        with self.assertRaises(wiredtiger.WiredTigerError) as caught:
-            session.timestamp_transaction('read_timestamp=' + self.timestamp_str(10))
-        self.assertIn('Invalid argument', str(caught.exception))
+
+        # The refusal is reported through the return value, so match on the exception rather than
+        # on the error output.
+        def refuse():
+            with self.assertRaises(wiredtiger.WiredTigerError) as caught:
+                session.timestamp_transaction('read_timestamp=' + self.timestamp_str(10))
+            self.assertIn('Invalid argument', str(caught.exception))
+
+        if wiredtiger.standalone_build():
+            refuse()
+        else:
+            # This is a MongoDB message, not written in standalone builds.
+            with self.expectedStdoutPattern('less than the oldest timestamp'):
+                refuse()
+
         session.rollback_transaction()
 
     # Rounding the read timestamp up moves it to the oldest timestamp, giving the version visible

--- a/test/suite/test_layered_txn03.py
+++ b/test/suite/test_layered_txn03.py
@@ -133,8 +133,8 @@ class test_layered_txn03(wttest.WiredTigerTestCase):
         self.assertEqual(self.read_at('k', 20), 'v20')
         self.assertEqual(self.read_at('k', 30), 'v30')
 
-        # Advance past the first version and checkpoint, giving garbage collection both the licence
-        # and the occasion to discard it.
+        # Advance past the first version and checkpoint, so garbage collection is both permitted to
+        # discard it and given the occasion to do so.
         self.set_oldest(20)
         self.session.checkpoint()
         self.disagg_advance_checkpoint_and_wait(self.conn_follow)

--- a/test/suite/test_rollback01.py
+++ b/test/suite/test_rollback01.py
@@ -31,7 +31,6 @@ class test_rollback(wttest.WiredTigerTestCase):
     test_name = __qualname__
     uri = f"table:{test_name}.wt"
 
-    @wttest.skip_for_hook("disagg", "disagg requires an additional condition to evict pages")
     def test_wt_rollback_cursor_next_no_retry(self):
         """
         Try to insert a key value pair while the cache is full, and verify cursor->next() calls


### PR DESCRIPTION
WT-17842 listed four potential transaction testing gaps, flagged as possibly false positives. Three were real and are covered here by new tests: `test_layered_txn01` commits one ordinary transaction across several layered tables and checks that a restart picks it up all-or-nothing; `test_layered_txn02` rolls back ordinary writes over the ingest/stable/both placement axis, checking both point reads and scans; `test_layered_txn03` covers the read-before-oldest and commit-at-or-below-stable boundaries, and version visibility as the oldest timestamp advances, on a leader and on a follower holding the same data via a checkpoint.

The remaining item claimed test_eviction04, test_eviction05 and test_rollback01 were disabled under the disagg hook without explanation. They were not — each carries a `skip_for_hook` reason, which is a separate mechanism from the `fail_lists/hook_disagg.fail` list. The skips were stale, though: each was added when its test was introduced, because disagg could not then evict the page the test depends on. All three now pass with the skip removed, so this drops them. Note the assertions still bite under disagg, so the re-enabled tests carry real weight rather than passing vacuously.

Each new test was checked against a mutation to confirm it is not vacuous, and the whole set was run repeatedly to check for flakiness. Full analysis is on the ticket.