### PR TITLE
WT-18521 PALite: Enable checkpoint retrieval by given LSN

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1199,17 +1199,15 @@ struct Checkpoints : public Table<Checkpoints> {
 
         /*
          * Get the latest checkpoint (i.e., checkpoint with the highest lsn) if query lsn equals to
-         * WT_PAGE_LOG_LSN_MAX ( passed as parameter: ?2); otherwise get the checkpoint with the
-         * given lsn.
+         * 0; otherwise get the checkpoint with the given lsn. If no checkpoint exists with the
+         * given lsn, the next closest checkpoint is returned.
          */
         stmt[GET_CHECKPOINT] =
           R"(SELECT lsn, timestamp, checkpoint_metadata
              FROM checkpoints
-             WHERE (?1 = ?2 OR lsn = ?1)
-             ORDER BY
-                 lsn DESC,
-                 timestamp DESC
-             LIMIT 1;)";
+             WHERE lsn = (SELECT CASE WHEN ?1 = 0 THEN MAX(lsn) ELSE MIN(lsn) END
+                          FROM checkpoints
+                          WHERE lsn >= ?1);)";
 
         /*
          * Delete all checkpoints with lsn greater than the given lsn.
@@ -1230,7 +1228,7 @@ struct Checkpoints : public Table<Checkpoints> {
             lsn INTEGER NOT NULL,
             timestamp INTEGER NOT NULL,
             checkpoint_metadata BLOB,
-         PRIMARY KEY (lsn, timestamp));)"};
+         PRIMARY KEY (lsn));)"};
 
     ~Checkpoints() = default;
     Checkpoints(Config &cfg, std::shared_mutex &store_access, const std::filesystem::path &home)
@@ -1263,7 +1261,7 @@ struct Checkpoints : public Table<Checkpoints> {
     }
 
     int
-    get(uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata,
+    get(uint64_t lsn, uint64_t *checkpoint_lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata,
       AccessMode mode = AccessMode::READ)
     {
         auto acc = request(mode);
@@ -1271,11 +1269,12 @@ struct Checkpoints : public Table<Checkpoints> {
 
         Connection::StatementPtr stmt = conn.db_statement(Statement::GET_CHECKPOINT);
         SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(
-          sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(WT_PAGE_LOG_LSN_MAX));
         int ret = SQ_CHECK(sqlite3_step, stmt.get());
         if (ret == SQLITE_DONE) {
             /* No checkpoint found */
+            if (checkpoint_lsn)
+                *checkpoint_lsn = 0;
+
             if (timestamp)
                 *timestamp = 0;
 
@@ -1287,7 +1286,9 @@ struct Checkpoints : public Table<Checkpoints> {
             return WT_NOTFOUND;
         }
 
-        lsn = sqlite3_column_int64(stmt.get(), 0);
+        if (checkpoint_lsn)
+            *checkpoint_lsn = sqlite3_column_int64(stmt.get(), 0);
+
         if (timestamp)
             *timestamp = sqlite3_column_int64(stmt.get(), 1);
 
@@ -2127,9 +2128,10 @@ public:
     }
 
     int
-    get_checkpoint(uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
+    get_checkpoint(
+      uint64_t lsn, uint64_t *checkpoint_lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
     {
-        return checkpoints.get(lsn, timestamp, checkpoint_metadata);
+        return checkpoints.get(lsn, checkpoint_lsn, timestamp, checkpoint_metadata);
     }
 
     void
@@ -2169,13 +2171,14 @@ public:
     void
     abandon_checkpoint()
     {
-        uint64_t checkpoint_lsn = WT_PAGE_LOG_LSN_MAX;
+        uint64_t checkpoint_lsn = 0;
 
         /* Ensure exclusive access to storage since we update multiple tables. */
         std::unique_lock write_lock(store_access);
 
+        /* Request LSN = 0: get the most recent checkpoint. */
         int ret =
-          checkpoints.get(checkpoint_lsn, nullptr, nullptr, Checkpoints::AccessMode::BYPASS);
+          checkpoints.get(0u, &checkpoint_lsn, nullptr, nullptr, Checkpoints::AccessMode::BYPASS);
         if (ret == WT_NOTFOUND) {
             LOG_DEBUG("No checkpoint found to abandon; lsn = {}", checkpoint_lsn);
             return;
@@ -2415,7 +2418,7 @@ public:
     }
 
     int
-    get_complete_checkpoint(uint64_t *checkpoint_lsn, uint64_t *checkpoint_id,
+    get_complete_checkpoint(uint64_t lsn, uint64_t *checkpoint_lsn, uint64_t *checkpoint_id,
       uint64_t *checkpoint_timestamp, WT_ITEM *checkpoint_metadata)
     {
         if (checkpoint_lsn)
@@ -2425,17 +2428,17 @@ public:
         if (checkpoint_timestamp)
             *checkpoint_timestamp = 0;
 
-        uint64_t last_ckpt_lsn = WT_PAGE_LOG_LSN_MAX; /* most recent checkpoint */
-        int ret = storage.get_checkpoint(last_ckpt_lsn, checkpoint_timestamp, checkpoint_metadata);
+        uint64_t ckpt_lsn = 0; /* found checkpoint */
+        int ret = storage.get_checkpoint(lsn, &ckpt_lsn, checkpoint_timestamp, checkpoint_metadata);
 
-        LOG_DEBUG("checkpoint_lsn={}, timestamp={}", last_ckpt_lsn,
+        LOG_DEBUG("request_lsn={}, checkpoint_lsn={}, timestamp={}", lsn, ckpt_lsn,
           checkpoint_timestamp ? *checkpoint_timestamp : 0);
         LOG_TRACE("checkpoint_metadata (size={}) =====\n{}",
           checkpoint_metadata ? checkpoint_metadata->size : 0,
           checkpoint_metadata ? verbose_item(checkpoint_metadata) : "<none>");
 
         if (checkpoint_lsn)
-            *checkpoint_lsn = last_ckpt_lsn;
+            *checkpoint_lsn = ckpt_lsn;
 
         return ret;
     }
@@ -2533,7 +2536,7 @@ static int
 palite_get_complete_checkpoint(
   WT_PAGE_LOG *page_log, WT_SESSION *sess, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args)
 {
-    return safe_call<Palite>(sess, page_log, &Palite::get_complete_checkpoint,
+    return safe_call<Palite>(sess, page_log, &Palite::get_complete_checkpoint, args->lsn,
       &args->checkpoint_lsn, &args->checkpoint_id, &args->checkpoint_timestamp,
       &args->checkpoint_metadata);
 }

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -252,8 +252,37 @@ from packing import pack, unpack
 }
 
 /*
+ * This typemap removes the two last arguments for plh_get_page_ids, and uses local variables for
+ * them instead. The local variables will be used in the matching argout typemap.
+ * Code in this typemap appears before the call to the API function.
+ */
+%typemap(in,numinputs=0) (WT_ITEM *item, size_t *size) (WT_ITEM ids, size_t count) {
+    memset(&ids, 0, sizeof(ids));
+    count = 0;
+    $1 = &ids;
+    $2 = &count;
+}
+
+/*
+ * This typemap is for plh_get_page_ids, and is used in conjunction with the previous typemap.
+ * Code in this typemap appears after the call to the API function.
+ * The packed array of page ids is converted to a python list of integers.
+ */
+%typemap(argout) (WT_ITEM *item, size_t *size) {
+    const uint64_t *ids;
+    size_t n;
+
+    ids = (const uint64_t *)$1->data;
+    $result = PyList_New((Py_ssize_t)*$2);
+    for (n = 0; n < *$2; n++)
+        PyList_SetItem($result, (Py_ssize_t)n, PyLong_FromUnsignedLongLong(ids[n]));
+    free($1->mem);
+}
+
+/*
  * This typemap removes the argument for pl_get_complete_checkpoint and allocates a local
- * WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS struct instead.
+ * WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS struct instead. Zeroing it selects the most recently
+ * completed checkpoint; the wrapper below overwrites the selector when the caller supplies one.
  * Code in this typemap appears before the call to the API function.
  */
 %typemap(in,numinputs=0) WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *
@@ -1221,13 +1250,27 @@ typedef int int_void;
 };
 %enddef
 
+SIDESTEP_METHOD(__wt_page_log, pl_abandon_checkpoint,
+  (WT_SESSION *session),
+  ($self, session))
+
 SIDESTEP_METHOD(__wt_page_log, pl_complete_checkpoint,
   (WT_SESSION *session, WT_PAGE_LOG_COMPLETE_CHECKPOINT_ARGS *args),
   ($self, session, args))
 
-SIDESTEP_METHOD(__wt_page_log, pl_get_complete_checkpoint,
-  (WT_SESSION *session, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args),
-  ($self, session, args))
+/*
+ * Optionally ask for specific checkpoint LSN. If omitted, it defaults to zero, which asks for the
+ * most recently completed checkpoint.
+ */
+%ignore __wt_page_log::pl_get_complete_checkpoint;
+%rename (pl_get_complete_checkpoint) __wt_page_log::_pl_get_complete_checkpoint;
+%extend __wt_page_log {
+    int _pl_get_complete_checkpoint(WT_SESSION *session,
+      WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args, uint64_t lsn = 0) {
+        args->lsn = lsn;
+        return ($self->pl_get_complete_checkpoint($self, session, args));
+     }
+};
 
 SIDESTEP_METHOD(__wt_page_log, pl_get_last_lsn,
   (WT_SESSION *session, uint64_t *lsn),

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5773,11 +5773,18 @@ struct __wt_page_log {
     /*!
      * Get information about the most recently completed checkpoint.
      *
+     * WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS::lsn specifies the LSN of the checkpoint to
+     * retrieve:
+     *     - 0: the most recently completed checkpoint,
+     *     - non-zero: the checkpoint at that LSN if exists, otherwise the next one above it.
+     * A caller that needs a specific checkpoint must check returned checkpoint_lsn.
+     * If no satisfying checkpoint exists, the call returns WT_NOTFOUND.
+     *
      * @errors
      *
      * @param page_log the WT_PAGE_LOG
      * @param session the current WiredTiger session
-     * @param args the most recently completed checkpoint and its metadata, returned by the call
+     * @param args the completed checkpoint and its metadata, returned by the call
      */
     int (*pl_get_complete_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session,
         WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args);
@@ -6012,6 +6019,11 @@ struct __wt_page_log_complete_checkpoint_args {
  * WT_PAGE_LOG::pl_get_complete_checkpoint interface.
  */
 struct __wt_page_log_get_complete_checkpoint_args {
+        /*
+         * Input arguments
+         */
+        uint64_t lsn;                   /* LSN of the checkpoint or 0 for the latest checkpoint. */
+
         /*
          * Output arguments, returned by the call.
          */

--- a/test/suite/test_layered_config07.py
+++ b/test/suite/test_layered_config07.py
@@ -49,8 +49,8 @@ class test_layered_config07(wttest.WiredTigerTestCase, DisaggConfigMixin):
         DisaggConfigMixin.conn_extensions(self, extlist)
 
     def test_disagg_basic(self):
-        # Test some basic functionality of the page log API, calling
-        # each supported method in the API at least once.
+        # Test some basic functionality of the page log API. The methods left out are either
+        # deprecated, or exercised extensively by other tests.
         session = self.session
         page_log = self.conn.get_page_log('palite')
 
@@ -61,6 +61,11 @@ class test_layered_config07(wttest.WiredTigerTestCase, DisaggConfigMixin):
         ckpt_complete_args.lsn = 0
         ckpt_complete_args.checkpoint_oldest_timestamp = 0
         page_log.pl_complete_checkpoint(session, ckpt_complete_args)
+        ckpt1_lsn = ckpt_complete_args.lsn
+
+        # The checkpoint just written is the only one, so it is also the most recent.
+        (lsn, _, ts, meta) = page_log.pl_get_complete_checkpoint(session)
+        self.assertEqual((lsn, ts, meta), (ckpt1_lsn, 0, 'Checkpoint'))
 
         handle = page_log.pl_open_handle(session, 1)
 
@@ -115,5 +120,47 @@ class test_layered_config07(wttest.WiredTigerTestCase, DisaggConfigMixin):
         handle.plh_discard(session, 20, 2, discard_args)
 
         self.assertGreater(discard_args.lsn, put_args_delta.lsn)
+
+        # The last LSN is the one the discard just took.
+        (_, last_lsn) = page_log.pl_get_last_lsn(session)
+        self.assertEqual(last_lsn, discard_args.lsn)
+
+        # The page ids live for this table at a given LSN. Both pages are live before the
+        # discard; at the discard's own LSN page 20 is gone and only page 21 remains.
+        self.assertEqual(sorted(handle.plh_get_page_ids(session, page21_delta1_lsn)), [20, 21])
+        self.assertEqual(sorted(handle.plh_get_page_ids(session, discard_args.lsn)), [21])
+
+        # A second checkpoint, so the selector below has more than one to choose between.
+        ckpt_complete_args.checkpoint_id = 2
+        ckpt_complete_args.checkpoint_timestamp = 5
+        ckpt_complete_args.checkpoint_metadata = 'Checkpoint2'
+        ckpt_complete_args.lsn = 0
+        page_log.pl_complete_checkpoint(session, ckpt_complete_args)
+        ckpt2_lsn = ckpt_complete_args.lsn
+        self.assertGreater(ckpt2_lsn, ckpt1_lsn)
+
+        # No selector and an explicit zero both ask for the most recent checkpoint.
+        for selector in ((), (0,)):
+            (lsn, _, ts, meta) = page_log.pl_get_complete_checkpoint(session, *selector)
+            self.assertEqual((lsn, ts, meta), (ckpt2_lsn, 5, 'Checkpoint2'))
+
+        # A selector naming a checkpoint returns that one; a selector between two checkpoints
+        # returns the next one above it; one above the newest finds nothing.
+        self.assertEqual(page_log.pl_get_complete_checkpoint(session, ckpt1_lsn)[3], 'Checkpoint')
+        self.assertEqual(page_log.pl_get_complete_checkpoint(session, ckpt1_lsn + 1)[0], ckpt2_lsn)
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: page_log.pl_get_complete_checkpoint(session, ckpt2_lsn + 1), '/WT_NOTFOUND/')
+
+        # Abandoning drops everything written above the newest complete checkpoint: the page
+        # written after it goes, the checkpoint itself and the pages below it stay.
+        put_args_main.backlink_lsn = 0
+        put_args_main.base_lsn = 0
+        handle.plh_put(session, 22, 2, put_args_main, encode_bytes('Hello22'))
+        page22_lsn = put_args_main.lsn
+        self.assertEqual(sorted(handle.plh_get_page_ids(session, page22_lsn)), [21, 22])
+
+        page_log.pl_abandon_checkpoint(session)
+        self.assertEqual(sorted(handle.plh_get_page_ids(session, page22_lsn)), [21])
+        self.assertEqual(page_log.pl_get_complete_checkpoint(session)[0], ckpt2_lsn)
 
         page_log.terminate(session) # dereference


### PR DESCRIPTION
Enable PALite to retrieve specific checkpoint by given LSN.
Existing code works as before, no changes required.

In addition:
- update SWIG wrappers
- update tests