### PR TITLE
WT-18520 A refused layered drop discards the table's history store content

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -836,6 +836,8 @@ extern int __wt_meta_track_fileop(WT_SESSION_IMPL *session, const char *olduri, 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_track_handle_lock(WT_SESSION_IMPL *session, bool created)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_meta_track_hs_truncate(WT_SESSION_IMPL *session, const char *uri, uint32_t btree_id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_track_init(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -20,6 +20,7 @@ typedef struct __wt_meta_track {
         WT_ST_DROP_COMMIT,        /* Drop post commit */
         WT_ST_DROP_OBJECT_COMMIT, /* Drop an object post commit */
         WT_ST_FILEOP,             /* File operation */
+        WT_ST_HS_TRUNCATE,        /* Truncate the history store post commit */
         WT_ST_LOCK,               /* Lock a handle */
         WT_ST_REMOVE,             /* Remove a metadata entry */
         WT_ST_SET                 /* Reset a metadata entry */
@@ -27,6 +28,7 @@ typedef struct __wt_meta_track {
     char *a, *b;                 /* Strings */
     WT_BUCKET_STORAGE *bstorage; /* Bucket */
     WT_DATA_HANDLE *dhandle;     /* Locked handle */
+    uint32_t btree_id;           /* Btree whose history store content is dropped */
     bool created;                /* Handle on newly created file */
 } WT_META_TRACK;
 
@@ -153,6 +155,16 @@ __meta_track_apply(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
         if ((ret = __wt_block_manager_drop_object(session, trk->bstorage, trk->a, false)) != 0)
             __wt_err(session, ret, "metadata remove dropped object file %s", trk->a);
         break;
+    case WT_ST_HS_TRUNCATE:
+        /* The truncate opens its own cursors, so save our caller's handle. */
+        WT_SAVE_DHANDLE(session, ret = __wt_hs_btree_truncate(session, trk->btree_id));
+        if (ret != 0) {
+            __wt_verbose_warning(session, WT_VERB_HS,
+              "Failed to truncate history store for the file: %s, btree ID: %" PRIu32, trk->a,
+              trk->btree_id);
+            ret = 0;
+        }
+        break;
     case WT_ST_LOCK:
         WT_WITH_DHANDLE(session, trk->dhandle, ret = __wt_session_release_dhandle(session));
         break;
@@ -188,6 +200,8 @@ __meta_track_unroll(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
     case WT_ST_DROP_COMMIT:
         break;
     case WT_ST_DROP_OBJECT_COMMIT:
+        break;
+    case WT_ST_HS_TRUNCATE: /* History store truncate, only done post commit */
         break;
     case WT_ST_LOCK: /* Handle lock, see above */
         if (trk->created)
@@ -516,6 +530,29 @@ __wt_meta_track_drop_object(
     trk->op = WT_ST_DROP_OBJECT_COMMIT;
     trk->bstorage = bstorage;
     WT_ERR(__wt_strdup(session, filename, &trk->a));
+    return (0);
+
+err:
+    __meta_track_err(session);
+    return (ret);
+}
+
+/*
+ * __wt_meta_track_hs_truncate --
+ *     Track a history store truncate, where the truncate is deferred until commit. The btree ID is
+ *     needed because the file's metadata entry, which holds it, is gone by then.
+ */
+int
+__wt_meta_track_hs_truncate(WT_SESSION_IMPL *session, const char *uri, uint32_t btree_id)
+{
+    WT_DECL_RET;
+    WT_META_TRACK *trk;
+
+    WT_RET(__meta_track_next(session, &trk));
+
+    trk->op = WT_ST_HS_TRUNCATE;
+    trk->btree_id = btree_id;
+    WT_ERR(__wt_strdup(session, uri, &trk->a));
     return (0);
 
 err:

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -64,20 +64,18 @@ __drop_file(
       session, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE, "after dropping file entry", uri);
 
     /*
-     * Truncate history store for the dropped file if we can find its id from the metadata, this is
-     * a best-effort operation, as we don't fail drop if truncate returns an error. There is no
-     * history store to truncate for in-memory database, and we should not call truncate if
-     * connection is not ready for history store operations, or if we're truncating a disaggregated
-     * btree on a follower.
+     * Schedule the truncate of the dropped file's history store content, if we can find its id from
+     * the metadata. The truncate cannot be undone, so it must not run until the drop can no longer
+     * fail. There is no history store to truncate for in-memory database, and we should not
+     * truncate if the connection is not ready for history store operations, or if we're truncating
+     * a disaggregated btree on a follower.
      */
     WT_ERR(ret);
     if (id_found && !F_ISSET(conn, WT_CONN_IN_MEMORY) && F_ISSET_ATOMIC_32(conn, WT_CONN_READY) &&
       (!__wt_conn_is_disagg(session) ||
         __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader) ||
         !WT_BTREE_ID_SHARED(id)))
-        if (__wt_hs_btree_truncate(session, id) != 0)
-            __wt_verbose_warning(
-              session, WT_VERB_HS, "Failed to truncate history store for the file: %s", uri);
+        WT_ERR(__wt_meta_track_hs_truncate(session, uri, id));
 err:
     __wt_free(session, metadata_cfg);
     return (ret);

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -63,7 +63,7 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
 
-    def write_rows(self, commit_ts=None, session=None, keys=None):
+    def write_rows(self, commit_ts=None, session=None, keys=None, value='value'):
         """Write nrows to the table, then commit at commit_ts or roll back if it is None."""
         if session is None:
             session = self.session
@@ -72,19 +72,19 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         session.begin_transaction()
         cursor = session.open_cursor(self.uri)
         for i in keys:
-            cursor[i] = 'value'
+            cursor[i] = value
         cursor.close()
         if commit_ts is None:
             session.rollback_transaction()
         else:
             session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
-    def assert_all_rows(self, session):
+    def assert_all_rows(self, session, value='value'):
         """Assert that every written row is readable through the given session."""
         cursor = session.open_cursor(self.uri)
         count = 0
         while cursor.next() == 0:
-            self.assertEqual(cursor.get_value(), 'value')
+            self.assertEqual(cursor.get_value(), value)
             count += 1
         cursor.close()
         self.assertEqual(count, self.nrows)
@@ -460,6 +460,34 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # The stable constituent is dropped before the ingest one, so its metadata removal must
         # have unrolled: both constituents are back.
         self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri, leader=True))
+
+    def test_refused_drop_keeps_the_history_reads_depend_on(self):
+        # A refused drop must leave the table exactly as it was. The drop destroys the stable
+        # constituent before it reaches the ingest one that refuses, and the rows a snapshot below
+        # the newest checkpoint must see live only in the history store.
+        self.publish_and_checkpoint_table()
+        self.write_rows(commit_ts=10, value='old')
+        self.leader_checkpoint(10)
+        self.write_rows(commit_ts=20, value='new')
+        self.leader_checkpoint(20)
+
+        # Past the step-down boundary the commits land in the ingest constituent, which no
+        # checkpoint covers, so the drop is refused.
+        self.conn.set_timestamp('step_down_timestamp=' + self.timestamp_str(30) +
+            ',step_down_disaggregated_schema_epoch=' + self.timestamp_str(10))
+        self.write_rows(commit_ts=40, value='window')
+        self.assert_drop_refused_uncovered(self.session)
+
+        # Every snapshot still reads what it read before the drop was attempted.
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
+        self.assert_all_rows(self.session, value='old')
+        self.session.rollback_transaction()
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
+        self.assert_all_rows(self.session, value='new')
+        self.session.rollback_transaction()
+        self.session.begin_transaction()
+        self.assert_all_rows(self.session, value='window')
+        self.session.rollback_transaction()
 
     def test_drop_on_follower_of_leader_only_data_is_allowed(self):
         # Rows the follower only reads live in the picked-up checkpoint, not in its ingest tree.


### PR DESCRIPTION
`__drop_layered()` drops the stable constituent before the ingest one, and `__drop_file()` truncates the history store for the dropped btree immediately, outside metadata tracking. A failure after that point unrolls the metadata but not the truncation.

Fix: Defer the history store truncation to metadata tracking commit.