### PR TITLE
WT-18519 Remove leftover tiered remnants

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -277,29 +277,38 @@ lsm_config = [
     ]),
 ]
 
+# Common removed-option fields for table/file and wiredtiger_open.
+tiered_storage_local_retention = Config('local_retention', '300', r'''
+    removed option, preserved to allow parsing old metadata''',
+    min='0', max='10000', undoc=True)
+tiered_storage_shared = Config('shared', 'false', r'''
+    removed option, preserved to allow parsing old metadata''',
+    type='boolean', undoc=True)
+tiered_storage_configuration_common = [
+    Config('name', 'none', r'''
+        removed option, preserved to allow parsing old metadata''', undoc=True),
+    Config('auth_token', '', r'''
+        removed option, preserved to allow parsing old metadata''', undoc=True),
+    Config('bucket', '', r'''
+        removed option, preserved to allow parsing old metadata''', undoc=True),
+    Config('bucket_prefix', '', r'''
+        removed option, preserved to allow parsing old metadata''', undoc=True),
+    Config('cache_directory', '', r'''
+        removed option, preserved to allow parsing old metadata''', undoc=True),
+    tiered_storage_local_retention,
+    tiered_storage_shared,
+]
+
 tiered_config = [
     Config('tiered_storage', '', r'''
         Removed options, preserved to allow parsing old metadata''',
-        type='category', subconfig=[
-        Config('name', 'none', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('auth_token', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('bucket', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('bucket_prefix', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('cache_directory', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('local_retention', '300', r'''
-            removed option, preserved to allow parsing old metadata''',
-            min='0', max='10000', undoc=True),
+        type='category', subconfig=
+        # object_target_size before shared so compiled key numbers keep first-seen order.
+        tiered_storage_configuration_common[:-1] + [
         Config('object_target_size', '0', r'''
             removed option, preserved to allow parsing old metadata''',
             min='0', undoc=True),
-        Config('shared', 'false', r'''
-            removed option, preserved to allow parsing old metadata''',
-            type='boolean', undoc=True),
+        tiered_storage_shared,
         ]),
 ]
 
@@ -1261,37 +1270,19 @@ wiredtiger_open_statistics_log_configuration = [
         ])
 ]
 
-tiered_storage_configuration_common = [
-    Config('local_retention', '300', r'''
-        removed option, preserved to allow parsing old metadata''',
-        min='0', max='10000', undoc=True),
-]
 connection_reconfigure_tiered_storage_configuration = [
     Config('tiered_storage', '', r'''
         Removed options, preserved to allow parsing old metadata''',
-        type='category', subconfig=tiered_storage_configuration_common)
+        type='category', subconfig=[tiered_storage_local_retention])
 ]
 wiredtiger_open_tiered_storage_configuration = [
     Config('tiered_storage', '', r'''
         Removed options, preserved to allow parsing old metadata''',
         type='category', undoc=True, subconfig=
         tiered_storage_configuration_common + [
-        Config('auth_token', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('bucket', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('bucket_prefix', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('cache_directory', '', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('interval', '60', r'''
             removed option, preserved to allow parsing old metadata''',
             min=1, max=1000, undoc=True),
-        Config('name', 'none', r'''
-            removed option, preserved to allow parsing old metadata''', undoc=True),
-        Config('shared', 'false', r'''
-            removed option, preserved to allow parsing old metadata''',
-            type='boolean', undoc=True),
     ]),
 ]
 

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -279,30 +279,27 @@ lsm_config = [
 
 tiered_config = [
     Config('tiered_storage', '', r'''
-        configure a storage source for this table''',
+        Removed options, preserved to allow parsing old metadata''',
         type='category', subconfig=[
         Config('name', 'none', r'''
-            permitted value is \c "none"'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('auth_token', '', r'''
-            authentication string identifier'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('bucket', '', r'''
-            the bucket indicating the location for this table'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('bucket_prefix', '', r'''
-            the unique bucket prefix for this table'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('cache_directory', '', r'''
-            a directory to store locally cached versions of files in the storage source. By
-            default, it is named with \c "-cache" appended to the bucket name. A relative
-            directory name is relative to the home directory'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('local_retention', '300', r'''
-            time in seconds to retain data on tiered storage on the local tier for faster
-            read access''',
-            min='0', max='10000'),
+            removed option, preserved to allow parsing old metadata''',
+            min='0', max='10000', undoc=True),
         Config('object_target_size', '0', r'''
-            this option is no longer supported, retained for backward compatibility''',
+            removed option, preserved to allow parsing old metadata''',
             min='0', undoc=True),
         Config('shared', 'false', r'''
-            enable sharing tiered tables across other WiredTiger instances.''',
-            type='boolean'),
+            removed option, preserved to allow parsing old metadata''',
+            type='boolean', undoc=True),
         ]),
 ]
 
@@ -506,8 +503,7 @@ file_meta = file_config + [
         readonly for more information''',
         type='boolean'),
     Config('tiered_object', 'false', r'''
-        this file is a tiered object. When opened on its own, it is marked as readonly and may
-        be restricted in other ways''',
+        removed option, preserved to allow parsing old metadata''',
         type='boolean', undoc=True),
     Config('version', '(major=0,minor=0)', r'''
         the file version'''),
@@ -1267,41 +1263,35 @@ wiredtiger_open_statistics_log_configuration = [
 
 tiered_storage_configuration_common = [
     Config('local_retention', '300', r'''
-        time in seconds to retain data on tiered storage on the local tier for faster read
-        access''',
-        min='0', max='10000'),
+        removed option, preserved to allow parsing old metadata''',
+        min='0', max='10000', undoc=True),
 ]
 connection_reconfigure_tiered_storage_configuration = [
     Config('tiered_storage', '', r'''
-        enable tiered storage. Enabling tiered storage may use one session from the configured
-        session_max''',
+        Removed options, preserved to allow parsing old metadata''',
         type='category', subconfig=tiered_storage_configuration_common)
 ]
 wiredtiger_open_tiered_storage_configuration = [
     Config('tiered_storage', '', r'''
-        enable tiered storage. Enabling tiered storage may use one session from the configured
-        session_max''',
+        Removed options, preserved to allow parsing old metadata''',
         type='category', undoc=True, subconfig=
         tiered_storage_configuration_common + [
         Config('auth_token', '', r'''
-            authentication string identifier'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('bucket', '', r'''
-            bucket string identifier where the objects should reside'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('bucket_prefix', '', r'''
-            unique string prefix to identify our objects in the bucket. Multiple instances
-            can share the storage bucket and this identifier is used in naming objects'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('cache_directory', '', r'''
-            a directory to store locally cached versions of files in the storage source. By
-            default, it is named with \c "-cache" appended to the bucket name. A relative
-            directory name is relative to the home directory'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('interval', '60', r'''
-            interval in seconds at which to check for tiered storage related work to perform''',
-            min=1, max=1000),
+            removed option, preserved to allow parsing old metadata''',
+            min=1, max=1000, undoc=True),
         Config('name', 'none', r'''
-            permitted value is \c "none"'''),
+            removed option, preserved to allow parsing old metadata''', undoc=True),
         Config('shared', 'false', r'''
-            enable sharing tiered tables across other WiredTiger instances.''',
-            type='boolean'),
+            removed option, preserved to allow parsing old metadata''',
+            type='boolean', undoc=True),
     ]),
 ]
 

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -810,14 +810,13 @@ __wt_blkcache_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
 
     WT_RET(__wt_calloc_one(session, &bm));
     __wti_bm_method_set(bm, false);
-    bm->is_multi_handle = false;
 
     if (WT_PREFIX_MATCH(uri, "file:")) {
         uri += strlen("file:");
         WT_ERR(__wt_block_open(session, uri, WT_TIERED_OBJECTID_NONE, cfg, forced_salvage, readonly,
           false, allocsize, lr_fh_meta, &bm->block));
     } else {
-        /* Leftover tiered URIs must not map onto a file or a multi-handle open. */
+        /* Leftover tiered URIs must not map onto a file. */
         WT_ERR(__wt_object_unsupported(session, uri));
     }
 
@@ -825,7 +824,6 @@ __wt_blkcache_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
     return (0);
 
 err:
-    __wt_rwlock_destroy(session, &bm->handle_array_lock);
     __wt_free(session, bm);
     return (ret);
 }

--- a/src/block_cache/block_map.c
+++ b/src/block_cache/block_map.c
@@ -97,7 +97,6 @@ __wti_blkcache_map_read(
     if (!bm->map)
         return (0);
 
-    WT_ASSERT(session, !bm->is_multi_handle);
     WT_ASSERT(session, !bm->is_remote);
 
     block = bm->block;
@@ -106,7 +105,6 @@ __wti_blkcache_map_read(
     WT_RET(__wt_block_addr_unpack(
       session, block, addr, addr_size, &objectid, &offset, &size, &checksum));
 
-    /* Not supported on multi-handle trees */
     WT_ASSERT(session, block->objectid == objectid);
 
     /* Map the block if it's possible. */

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -145,11 +145,9 @@ __bm_checkpoint_load(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, s
     if (checkpoint) {
         /*
          * Read-only objects are optionally mapped into memory instead of being read into cache
-         * buffers. This isn't supported for trees that use multiple files.
+         * buffers.
          */
-        if (!bm->is_multi_handle)
-            WT_RET(
-              __wti_blkcache_map(session, bm->block, &bm->map, &bm->maplen, &bm->mapped_cookie));
+        WT_RET(__wti_blkcache_map(session, bm->block, &bm->map, &bm->maplen, &bm->mapped_cookie));
 
         /*
          * If this handle is for a checkpoint, that is, read-only, there isn't a lot you can do with
@@ -169,15 +167,7 @@ __bm_checkpoint_load(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, s
 static int
 __bm_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool failed)
 {
-    WT_DECL_RET;
-
-    /* If we have made a switch from the older file, resolve the older one instead. */
-    if (bm->prev_block != NULL) {
-        if ((ret = __wt_block_checkpoint_resolve(session, bm->prev_block, failed)) == 0)
-            bm->prev_block = NULL;
-        return (ret);
-    } else
-        return (__wt_block_checkpoint_resolve(session, bm->block, failed));
+    return (__wt_block_checkpoint_resolve(session, bm->block, failed));
 }
 
 /*
@@ -239,26 +229,11 @@ static int
 __bm_close(WT_BM *bm, WT_SESSION_IMPL *session)
 {
     WT_DECL_RET;
-    u_int i;
 
     if (bm == NULL) /* Safety check */
         return (0);
 
-    if (!bm->is_multi_handle)
-        ret = __wti_bm_close_block(session, bm->block);
-    else {
-        /*
-         * Higher-level code ensures that we can only have one call to close a block manager. So we
-         * don't need to lock the block handle array here.
-         *
-         * We don't need to explicitly close the active handle; it is also in the handle array.
-         */
-        for (i = 0; i < bm->handle_array_next; ++i)
-            WT_TRET(__wti_bm_close_block(session, bm->handle_array[i]));
-
-        __wt_rwlock_destroy(session, &bm->handle_array_lock);
-        __wt_free(session, bm->handle_array);
-    }
+    ret = __wti_bm_close_block(session, bm->block);
 
     __wt_overwrite_and_free(session, bm);
     return (ret);
@@ -583,11 +558,7 @@ __bm_stat(WT_BM *bm, WT_SESSION_IMPL *session, WT_DSRC_STATS *stats)
 static int
 __bm_sync(WT_BM *bm, WT_SESSION_IMPL *session, bool block)
 {
-    /* If we have made a switch from the older file, sync the older one instead. */
-    if (bm->prev_block != NULL)
-        return (__wt_fsync(session, bm->prev_block->fh, block));
-    else
-        return (__wt_fsync(session, bm->block->fh, block));
+    return (__wt_fsync(session, bm->block->fh, block));
 }
 
 /*

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -676,28 +676,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
         F_CLR(btree, WT_BTREE_LOGGED);
     }
 
-    WT_RET(__wt_config_gets(session, cfg, "tiered_object", &cval));
-    if (cval.val)
-        F_SET(btree, WT_BTREE_NO_CHECKPOINT);
-    else
-        F_CLR(btree, WT_BTREE_NO_CHECKPOINT);
-
     /* Page sizes */
     WT_RET(__btree_page_sizes(session));
-
-    /* Get the last flush times for tiered storage, if applicable. */
-    btree->flush_most_recent_secs = 0;
-    ret = __wt_config_gets(session, cfg, "flush_time", &cval);
-    WT_RET_NOTFOUND_OK(ret);
-    if (ret == 0)
-        btree->flush_most_recent_secs = (uint64_t)cval.val;
-
-    btree->flush_most_recent_ts = WT_TS_NONE;
-    ret = __wt_config_gets(session, cfg, "flush_timestamp", &cval);
-    WT_RET_NOTFOUND_OK(ret);
-    if (ret == 0 && cval.len != 0)
-        WT_RET(__wt_txn_parse_timestamp_raw(
-          session, "flush timestamp", &btree->flush_most_recent_ts, &cval));
 
     /* Checksums */
     WT_RET(__wt_config_gets(session, cfg, "checksum", &cval));

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -657,17 +657,8 @@ err:
             F_CLR(btree, WT_BTREE_SPECIAL_FLAGS);
     }
 
-    if (WT_DHANDLE_BTREE(dhandle) && session->dhandle != NULL) {
+    if (WT_DHANDLE_BTREE(dhandle) && session->dhandle != NULL)
         __wt_evict_file_exclusive_off(session);
-
-        /*
-         * We want to close the Btree for an object that lives in the local directory. It will
-         * actually be part of the corresponding tiered Btree.
-         */
-        if (__wt_atomic_load_enum_relaxed(&dhandle->type) == WT_DHANDLE_TYPE_BTREE &&
-          WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
-            WT_TRET(__wt_btree_close(session));
-    }
 
     if (ret == ENOENT && F_ISSET(dhandle, WT_DHANDLE_IS_METADATA)) {
         F_SET_ATOMIC_32(S2C(session), WT_CONN_DATA_CORRUPTION);
@@ -769,7 +760,7 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
             if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
               F_ISSET(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_OUTDATED) ||
               !WT_DHANDLE_BTREE(dhandle) || dhandle->checkpoint != NULL ||
-              WT_IS_ANY_METADATA(dhandle) || WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
+              WT_IS_ANY_METADATA(dhandle))
                 continue;
 
             WT_ERR(__conn_btree_apply_internal(session, dhandle, file_func, name_func, cfg));
@@ -1086,7 +1077,7 @@ __wti_verbose_dump_handles(WT_SESSION_IMPL *session)
         WT_RET(__wt_msg(session, "Name: %s", dhandle->name));
         if (dhandle->checkpoint != NULL)
             WT_RET(__wt_msg(session, "Checkpoint: %s", dhandle->checkpoint));
-        WT_RET(__wt_msg(session, "  Handle session and tiered work references: %" PRIu32,
+        WT_RET(__wt_msg(session, "  Handle references: %" PRIu32,
           __wt_atomic_load_uint32_relaxed(&dhandle->references)));
         WT_RET(__wt_msg(session, "  Sessions using handle: %" PRId32,
           __wt_atomic_load_int32_relaxed(&dhandle->session_inuse)));

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -238,8 +238,6 @@ struct __wt_bm {
     int (*salvage_valid)(WT_BM *, WT_SESSION_IMPL *, uint8_t *, size_t, bool);
     int (*size)(WT_BM *, WT_SESSION_IMPL *, wt_off_t *);
     int (*stat)(WT_BM *, WT_SESSION_IMPL *, WT_DSRC_STATS *stats);
-    int (*switch_object)(WT_BM *, WT_SESSION_IMPL *, uint32_t);
-    int (*switch_object_end)(WT_BM *, WT_SESSION_IMPL *, uint32_t);
     int (*sync)(WT_BM *, WT_SESSION_IMPL *, bool);
     int (*verify_addr)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
     int (*verify_end)(WT_BM *, WT_SESSION_IMPL *, bool verify_success);
@@ -248,27 +246,12 @@ struct __wt_bm {
       size_t *, bool, bool);
     int (*write_size)(WT_BM *, WT_SESSION_IMPL *, size_t *);
 
-    WT_BLOCK *block; /* Underlying file. For a multi-handle tree this will be the writable file. */
-    WT_BLOCK *next_block; /* If doing a tier switch, this is going to be the new file. */
-    WT_BLOCK *prev_block; /* If a tier switch was done, this was the old file. */
+    WT_BLOCK *block; /* Underlying file. */
 
     void *map; /* Mapped region */
     size_t maplen;
     void *mapped_cookie;
     bool is_remote; /* Whether the storage is located on a remote host. */
-
-    /*
-     * For trees, such as tiered tables, that are allowed to have more than one backing file or
-     * object, we maintain an array of the block handles used by the tree. We use a reader-writer
-     * mutex to protect the array. We lock it for reading when looking for a handle in the array and
-     * lock it for writing when adding or removing handles in the array.
-     */
-    bool is_multi_handle;
-    WT_BLOCK **handle_array;       /* Array of block handles */
-    size_t handle_array_allocated; /* Size of handle array */
-    WT_RWLOCK handle_array_lock;   /* Lock for block handle array */
-    u_int handle_array_next;       /* Next open slot */
-    uint32_t max_flushed_objectid; /* Local objects at or below this id should be closed */
 
     /*
      * There's only a single block manager handle that can be written, all others are checkpoints.

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -319,9 +319,7 @@ struct __wt_btree {
      * We flush pages from the tree (in order to make checkpoint faster), without a high-level lock.
      * To avoid multiple threads flushing at the same time, lock the tree.
      */
-    WT_SPINLOCK flush_lock;              /* Lock to flush the tree's pages */
-    uint64_t flush_most_recent_secs;     /* Wall clock time for the most recent flush */
-    wt_timestamp_t flush_most_recent_ts; /* Timestamp of the most recent flush */
+    WT_SPINLOCK flush_lock; /* Lock to flush the tree's pages */
 
 /*
  * All of the following fields live at the end of the structure so it's easier to clear everything

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1322,26 +1322,8 @@ struct __wt_session {
      * that is\, when a Btree page is split\, it will be split into smaller pages\, where each page
      * is the specified percentage of the maximum Btree page size., an integer between \c 50 and \c
      * 100; default \c 90.}
-     * @config{tiered_storage = (, configure a storage source for this table., a set of related
-     * configuration options defined as follows.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;auth_token,
-     * authentication string identifier., a string; default empty.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-     * bucket, the bucket indicating the location for this table., a string; default empty.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;bucket_prefix, the unique bucket prefix for this table., a
-     * string; default empty.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;cache_directory, a directory to store
-     * locally cached versions of files in the storage source.  By default\, it is named with \c
-     * "-cache" appended to the bucket name.  A relative directory name is relative to the home
-     * directory., a string; default empty.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;local_retention, time
-     * in seconds to retain data on tiered storage on the local tier for faster read access., an
-     * integer between \c 0 and \c 10000; default \c 300.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;name,
-     * permitted value is \c "none"., a string; default \c none.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-     * shared, enable sharing tiered tables across other WiredTiger instances., a boolean flag;
-     * default \c false.}
+     * @config{tiered_storage = (, Removed options\, preserved to allow parsing old metadata., a set
+     * of related configuration options defined as follows.}
      * @config{ ),,}
      * @config{type, set the type of data source used to store a column group\, index or simple
      * table.  By default\, a \c "file:" URI is derived from the object name.  The \c type
@@ -2532,12 +2514,8 @@ struct __wt_connection {
      * setting this value above 0 configures statistics logging., an integer between \c 0 and \c
      * 100000; default \c 0.}
      * @config{ ),,}
-     * @config{tiered_storage = (, enable tiered storage.  Enabling tiered storage may use one
-     * session from the configured session_max., a set of related configuration options defined as
-     * follows.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;local_retention, time in seconds to retain data on
-     * tiered storage on the local tier for faster read access., an integer between \c 0 and \c
-     * 10000; default \c 300.}
+     * @config{tiered_storage = (, Removed options\, preserved to allow parsing old metadata., a set
+     * of related configuration options defined as follows.}
      * @config{ ),,}
      * @config{verbose, enable messages for various subsystems and operations.  Options are given as
      * a list\, where each message type can optionally define an associated verbosity level\, such

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -271,7 +271,6 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
      * be able to access the WT_FH by first getting to its block manager and then the WT_FH.
      */
     WT_BTREE *btree = CUR2BT(cursor);
-    WT_ASSERT(session, btree->bm->is_multi_handle == false);
 
     /* FIXME-WT-13897 Replace this with an API call into the block manager. */
     WT_WITH_DHANDLE(session, btree->dhandle,

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1372,7 +1372,6 @@ __meta_live_restore_to_meta(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle, W
     if (bm->is_remote)
         return (0);
 
-    WT_ASSERT(session, bm->is_multi_handle == false);
     /* FIXME-WT-13897 Replace this with an API call into the block manager. */
     WT_FILE_HANDLE *fh = bm->block->fh->handle;
     WT_RET_NOTFOUND_OK(__wt_live_restore_fh_to_metadata(session, fh, buf));

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1357,6 +1357,10 @@ __schema_create_config_check(
             WT_RET_SUB(session, EINVAL, WT_CONFLICT_DISAGG,
               "Cold collections only supported when disaggregated storage is enabled");
 
+    if (__wt_config_getones_none(session, config, "tiered_storage.name", &cval) == 0 &&
+      cval.len != 0)
+        WT_RET_MSG(session, ENOTSUP, "tiered storage is not supported");
+
     return (0);
 }
 

--- a/test/suite/test_tiered_deprecate.py
+++ b/test/suite/test_tiered_deprecate.py
@@ -66,6 +66,9 @@ class test_tiered_deprecate(_tiered_uri_deprecate, wttest.WiredTigerTestCase):
     def test_compact(self):
         self._assert_unsupported(lambda: self.session.compact(self._uri()))
 
+    def test_create(self):
+        self._assert_unsupported(lambda: self.session.create(self._uri()))
+
     def test_open_cursor(self):
         self._assert_unsupported(lambda: self.session.open_cursor(self._uri()))
 
@@ -92,10 +95,21 @@ class test_tiered_deprecate_api(wttest.WiredTigerTestCase):
             lambda: self.wiredtiger_open('ts_home', 'create,tiered_storage=(name=dir_store)'),
             '/' + re.escape(msg) + '/')
 
+    def test_create_tiered_storage(self):
+        msg = 'tiered storage is not supported'
+        self.session.create('table:ts_none', 'tiered_storage=(name=none)')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.create('table:ts_name', 'tiered_storage=(name=dir_store)'),
+            '/' + re.escape(msg) + '/')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.create('file:ts_name.wt', 'tiered_storage=(name=dir_store)'),
+            '/' + re.escape(msg) + '/')
+
 class test_tiered_deprecate_truncate(_tiered_uri_deprecate, wttest.WiredTigerTestCase):
     uri_types = [
         ('object', dict(prefix='object:', err_prefix='unsupported object operation')),
         ('tier', dict(prefix='tier:', err_prefix='unknown object type')),
+        ('tiered', dict(prefix='tiered:', err_prefix='unsupported object operation')),
     ]
     scenarios = make_scenarios(uri_types)
 


### PR DESCRIPTION
> This PR was created by an automated coding agent.

Removes leftover block-manager multi-handle state, restyles remaining `tiered_storage` / `tiered_object` parse stubs, and rejects `session.create` of a `tiered:` URI or a table/file with `tiered_storage.name` set.

## Testing
- `python3 ../test/suite/run.py test_tiered_deprecate` → 30 passed
- `./test/catch2/catch2-unittests "[block]"` / `"[block_api]"` / `"[block_api_misc]"` → passed
- `cd dist && ./s_fast` → 0

Made with [Cursor](https://cursor.com)