### PR TITLE
WT-18523 Reject publishing a schema operation below the last adopted checkpoint epoch

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1399,7 +1399,8 @@ __checkpoint_can_skip(WT_SESSION_IMPL *session, WT_CHECKPOINT_DB_CONFIG *ckpt_cf
     if (!conn->modified && ckpt_cfg->use_timestamp && last_ckpt_ts != WT_TS_NONE &&
       last_ckpt_ts == __wt_get_stable_timestamp(session) &&
       (stable_disagg_epoch == WT_SCHEMA_EPOCH_NONE ||
-        txn_global->last_ckpt_disaggregated_schema_epoch == stable_disagg_epoch)) {
+        __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_disaggregated_schema_epoch) ==
+          stable_disagg_epoch)) {
         ckpt_cfg->can_skip = true;
         return (0);
     }
@@ -2150,7 +2151,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * WT_CONNECTION.rollback_to_stable is an allowed operation.
      */
     if (ckpt_cfg.use_timestamp) {
-        conn->txn_global.last_ckpt_disaggregated_schema_epoch = ckpt_disagg_write_epoch;
+        __wt_atomic_store_uint64_release(
+          &conn->txn_global.last_ckpt_disaggregated_schema_epoch, ckpt_disagg_write_epoch);
         /*
          * MongoDB assumes the checkpoint timestamp will be initialized with WT_TS_NONE. In such
          * cases it queries the recovery timestamp to determine the last stable recovery timestamp.
@@ -2165,7 +2167,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
             ckpt_tmp_ts = conn->txn_global.recovery_timestamp;
         __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, ckpt_tmp_ts);
     } else {
-        conn->txn_global.last_ckpt_disaggregated_schema_epoch = WT_TS_NONE;
+        __wt_atomic_store_uint64_release(
+          &conn->txn_global.last_ckpt_disaggregated_schema_epoch, WT_TS_NONE);
         __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, WT_TS_NONE);
     }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -930,7 +930,7 @@ __wt_disagg_shared_metadata_queue_publish(
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *tmp;
-    wt_timestamp_t prev_schema_epoch, step_down_epoch;
+    wt_timestamp_t last_ckpt_epoch, prev_schema_epoch, step_down_epoch;
 
     conn = S2C(session);
     prev_schema_epoch = WT_SCHEMA_EPOCH_NONE;
@@ -942,6 +942,9 @@ __wt_disagg_shared_metadata_queue_publish(
     /* The schema lock held here serializes the boundary, making the relaxed load safe. */
     step_down_epoch =
       __wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_disaggregated_schema_epoch);
+
+    last_ckpt_epoch =
+      __wt_atomic_load_uint64_relaxed(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
 
     TAILQ_FOREACH_SAFE(entry, &conn->disaggregated_storage.shared_metadata_qh, q, tmp)
     {
@@ -959,6 +962,15 @@ __wt_disagg_shared_metadata_queue_publish(
                   "Cannot publish for table \"%s\" at schema epoch %" PRIu64
                   " at or below the step down boundary %" PRIu64,
                   table_name, schema_epoch, step_down_epoch);
+            /*
+             * The last checkpoint claims to cover everything at or below its epoch, so an entry
+             * stamped there can never reach shared metadata.
+             */
+            if (schema_epoch <= last_ckpt_epoch)
+                WT_ERR_SUB(session, EINVAL, WT_CONFLICT_DISAGG,
+                  "Cannot publish for table \"%s\" at schema epoch %" PRIu64
+                  " at or below the last checkpoint schema epoch %" PRIu64,
+                  table_name, schema_epoch, last_ckpt_epoch);
             __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Publishing metadata operation %s for table \"%s\" to schema epoch %" PRIu64,
               __wti_disagg_shared_metadata_op_to_string(entry->metadata_op), entry->table_name,

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1575,7 +1575,8 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
       &conn->disaggregated_storage.last_checkpoint_timestamp, metadata->checkpoint_timestamp);
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
-    conn->txn_global.last_ckpt_disaggregated_schema_epoch = metadata->schema_epoch;
+    __wt_atomic_store_uint64_release(
+      &conn->txn_global.last_ckpt_disaggregated_schema_epoch, metadata->schema_epoch);
     /* Release store to pair with the acquire load in sweep. */
     __wt_atomic_store_uint64_release(
       &conn->txn_global.last_ckpt_timestamp, metadata->checkpoint_timestamp);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1641,6 +1641,7 @@ __disagg_pick_up_checkpoint(
     WT_DISAGG_METADATA metadata;
     WT_ITEM metadata_buf;
     WT_TIMER pickup_timer;
+    wt_timestamp_t prune_epoch;
     uint64_t current_meta_lsn, pickup_elapsed_ms;
     char ts_string[3][WT_TS_INT_STRING_SIZE];
     bool is_startup;
@@ -1780,15 +1781,6 @@ __disagg_pick_up_checkpoint(
     /*
      * Part 3: Do the bookkeeping.
      *
-     * A node with no live stable epoch is not gating schema operations, so the adopted checkpoint
-     * covers the whole queue and it is cleared.
-     */
-    __wti_disagg_shared_metadata_queue_prune(session,
-      __wt_get_stable_disaggregated_schema_epoch(session) == WT_SCHEMA_EPOCH_NONE ?
-        WT_SCHEMA_EPOCH_NONE :
-        metadata.schema_epoch);
-
-    /*
      * The merge is complete: a failure from here leaves the local metadata resolving to the new
      * checkpoint while the published LSN still admits only the old one, and there is no
      * compensation short of completing the adoption, so it is fatal.
@@ -1796,6 +1788,16 @@ __disagg_pick_up_checkpoint(
     if ((ret = __disagg_finalize_checkpoint_meta(session, ckpt_meta, &metadata)) != 0)
         WT_ERR_PANIC(
           session, ret, "failed to adopt a checkpoint after completing its metadata merge");
+
+    /*
+     * Prune entries the adopted checkpoint covers, once its epoch is published so that a publish is
+     * either rejected against it or removed by this pass. A node with no live stable epoch is not
+     * gating schema operations, and passing no epoch clears the queue outright.
+     */
+    prune_epoch = __wt_get_stable_disaggregated_schema_epoch(session) == WT_SCHEMA_EPOCH_NONE ?
+      WT_SCHEMA_EPOCH_NONE :
+      metadata.schema_epoch;
+    __wti_disagg_shared_metadata_queue_prune(session, prune_epoch);
 
     /* Log the completion of the checkpoint pick-up. */
     __wt_timer_evaluate_ms(session, &pickup_timer, &pickup_elapsed_ms);

--- a/test/suite/test_layered_schema32.py
+++ b/test/suite/test_layered_schema32.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test that publishing at a schema epoch at or below the last adopted
+# checkpoint's epoch is rejected.
+#
+# A checkpoint claims to cover every schema operation published at or below its
+# epoch, so an operation published there can never reach shared metadata. A
+# follower's stable schema epoch legitimately lags the checkpoint it adopted,
+# leaving a range the stable epoch alone does not reject.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema32(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    uri2 = f'layered:{test_name}_b'
+    table_config = 'key_format=i,value_format=S'
+
+    # The epoch the leader's checkpoint is stamped with, and so the epoch the
+    # follower adopts.
+    ckpt_epoch = 10
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def last_epoch(self, conn):
+        """The schema epoch of the most recently adopted or written checkpoint."""
+        return int(conn.query_timestamp('get=last_disaggregated_schema_epoch'), 16)
+
+    def setup_follower_behind_checkpoint(self):
+        """
+        Open a follower whose stable schema epoch sits below the checkpoint it adopted.
+
+        This is the ordinary state of a follower: the stable epoch tracks what the node has
+        applied, while the adopted checkpoint comes from a leader that is ahead of it.
+        """
+        self.set_stable_epoch(1)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, self.ckpt_epoch)
+        self.set_stable_epoch(self.ckpt_epoch)
+        self.leader_checkpoint(1)
+
+        conn_follow, session_follow = self.open_follower_epoch(1)
+        self.assertEqual(self.last_epoch(conn_follow), self.ckpt_epoch)
+        return conn_follow, session_follow
+
+    def assert_publish_rejected(self, session, uri, epoch):
+        """Publishing at this epoch fails, and fails specifically as a disaggregated conflict."""
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.publish(uri, epoch, session))
+        _, sub_level_err, err_msg = session.get_last_error()
+        self.assertEqual(sub_level_err, wiredtiger.WT_CONFLICT_DISAGG)
+        self.assertIn('at or below the last checkpoint schema epoch', err_msg)
+
+    def test_publish_below_last_checkpoint_epoch_rejected(self):
+        """
+        A follower create published in the gap between its stable epoch and the epoch of the
+        checkpoint it adopted is rejected, at the boundary and below it.
+        """
+        conn_follow, session_follow = self.setup_follower_behind_checkpoint()
+
+        session_follow.create(self.uri2, self.table_config)
+
+        # Both epochs clear the follower's stable epoch of 1, so only the checkpoint's epoch
+        # rejects them.
+        self.assert_publish_rejected(session_follow, self.uri2, self.ckpt_epoch - 5)
+        self.assert_publish_rejected(session_follow, self.uri2, self.ckpt_epoch)
+
+        # Above it the same publish succeeds, leaving the table published.
+        self.publish(self.uri2, self.ckpt_epoch + 1, session_follow)
+
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_publish_below_last_checkpoint_epoch_rejected_for_drop(self):
+        """A drop is subject to the same limit as a create."""
+        conn_follow, session_follow = self.setup_follower_behind_checkpoint()
+
+        session_follow.drop(self.uri)
+
+        self.assert_publish_rejected(session_follow, self.uri, self.ckpt_epoch)
+        self.publish(self.uri, self.ckpt_epoch + 1, session_follow)
+
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_rejected_range_grows_with_each_pickup(self):
+        """
+        The rejected range grows as the follower adopts newer checkpoints: an epoch that was
+        publishable before a pickup is rejected after it.
+        """
+        conn_follow, session_follow = self.setup_follower_behind_checkpoint()
+
+        # The leader moves on to a later epoch and checkpoints again.
+        later_epoch = self.ckpt_epoch + 10
+        self.set_stable_epoch(later_epoch)
+        self.leader_checkpoint(2)
+
+        session_follow.create(self.uri2, self.table_config)
+        self.disagg_advance_checkpoint(conn_follow)
+        self.assertEqual(self.last_epoch(conn_follow), later_epoch)
+
+        # This epoch cleared the previously adopted checkpoint but not the new one.
+        self.assert_publish_rejected(session_follow, self.uri2, self.ckpt_epoch + 1)
+        self.publish(self.uri2, later_epoch + 1, session_follow)
+
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_leader_publish_above_own_checkpoint_epoch(self):
+        """
+        A leader publishing above the checkpoint it wrote is unaffected, which is the
+        ordinary path.
+        """
+        self.set_stable_epoch(1)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, self.ckpt_epoch)
+        self.set_stable_epoch(self.ckpt_epoch)
+        self.leader_checkpoint(1)
+        self.assertEqual(self.last_epoch(self.conn), self.ckpt_epoch)
+
+        self.session.create(self.uri2, self.table_config)
+        self.publish(self.uri2, self.ckpt_epoch + 1)


### PR DESCRIPTION
**Summary**

A checkpoint covers every schema operation published at or below its epoch, and the shared
metadata queue relies on that when removing entries. Publishing never enforced it, so an operation
could be stamped below the epoch of a checkpoint the node had already adopted, leaving an entry no
removal path handles correctly. Only followers are exposed. A leader's stable schema epoch is
already floored at its last checkpoint, while a follower's legitimately lags.

**Technical changes**

- Reject a publish at or below the last adopted checkpoint epoch, alongside the existing
  stable-epoch and step-down checks.
- Prune the shared metadata queue after the adoption bookkeeping rather than before it, so the
  adopted epoch is published first.
- Use atomic accesses for the last checkpoint schema epoch (WT-18397, independent first commit).
