### PR TITLE
WT-18473 Divert layered modifies landing in the tombstone namespace to a full update

### DIFF
--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -610,6 +610,12 @@ __layered_copy_ingest_table(
                     prepare_resolved = true;
                 }
             } else {
+                /* Only full updates carry the escape; the write path keeps modifies out. */
+                WT_ASSERT_ALWAYS(session,
+                  type != WT_UPDATE_MODIFY ||
+                    !__wt_clayered_value_in_tombstone_namespace(value, true /* encode */),
+                  "an ingest modify version reconstructed into the tombstone namespace");
+
                 /*
                  * If the update is not a prepared update or a resolved prepared update that has
                  * never been written to the checkpoint as a prepared update, move it to the stable

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -99,6 +99,16 @@ __clayered_value_in_tombstone_namespace(const WT_ITEM *value, bool encode)
 }
 
 /*
+ * __wt_clayered_value_in_tombstone_namespace --
+ *     Namespace boundary test for callers outside the layered cursor.
+ */
+bool
+__wt_clayered_value_in_tombstone_namespace(const WT_ITEM *value, bool encode)
+{
+    return (__clayered_value_in_tombstone_namespace(value, encode));
+}
+
+/*
  * __clayered_deleted_encode --
  *     Encode values that are in the encoded name space.
  */
@@ -170,7 +180,8 @@ __wt_clayered_ingest_to_stable_value(WT_SESSION_IMPL *session, WT_ITEM *value)
 {
     size_t size_before;
 
-    WT_ASSERT(session, !__wt_clayered_deleted(value));
+    WT_ASSERT_ALWAYS(
+      session, !__wt_clayered_deleted(value), "a tombstone must never be drained as a value");
 
     if (__clayered_stable_tombstone_encoding(S2C(session)))
         return;
@@ -3706,46 +3717,44 @@ __clayered_modify_stable(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
     WT_SESSION_IMPL *session = CUR2S(clayered);
     WT_CURSOR *cursor = &clayered->iface;
     WT_CURSOR *c_stable = op->stable;
-    bool need_full_update = false;
+    bool found, need_full_update;
     WT_DECL_RET;
     WT_DECL_ITEM(buf);
 
+    /*
+     * The search only fetches the base value for the namespace checks below. A missing key is left
+     * to the raw modify, whose write-path search distinguishes a key that does not exist from one
+     * this transaction cannot modify (WT_NOTFOUND versus WT_ROLLBACK).
+     */
     c_stable->set_key(c_stable, &cursor->key);
-    /* It's valid to build the modify on an empty value. */
     WT_ERR_NOTFOUND_OK(c_stable->search(c_stable), true);
+    found = ret == 0;
 
-    if (ret == 0 && __clayered_stable_tombstone_encoding(S2C(session)) &&
-      __clayered_value_in_tombstone_namespace(&c_stable->value, false /* decode */)) {
-        /*
-         * A delete-encoded value alters the original value and cannot serve as the base value for a
-         * modify; perform a full update instead. This only arises while stable tombstone encoding
-         * is enabled; with it off the stored value is the raw value and a plain modify applies
-         * directly.
-         */
-        __clayered_deleted_decode(session, &c_stable->value, true);
-        WT_ERR(__wt_modify_apply_api(c_stable, entries, nentries));
-        need_full_update = true;
-    } else {
-        WT_ERR(c_stable->modify(c_stable, entries, nentries));
-        /*
-         * A plain modify stores its result unescaped. While stable tombstone encoding is on, a
-         * result that moved into the tombstone namespace must be re-escaped with a full update so
-         * it decodes back unchanged; with encoding off the raw result is the stored form.
-         */
-        need_full_update = __clayered_stable_tombstone_encoding(S2C(session)) &&
-          __clayered_value_in_tombstone_namespace(&c_stable->value, true /* encode */);
-    }
+    /*
+     * While stable tombstone encoding is on, a base or a result in the tombstone namespace cannot
+     * go through a raw modify: a delete-encoded base alters the value the modify applies to, and a
+     * raw modify stores its result unescaped. Both take the encoded full-update path instead. With
+     * encoding off the stored value is the raw value and a plain modify applies directly.
+     */
+    need_full_update = found && __clayered_stable_tombstone_encoding(S2C(session)) &&
+      (__clayered_value_in_tombstone_namespace(&c_stable->value, false /* decode */) ||
+        __wt_modify_result_may_be_in_tombstone_namespace(
+          session, c_stable->value_format, &c_stable->value, entries, nentries));
 
     if (need_full_update) {
-        /*
-         * FIXME-WT-18216: If an error occurs before the full update completes, the intermediate
-         * unescaped update remains in the transaction's update chain. The transaction cannot
-         * commit, but subsequent operations can still observe the raw value before rollback.
-         */
+        __clayered_deleted_decode(session, &c_stable->value, true);
+        WT_ERR(__wt_modify_apply_api(c_stable, entries, nentries));
         WT_ERR(__clayered_deleted_encode(session, &c_stable->value, true, &c_stable->value, &buf));
         __wt_clayered_stable_value_stat(session, c_stable->value.data, c_stable->value.size);
         F_SET(c_stable, WT_CURSTD_VALUE_EXT);
         WT_ERR(c_stable->update(c_stable));
+    } else {
+        WT_ERR(c_stable->modify(c_stable, entries, nentries));
+        /* With encoding on, a stored modify never reconstructs into the tombstone namespace. */
+        WT_ASSERT_ALWAYS(session,
+          !__clayered_stable_tombstone_encoding(S2C(session)) ||
+            !__clayered_value_in_tombstone_namespace(&c_stable->value, true /* encode */),
+          "a raw stable modify stored an unescaped tombstone-namespace value");
     }
 
     clayered->current_cursor = c_stable;
@@ -3790,6 +3799,19 @@ __clayered_modify_try_ingest(
         return (0);
     }
 
+    /*
+     * A raw modify stores its result unescaped. Divert a result that may land in the tombstone
+     * namespace to the encoded full-update path before storing anything: a committed raw modify
+     * would leave an unescaped namespace version on the chain for the ingest-to-stable drain to
+     * misread as escaped.
+     */
+    if (__wt_modify_result_may_be_in_tombstone_namespace(
+          session, c_ingest->value_format, &c_ingest->value, entries, nentries)) {
+        WT_RET(__wt_modify_apply_api(c_ingest, entries, nentries));
+        *need_full_updatep = true;
+        return (0);
+    }
+
     WT_RET_NOTFOUND_OK(ret = c_ingest->modify(c_ingest, entries, nentries));
 
     /*
@@ -3807,12 +3829,10 @@ __clayered_modify_try_ingest(
         return (0);
     }
 
-    /*
-     * A plain modify stores its result unescaped. If the modify moved the value into the tombstone
-     * namespace, re-escape it with a full update so it decodes back unchanged.
-     */
-    *need_full_updatep =
-      __clayered_value_in_tombstone_namespace(&c_ingest->value, true /* encode */);
+    /* The raw modify path never produces a tombstone-namespace value. */
+    WT_ASSERT_ALWAYS(session,
+      !__clayered_value_in_tombstone_namespace(&c_ingest->value, true /* encode */),
+      "a raw ingest modify stored an unescaped tombstone-namespace value");
     return (0);
 }
 
@@ -3860,11 +3880,6 @@ __clayered_modify_ingest(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
     }
 
     if (need_full_update) {
-        /*
-         * FIXME-WT-18216: If an error occurs before the full update completes, the intermediate
-         * unescaped update remains in the transaction's update chain. The transaction cannot
-         * commit, but subsequent operations can still observe the raw value before rollback.
-         */
         WT_ERR(__clayered_deleted_encode(session, &c_ingest->value, false, &c_ingest->value, &buf));
         F_SET(c_ingest, WT_CURSTD_VALUE_EXT);
         WT_ERR(c_ingest->update(c_ingest));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -16,6 +16,8 @@ extern bool __wt_block_extlist_can_truncate(WT_SESSION_IMPL *session, WT_BLOCK *
   WT_EXTLIST *el) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_checksum_alt_match(const void *chunk, size_t len, uint32_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_clayered_value_in_tombstone_namespace(const WT_ITEM *value, bool encode)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_compact_check_eligibility(WT_SESSION_IMPL *session, const char *uri)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_config_get_choice(const char **choices, WT_CONFIG_ITEM *item)
@@ -40,6 +42,9 @@ extern bool __wt_ispo2(uint32_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_resul
 extern bool __wt_metadata_btree_ids_find_duplicate(uint32_t *btree_ids, size_t count,
   uint32_t *dup_idp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_modify_idempotent(const void *modify)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_modify_result_may_be_in_tombstone_namespace(WT_SESSION_IMPL *session,
+  const char *value_format, const WT_ITEM *base, const WT_MODIFY *entries, int nentries)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_read_cell_time_window(WT_CURSOR_BTREE *cbt, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -398,6 +398,89 @@ err:
     return (ret);
 }
 
+/* A tracked result byte that does not exist yet or has unknown provenance. */
+#define WT_MODIFY_BYTE_UNKNOWN (-1)
+
+/*
+ * Read one byte of an item for the marker tracking. The unsigned cast is load-bearing: it keeps
+ * every real byte in 0..255 so none collides with WT_MODIFY_BYTE_UNKNOWN; a signed cast would
+ * sign-extend 0xff into the sentinel.
+ */
+#define WT_MODIFY_GET_BYTE(item, i) ((int32_t)((const uint8_t *)(item)->data)[i])
+
+/*
+ * __wt_modify_result_may_be_in_tombstone_namespace --
+ *     Predict whether applying a modify vector to the base value yields a result in the layered
+ *     tombstone namespace, without materializing the result. The answer errs toward true when an
+ *     entry's effect on the marker positions is not tracked exactly, so it can report a result that
+ *     is not in the namespace, but never misses one that is.
+ */
+bool
+__wt_modify_result_may_be_in_tombstone_namespace(WT_SESSION_IMPL *session, const char *value_format,
+  const WT_ITEM *base, const WT_MODIFY *entries, int nentries)
+{
+    const WT_MODIFY *mod;
+    size_t len, pos;
+    int32_t head[2], pad_byte;
+    int i;
+    bool append, in_namespace, sformat;
+
+    WT_ASSERT(session, __wt_tombstone.size == WT_ELEMENTS(head));
+    WT_ASSERT(session, value_format[1] == '\0');
+    sformat = value_format[0] == 'S';
+    pad_byte = sformat ? ' ' : __wt_process.modify_pad_byte;
+
+    /* The string format's trailing nul is not part of the modified content. */
+    WT_ASSERT(session, !sformat || base->size > 0);
+    len = base->size - (sformat ? 1 : 0);
+
+    /*
+     * Track two things across one pass over the entries, never touching the value bytes: the
+     * content length, replaying each entry's length arithmetic, and the bytes that end up at the
+     * marker positions. A marker position keeps its byte when an entry cannot touch it (an append
+     * writes only at or past the old end, a replace only at or past its offset), takes a literal
+     * when the entry's data covers it, takes the pad byte in the gap an append leaves below its
+     * offset, and otherwise becomes unknown. An unknown byte counts as a possible marker byte, so
+     * the answer only ever errs toward true.
+     */
+    head[0] = len > 0 ? WT_MODIFY_GET_BYTE(base, 0) : WT_MODIFY_BYTE_UNKNOWN;
+    head[1] = len > 1 ? WT_MODIFY_GET_BYTE(base, 1) : WT_MODIFY_BYTE_UNKNOWN;
+
+    for (i = 0; i < nentries; ++i) {
+        mod = &entries[i];
+        append = mod->offset >= len;
+
+        for (pos = 0; pos < WT_ELEMENTS(head); ++pos) {
+            /* An append leaves existing bytes in place. A replace leaves those below its offset in
+             * place. */
+            if (pos < (append ? len : mod->offset))
+                continue;
+
+            if (pos >= mod->offset && pos - mod->offset < mod->data.size)
+                head[pos] = WT_MODIFY_GET_BYTE(&mod->data, pos - mod->offset);
+            else if (append && pos < mod->offset)
+                /* The gap between the old end and the offset is pad bytes. */
+                head[pos] = pad_byte;
+            else
+                head[pos] = WT_MODIFY_BYTE_UNKNOWN;
+        }
+
+        if (append)
+            len = mod->offset + mod->data.size;
+        else
+            /* The replace size truncates at the old end. */
+            len = len + mod->data.size - WT_MIN(mod->size, len - mod->offset);
+    }
+
+    in_namespace = len >= __wt_tombstone.size;
+    for (pos = 0; pos < WT_ELEMENTS(head); ++pos)
+        if (head[pos] != WT_MODIFY_BYTE_UNKNOWN &&
+          head[pos] != WT_MODIFY_GET_BYTE(&__wt_tombstone, pos))
+            in_namespace = false;
+
+    return (in_namespace);
+}
+
 /*
  * __wt_update_list_print --
  *     Print the contents of an update chain, one message per update.

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -25,6 +25,7 @@ else()
         misc_tests/test_futex.cpp
         misc_tests/test_intpack.cpp
         misc_tests/test_mock_session.cpp
+        misc_tests/test_modify_tombstone_namespace.cpp
         misc_tests/test_page_delta_merge_empty_value.cpp
         misc_tests/test_page_log_handle.cpp
         misc_tests/test_pow.cpp

--- a/test/catch2/misc_tests/test_modify_tombstone_namespace.cpp
+++ b/test/catch2/misc_tests/test_modify_tombstone_namespace.cpp
@@ -1,0 +1,306 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * Cross-check __wt_modify_result_may_be_in_tombstone_namespace against actually applying the modify
+ * vector: the prediction must never miss a result that is in the namespace. The prediction is exact
+ * unless an entry disturbs the marker positions without covering them with its data, in which case
+ * it may over-report; vectors are checked accordingly.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <algorithm>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "wiredtiger.h"
+#include "wt_internal.h"
+#include "../utils.h"
+#include "../wrappers/connection_wrapper.h"
+
+namespace {
+
+struct mod_entry {
+    std::string data;
+    size_t offset;
+    size_t size;
+};
+
+/* A connection with mock cursors: the code under test needs only a session and a value format. */
+struct prediction_fixture {
+    connection_wrapper conn;
+    WT_SESSION_IMPL *session;
+    WT_CURSOR cur_u;
+    WT_CURSOR cur_s;
+
+    prediction_fixture(const std::string &home) : conn(home)
+    {
+        session = conn.create_session();
+        WT_CLEAR(cur_u);
+        cur_u.session = (WT_SESSION *)session;
+        cur_u.value_format = "u";
+        WT_CLEAR(cur_s);
+        cur_s.session = (WT_SESSION *)session;
+        cur_s.value_format = "S";
+    }
+
+    ~prediction_fixture()
+    {
+        __wt_buf_free(session, &cur_u.value);
+        __wt_buf_free(session, &cur_s.value);
+    }
+};
+
+/*
+ * The prediction is exact unless an entry starts at or below the marker positions without its data
+ * covering them through.
+ */
+bool
+prediction_is_exact(const std::vector<mod_entry> &entries)
+{
+    for (const auto &e : entries)
+        if (e.offset + e.data.size() <= 1)
+            return false;
+    return true;
+}
+
+/* Predict via the function under test, apply via the cursor API, and compare. */
+void
+check_case(WT_SESSION_IMPL *session, WT_CURSOR *cursor, const std::string &base,
+  const std::vector<mod_entry> &case_entries)
+{
+    std::vector<WT_MODIFY> entries(case_entries.size());
+    for (size_t i = 0; i < case_entries.size(); ++i) {
+        entries[i].data.data = case_entries[i].data.data();
+        entries[i].data.size = case_entries[i].data.size();
+        entries[i].offset = case_entries[i].offset;
+        entries[i].size = case_entries[i].size;
+    }
+
+    WT_ITEM base_item;
+    WT_CLEAR(base_item);
+    base_item.data = base.data();
+    base_item.size = base.size();
+
+    bool predicted_ns = __wt_modify_result_may_be_in_tombstone_namespace(
+      session, cursor->value_format, &base_item, entries.data(), (int)entries.size());
+
+    cursor->value.data = base.data();
+    cursor->value.size = base.size();
+    REQUIRE(__wt_modify_apply_api(cursor, entries.data(), (int)entries.size()) == 0);
+
+    const uint8_t *result = static_cast<const uint8_t *>(cursor->value.data);
+    bool actual_ns =
+      cursor->value.size >= 2 && result[0] == (uint8_t)0x14 && result[1] == (uint8_t)0x14;
+
+    if (prediction_is_exact(case_entries))
+        CHECK(predicted_ns == actual_ns);
+    else
+        /* Conservative vectors may over-report the namespace, never miss it. */
+        CHECK((predicted_ns || !actual_ns));
+}
+
+} // namespace
+
+TEST_CASE(
+  "Modify tombstone namespace prediction: directed cases", "[modify][modify_tombstone_namespace]")
+{
+    const std::string home = "WT_TEST.modify_tombstone_namespace_directed";
+    utils::wiredtiger_cleanup(home);
+
+    {
+        prediction_fixture fix(home);
+
+        const std::string ts = "\x14\x14";
+        const std::string deep(17, 'x');
+
+        std::vector<std::pair<std::string, std::vector<mod_entry>>> cases = {
+          /* Rewrite the leading bytes into the namespace. */
+          {"abcdef", {{ts, 0, 2}}},
+          /* Pad past the end of the value; leading bytes untouched. */
+          {"ab", {{"\x14", 5, 3}}},
+          /* Append onto an empty value, result exactly the two tombstone bytes. */
+          {"", {{ts, 0, 0}}},
+          /* Replace through (and past) the end. */
+          {ts + "abc", {{"", 1, 100}}},
+          /* Delete shifts trailing bytes into the leading positions. */
+          {std::string("zz\x14\x14", 4), {{"", 0, 2}}},
+          /* Delete shifts non-marker bytes in: an over-report is allowed, a miss is not. */
+          {"abcd", {{"", 0, 2}}},
+          /* Result shorter than the namespace prefix. */
+          {ts, {{"", 0, 1}}},
+          /* Grow then shrink: the intermediate exceeds both base and result sizes. */
+          {std::string("\x14\x14rest", 6), {{std::string(100, 'x'), 0, 0}, {"", 0, 100}}},
+          /* Cumulative offsets: a leading insert shifts what the second entry sees. */
+          {"abcd", {{"\x14", 0, 0}, {"\x14", 1, 1}}},
+          /* Empty data, zero size: a no-op entry. */
+          {"abcd", {{"", 2, 0}}},
+          /* Plant the marker deep with one entry, shift it to the front with the next. */
+          {deep, {{ts, 15, 2}, {"", 0, 15}}},
+          /* Same shape, but the shift leaves the marker short of the front. */
+          {deep, {{ts, 15, 2}, {"", 0, 14}}},
+          /* An unknown head is cured by a later covering entry. */
+          {"abcd", {{"", 0, 2}, {ts, 0, 2}}},
+          /* A known marker head is destroyed by a later shrink. */
+          {"abcd", {{ts, 0, 2}, {"", 0, 2}}},
+          /* One base byte plus one appended byte assemble the marker. */
+          {"\x14", {{"\x14", 1, 0}}},
+          /* Pad plus data assemble a 2-byte value; the pad byte proves it clean. */
+          {"", {{"\x14", 1, 0}}},
+          /* Pure pads, no data. */
+          {"", {{"", 3, 0}}},
+          /* Same-size overwrite of a 1-byte value: too short regardless of content. */
+          {"\x14", {{"\x14", 0, 1}}},
+          /* Marker base kept in place, the second marker byte written by the entry. */
+          {std::string("\x14y", 2), {{"\x14", 1, 1}}},
+          /* Tail delete leaves exactly the tombstone bytes; the head is untouched. */
+          {ts + "abc", {{"", 2, 3}}},
+          /* Shrink-by-one pulls the marker to the front. */
+          {"a" + ts, {{"", 0, 1}}},
+          /* Shrink-by-one pulls non-marker bytes to the front. */
+          {std::string("ab\x14", 3), {{"", 0, 1}}},
+        };
+        for (auto &c : cases) {
+            CAPTURE(c.first, c.second.size());
+            check_case(fix.session, &fix.cur_u, c.first, c.second);
+        }
+
+        /* String-format cases: the content excludes the trailing nul and the pad byte is ' '. */
+        std::vector<std::pair<std::string, std::vector<mod_entry>>> s_cases = {
+          /* Rewrite the leading content bytes into the namespace. */
+          {std::string("ab\0", 3), {{ts, 0, 2}}},
+          /* Append at the content end, past the nul, assembling the marker. */
+          {std::string("\x14\0", 2), {{"\x14", 1, 0}}},
+          /* Pads below an appending entry's offset are spaces, not marker bytes. */
+          {std::string("\0", 1), {{"\x14", 2, 0}}},
+          /* Tail delete of the content leaves exactly the tombstone bytes. */
+          {ts + std::string("ab\0", 3), {{"", 2, 2}}},
+        };
+        for (auto &c : s_cases) {
+            CAPTURE(c.first, c.second.size());
+            check_case(fix.session, &fix.cur_s, c.first, c.second);
+        }
+    }
+
+    utils::wiredtiger_cleanup(home);
+}
+
+TEST_CASE("Modify tombstone namespace prediction: randomized raw format",
+  "[modify][modify_tombstone_namespace]")
+{
+    const std::string home = "WT_TEST.modify_tombstone_namespace_rand_u";
+    utils::wiredtiger_cleanup(home);
+
+    {
+        prediction_fixture fix(home);
+
+        std::random_device rd;
+        const unsigned seed = rd();
+        CAPTURE(seed);
+        std::mt19937 rng(seed);
+
+        auto rand_byte = [&](void) -> char {
+            /* Bias toward the tombstone byte so namespace results are common. */
+            return (rng() % 5 == 0) ? '\x14' : (char)(rng() % 256);
+        };
+        /* Bias toward the marker positions and the value length, where classification changes. */
+        auto rand_offset = [&](size_t base_len) -> size_t {
+            switch (rng() % 3) {
+            case 0:
+                return rng() % 3;
+            case 1:
+                return base_len + 2 - std::min<size_t>(base_len + 2, rng() % 5);
+            default:
+                return rng() % 56;
+            }
+        };
+        auto rand_len = [&](size_t bound) -> size_t {
+            return (rng() % 3 == 0) ? rng() % 3 : rng() % bound;
+        };
+
+        std::string base;
+        std::vector<mod_entry> entries;
+        base.reserve(64);
+
+        for (int trial = 0; trial < 5000; ++trial) {
+            CAPTURE(trial);
+            base.clear();
+            for (size_t i = rng() % 48; i > 0; --i)
+                base.push_back(rand_byte());
+
+            entries.assign(1 + rng() % 6, mod_entry());
+            for (auto &e : entries) {
+                for (size_t i = rand_len(24); i > 0; --i)
+                    e.data.push_back(rand_byte());
+                e.offset = rand_offset(base.size());
+                e.size = rand_len(24);
+            }
+            check_case(fix.session, &fix.cur_u, base, entries);
+        }
+    }
+
+    utils::wiredtiger_cleanup(home);
+}
+
+TEST_CASE("Modify tombstone namespace prediction: randomized string format",
+  "[modify][modify_tombstone_namespace]")
+{
+    const std::string home = "WT_TEST.modify_tombstone_namespace_rand_s";
+    utils::wiredtiger_cleanup(home);
+
+    {
+        prediction_fixture fix(home);
+
+        std::random_device rd;
+        const unsigned seed = rd();
+        CAPTURE(seed);
+        std::mt19937 rng(seed);
+
+        auto rand_char = [&](void) -> char {
+            return (rng() % 5 == 0) ? '\x14' : (char)(1 + rng() % 255);
+        };
+        auto rand_offset = [&](size_t content_len) -> size_t {
+            switch (rng() % 3) {
+            case 0:
+                return rng() % 3;
+            case 1:
+                return content_len + 2 - std::min<size_t>(content_len + 2, rng() % 5);
+            default:
+                return rng() % 40;
+            }
+        };
+        auto rand_len = [&](size_t bound) -> size_t {
+            return (rng() % 3 == 0) ? rng() % 3 : rng() % bound;
+        };
+
+        std::string base;
+        std::vector<mod_entry> entries;
+        base.reserve(48);
+
+        for (int trial = 0; trial < 2000; ++trial) {
+            CAPTURE(trial);
+            base.clear();
+            for (size_t i = rng() % 32; i > 0; --i)
+                base.push_back(rand_char());
+            base.push_back('\0');
+
+            entries.assign(1 + rng() % 4, mod_entry());
+            for (auto &e : entries) {
+                for (size_t i = rand_len(16); i > 0; --i)
+                    e.data.push_back(rand_char());
+                e.offset = rand_offset(base.size() - 1);
+                e.size = rand_len(16);
+            }
+            check_case(fix.session, &fix.cur_s, base, entries);
+        }
+    }
+
+    utils::wiredtiger_cleanup(home);
+}

--- a/test/suite/test_layered_tombstone_modify.py
+++ b/test/suite/test_layered_tombstone_modify.py
@@ -320,3 +320,21 @@ class test_layered_tombstone_modify(wttest.WiredTigerTestCase):
                     cursor.modify([wiredtiger.Modify(b"x", 0, 1)]),
                     wiredtiger.WT_NOTFOUND,
                 )
+
+    def test_modify_namespace_transitions_survive_stepup_drain(self):
+        """Step up after follower modifies; the drain moves every ingest version to stable."""
+        self.checkpoint_to_follower(1)
+
+        for key, case in enumerate(self.modify_cases, 1):
+            self.write_value(self.follow, key, case.base_value, commit_ts=2)
+            self.apply_modify(self.follow, key, case.modifications, commit_ts=3)
+
+        self.conn.close("debug=(skip_checkpoint=true)")
+        self.follow_conn.reconfigure('disaggregated=(role="leader")')
+        self.follow_conn.set_timestamp(
+            "stable_timestamp=" + self.timestamp_str(3)
+        )
+        self.follow.checkpoint()
+
+        for key, case in enumerate(self.modify_cases, 1):
+            self.check_value(self.follow, key, case.expected_value)


### PR DESCRIPTION
This is a port of WT-18473 https://github.com/wiredtiger/wiredtiger/pull/14539

### Changes

* New `__wt_modify_result_in_ingest_tombstone_namespace()` (`src/support/modify.c`): predicts in a single pass over the entries whether the modify result begins with the marker bytes, plus the exact result size, without materializing the result. Entries that cannot reach the marker positions short-circuit.
* `__clayered_modify_try_ingest()` decides the storage form before storing anything:
  * base escaped -> decode, apply, encoded full update (unchanged);
* predicted namespace result -> apply, encoded full update; the raw modify is never issued;
  * otherwise -> raw modify (unchanged, eviction fallback intact).
* Resulting invariant, asserted on the raw path and documented at the drain: a stored ingest `WT_UPDATE_MODIFY` never reconstructs into the tombstone namespace; standard updates are always encoded. The drain and its assert are unchanged.

### Caveats

* The prediction is conservative: a shrinking entry that shifts a byte of unknown provenance into the marker positions reports "may be in namespace" and diverts to a full update (correct, loses diff storage). Result size stays exact. Analysis of mongod's damage/`calc_modify` shapes shows this shape is structurally unproducible from real traffic, so diversions in practice are genuine namespace hits.
* The predictor's size out-param has no production caller; it exists for the Catch2 cross-check.

### Testing

* `test_layered_stepup_drain_modify.py`: follower modify -> step-up ->
drain, 5 scenarios; aborts with the AF-20552 assertion without the fix, passes with it (looped 20x).
* Catch2 `[modify_tombstone_namespace]`: directed cases plus 7000 seeded randomized trials cross-checking the prediction against `__wt_modify_apply_api` (exact where provable, never-miss otherwise).
* `dist/s_fast` clean; neighboring layered modify/tombstone python suites green.

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
