### PR TITLE
WT-18527 Propagate __wt_config_next errors across config parsing loops

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -127,7 +127,7 @@ __wt_backup_open(WT_SESSION_IMPL *session)
      */
     F_CLR_ATOMIC_32(conn, WT_CONN_INCR_BACKUP);
     i = 0;
-    while (__wt_config_next(&blkconf, &k, &v) == 0) {
+    while ((ret = __wt_config_next(&blkconf, &k, &v)) == 0) {
         WT_ASSERT(session, i < WT_BLKINCR_MAX);
         /*
          * If we get here, we have at least one valid incremental backup. We want to set up its
@@ -136,6 +136,7 @@ __wt_backup_open(WT_SESSION_IMPL *session)
         WT_ERR(__wt_config_subgets(session, &v, "granularity", &b));
         WT_ERR(__wt_backup_set_blkincr(session, i++, (uint64_t)b.val, k.str, (uint32_t)k.len));
     }
+    WT_ERR_NOTFOUND_OK(ret, false);
 
 err:
     if (ret != 0 && ret != WT_NOTFOUND)

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -421,8 +421,7 @@ __ckpt_last(WT_SESSION_IMPL *session, const char *config, WT_CKPT *ckpt)
         found = a.val;
         WT_RET(__ckpt_load(session, &k, &v, ckpt));
     }
-    if (ret != 0 && ret != WT_NOTFOUND)
-        return (ret);
+    WT_RET_NOTFOUND_OK(ret);
 
     return (found ? 0 : WT_NOTFOUND);
 }

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -108,13 +108,13 @@ __wt_meta_checkpoint_has_prepare(WT_SESSION_IMPL *session, const char *config, b
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
-    for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
+    for (; (ret = __wt_config_next(&ckptconf, &key, &cval)) == 0;) {
         ret = __wt_config_subgets(session, &cval, "prepare", &value);
         if (ret == 0 && value.val)
             *has_prepp = true;
         WT_RET_NOTFOUND_OK(ret);
     }
-    return (0);
+    return (ret == WT_NOTFOUND ? 0 : ret);
 }
 
 /*
@@ -271,7 +271,7 @@ __wt_meta_checkpoint_by_name(WT_SESSION_IMPL *session, const char *uri, const ch
     /*
      * Take the first match: there should never be more than a single checkpoint of any name.
      */
-    while (__wt_config_next(&ckptconf, &k, &v) == 0)
+    while ((ret = __wt_config_next(&ckptconf, &k, &v)) == 0)
         if (WT_CONFIG_MATCH(checkpoint, k)) {
 
             WT_ERR(__wt_config_subgets(session, &v, "order", &a));
@@ -381,6 +381,7 @@ __ckpt_named(WT_SESSION_IMPL *session, const char *checkpoint, const char *confi
 {
     WT_CONFIG ckptconf;
     WT_CONFIG_ITEM k, v;
+    WT_DECL_RET;
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &v));
     __wt_config_subinit(session, &ckptconf, &v);
@@ -388,11 +389,11 @@ __ckpt_named(WT_SESSION_IMPL *session, const char *checkpoint, const char *confi
     /*
      * Take the first match: there should never be more than a single checkpoint of any name.
      */
-    while (__wt_config_next(&ckptconf, &k, &v) == 0)
+    while ((ret = __wt_config_next(&ckptconf, &k, &v)) == 0)
         if (WT_CONFIG_MATCH(checkpoint, k))
             return (__ckpt_load(session, &k, &v, ckpt));
 
-    return (WT_NOTFOUND);
+    return (ret == WT_NOTFOUND ? WT_NOTFOUND : ret);
 }
 
 /*
@@ -404,11 +405,12 @@ __ckpt_last(WT_SESSION_IMPL *session, const char *config, WT_CKPT *ckpt)
 {
     WT_CONFIG ckptconf;
     WT_CONFIG_ITEM a, k, v;
+    WT_DECL_RET;
     int64_t found;
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &v));
     __wt_config_subinit(session, &ckptconf, &v);
-    for (found = 0; __wt_config_next(&ckptconf, &k, &v) == 0;) {
+    for (found = 0; (ret = __wt_config_next(&ckptconf, &k, &v)) == 0;) {
         /* Ignore checkpoints before the ones we've already seen. */
         WT_RET(__wt_config_subgets(session, &v, "order", &a));
         if (found) {
@@ -419,6 +421,8 @@ __ckpt_last(WT_SESSION_IMPL *session, const char *config, WT_CKPT *ckpt)
         found = a.val;
         WT_RET(__ckpt_load(session, &k, &v, ckpt));
     }
+    if (ret != 0 && ret != WT_NOTFOUND)
+        return (ret);
 
     return (found ? 0 : WT_NOTFOUND);
 }
@@ -445,7 +449,7 @@ __wt_ckpt_last_name(WT_SESSION_IMPL *session, const char *config, const char **n
 
     WT_ERR(__wt_config_getones(session, config, "checkpoint", &v));
     __wt_config_subinit(session, &ckptconf, &v);
-    for (found = 0; __wt_config_next(&ckptconf, &k, &v) == 0;) {
+    for (found = 0; (ret = __wt_config_next(&ckptconf, &k, &v)) == 0;) {
 
         /* Ignore checkpoints before (by the order numbering) the ones we've already seen. */
         WT_ERR(__wt_config_subgets(session, &v, "order", &a));
@@ -460,6 +464,7 @@ __wt_ckpt_last_name(WT_SESSION_IMPL *session, const char *config, const char **n
         __wt_free(session, *namep);
         WT_ERR(__wt_strndup(session, k.str, k.len, namep));
     }
+    WT_ERR_NOTFOUND_OK(ret, false);
     if (!found)
         ret = WT_NOTFOUND;
     else {
@@ -931,7 +936,7 @@ __wt_meta_ckptlist_get_from_config(WT_SESSION_IMPL *session, bool update, WT_CKP
     /* Load any existing checkpoints into the array. */
     if ((ret = __wt_config_getones(session, config, "checkpoint", &v)) == 0) {
         __wt_config_subinit(session, &ckptconf, &v);
-        for (; __wt_config_next(&ckptconf, &k, &v) == 0; ++slot) {
+        for (; (ret = __wt_config_next(&ckptconf, &k, &v)) == 0; ++slot) {
             /*
              * Allocate a slot for a new value, plus a slot to mark the end.
              */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -393,7 +393,7 @@ __ckpt_named(WT_SESSION_IMPL *session, const char *checkpoint, const char *confi
         if (WT_CONFIG_MATCH(checkpoint, k))
             return (__ckpt_load(session, &k, &v, ckpt));
 
-    return (ret == WT_NOTFOUND ? WT_NOTFOUND : ret);
+    return (ret);
 }
 
 /*

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -340,7 +340,7 @@ __wti_rts_btree_walk_btree_apply(
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
-    for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
+    for (; (ret = __wt_config_next(&ckptconf, &key, &cval)) == 0;) {
         ret = __wt_config_subgets(session, &cval, "newest_start_durable_ts", &value);
         if (ret == 0)
             newest_start_durable_ts = WT_MAX(newest_start_durable_ts, (wt_timestamp_t)value.val);
@@ -378,6 +378,9 @@ __wti_rts_btree_walk_btree_apply(
               __wt_timestamp_to_string(newest_stop_durable_ts, ts_string[1]), rollback_txnid,
               write_gen);
     }
+    if (ret != 0 && ret != WT_NOTFOUND)
+        return (ret);
+
     max_durable_ts = WT_MAX(newest_start_durable_ts, newest_stop_durable_ts);
 
     /*

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -378,8 +378,7 @@ __wti_rts_btree_walk_btree_apply(
               __wt_timestamp_to_string(newest_stop_durable_ts, ts_string[1]), rollback_txnid,
               write_gen);
     }
-    if (ret != 0 && ret != WT_NOTFOUND)
-        return (ret);
+    WT_RET_NOTFOUND_OK(ret);
 
     max_durable_ts = WT_MAX(newest_start_durable_ts, newest_stop_durable_ts);
 

--- a/src/rollback_to_stable/rts_history.c
+++ b/src/rollback_to_stable/rts_history.c
@@ -147,7 +147,7 @@ __wti_rts_history_final_pass(WT_SESSION_IMPL *session, wt_timestamp_t rollback_t
     newest_stop_durable_ts = newest_stop_ts = WT_TS_NONE;
     WT_ERR(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
-    for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
+    for (; (ret = __wt_config_next(&ckptconf, &key, &cval)) == 0;) {
         ret = __wt_config_subgets(session, &cval, "newest_stop_durable_ts", &durableval);
         if (ret == 0)
             newest_stop_durable_ts = WT_MAX(newest_stop_durable_ts, (wt_timestamp_t)durableval.val);
@@ -157,6 +157,7 @@ __wti_rts_history_final_pass(WT_SESSION_IMPL *session, wt_timestamp_t rollback_t
             newest_stop_ts = WT_MAX(newest_stop_ts, (wt_timestamp_t)durableval.val);
         WT_ERR_NOTFOUND_OK(ret, false);
     }
+    WT_ERR_NOTFOUND_OK(ret, false);
     max_durable_ts = WT_MAX(newest_stop_ts, newest_stop_durable_ts);
     WT_ERR(__wt_session_get_dhandle(session, WT_HS_URI, NULL, NULL, 0));
     release_dhandle = true;

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -643,7 +643,7 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
 
         if (!is_unnamed_ckpt)
             /* Copy the checkpoint name first because we may need it to get the first wall time. */
-            WT_RET(__wt_strndup(session, cval.str, cval.len, &checkpoint));
+            WT_ERR(__wt_strndup(session, cval.str, cval.len, &checkpoint));
 
         if (ckpt_snapshot != NULL) {
             /* We're about to re-fetch this; discard the prior version. No effect the first time. */
@@ -653,32 +653,35 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
              * Now, as the first step of the retrieval process, get the wall-clock time of the
              * snapshot metadata (only). If we need the name, we'll have copied it already.
              */
-            WT_RET(__session_fetch_checkpoint_snapshot_wall_time(
+            WT_ERR(__session_fetch_checkpoint_snapshot_wall_time(
               session, is_unnamed_ckpt ? NULL : checkpoint, &first_snapshot_time));
         }
 
         if (is_unnamed_ckpt)
             /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
-            WT_RET(__wt_meta_checkpoint_last_name(session, uri, &checkpoint, &ds_order, &ds_time));
+            WT_ERR(__wt_meta_checkpoint_last_name(session, uri, &checkpoint, &ds_order, &ds_time));
         else
             /* Look up the checkpoint by name and get its time and order information. */
-            WT_RET(__wt_meta_checkpoint_by_name(session, uri, checkpoint, &ds_order, &ds_time));
+            WT_ERR(__wt_meta_checkpoint_by_name(session, uri, checkpoint, &ds_order, &ds_time));
 
         /* Look up the history store checkpoint. */
         if (hs_dhandlep != NULL) {
             if (is_unnamed_ckpt)
-                WT_RET_NOTFOUND_OK(__wt_meta_checkpoint_last_name(session,
-                  __wt_conn_is_disagg(session) ? WT_HS_URI_SHARED : WT_HS_URI, &hs_checkpoint,
-                  &hs_order, &hs_time));
+                /* Clear the return value; a missing history store checkpoint must not retry. */
+                WT_ERR_NOTFOUND_OK(__wt_meta_checkpoint_last_name(session,
+                                     __wt_conn_is_disagg(session) ? WT_HS_URI_SHARED : WT_HS_URI,
+                                     &hs_checkpoint, &hs_order, &hs_time),
+                  false);
             else {
                 ret = __wt_meta_checkpoint_by_name(session,
                   __wt_conn_is_disagg(session) ? WT_HS_URI_SHARED : WT_HS_URI, checkpoint,
                   &hs_order, &hs_time);
-                WT_RET_NOTFOUND_OK(ret);
+                /* Keep the return value; the test below distinguishes a missing checkpoint. */
+                WT_ERR_NOTFOUND_OK(ret, true);
                 if (ret == WT_NOTFOUND)
                     ret = 0;
                 else
-                    WT_RET(__wt_strdup(session, checkpoint, &hs_checkpoint));
+                    WT_ERR(__wt_strdup(session, checkpoint, &hs_checkpoint));
             }
         }
 
@@ -687,7 +690,7 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
          * checkpoint times) for each element.
          */
         if (ckpt_snapshot != NULL) {
-            WT_RET(__session_fetch_checkpoint_meta(session, is_unnamed_ckpt ? NULL : checkpoint,
+            WT_ERR(__session_fetch_checkpoint_meta(session, is_unnamed_ckpt ? NULL : checkpoint,
               ckpt_snapshot, &snapshot_time, &stable_time, &oldest_time));
 
             /*

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -621,7 +621,8 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
 
     /* This is the top of a retry loop. */
     do {
-        ret = 0;
+        /* All code paths below overwrite the return value, but clear it here to be defensive. */
+        WT_NOT_READ(ret, 0);
 
         /*
          * Save the checkpoint generation number and the checkpoint's state to detect races.


### PR DESCRIPTION
## Summary
- Capture the return value of `__wt_config_next()` in all metadata parsing loops that previously discarded it.
- Propagate non-`WT_NOTFOUND` errors instead of silently returning `WT_NOTFOUND` or `0`.
- Fix `__wt_meta_checkpoint_by_name()` to return `WT_NOTFOUND` when the requested named checkpoint does not exist, matching caller expectations.