### PR TITLE
WT-18513 Skip tiered config stripping when tiered storage is disabled

### DIFF
--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -361,15 +361,18 @@ __create_file(
 
         /*
          * Strip any configuration settings that should not be persisted. Only tiered storage
-         * settings are stripped; there is nothing to do unless the connection uses tiered storage.
+         * settings are stripped. In disaggregated storage, tiered storage is never used and the
+         * config merge performed by the strip is expensive, so skip it; the persisted metadata
+         * resolves to the same values through the config API.
          */
-        if (WT_CONN_TIERED_STORAGE_ENABLED(S2C(session))) {
+        if (__wt_conn_is_disagg(session)) {
+            WT_ASSERT(session, !WT_CONN_TIERED_STORAGE_ENABLED(S2C(session)));
+            filestripped = fileconf;
+            fileconf = NULL;
+        } else {
             filecfg[1] = fileconf;
             filecfg[2] = NULL;
             WT_ERR(__wt_config_tiered_strip(session, filecfg, &filestripped));
-        } else {
-            filestripped = fileconf;
-            fileconf = NULL;
         }
 
         /* Insert the stripped configuration into the metadata. */

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -359,10 +359,20 @@ __create_file(
             WT_ERR(__wt_import_repair(session, uri, &fileconf));
         }
 
-        /* Strip any configuration settings that should not be persisted. */
-        filecfg[1] = fileconf;
-        filecfg[2] = NULL;
-        WT_ERR(__wt_config_tiered_strip(session, filecfg, &filestripped));
+        /*
+         * Strip any configuration settings that should not be persisted. Only tiered storage
+         * settings are stripped; there is nothing to do unless the connection uses tiered storage.
+         */
+        if (WT_CONN_TIERED_STORAGE_ENABLED(S2C(session))) {
+            filecfg[1] = fileconf;
+            filecfg[2] = NULL;
+            WT_ERR(__wt_config_tiered_strip(session, filecfg, &filestripped));
+        } else {
+            filestripped = fileconf;
+            fileconf = NULL;
+        }
+
+        /* Insert the stripped configuration into the metadata. */
         WT_ERR(__wt_metadata_insert(session, uri, filestripped));
 
         /*


### PR DESCRIPTION
- Skip `__wt_config_tiered_strip` when tiered storage is not enabled.
- Avoids unnecessary config parsing overhead in disaggregated storage mode.
- No functional change when tiered storage is enabled.