### PR TITLE
WT-18534 Require both disaggregated and read-only flags in __wt_btree_is_outdated_disagg

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -43,8 +43,8 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 static WT_INLINE bool
 __wt_btree_is_outdated_disagg(WT_SESSION_IMPL *session)
 {
-    return ((F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
-              F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY)) &&
+    return (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+      F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY) &&
       F_ISSET(session->dhandle, WT_DHANDLE_OUTDATED));
 }
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -43,7 +43,7 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 static WT_INLINE bool
 __wt_btree_is_outdated_disagg(WT_SESSION_IMPL *session)
 {
-    return ((F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) ||
+    return ((F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
               F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY)) &&
       F_ISSET(session->dhandle, WT_DHANDLE_OUTDATED));
 }


### PR DESCRIPTION
## Summary
- `__wt_btree_is_outdated_disagg` combined the `WT_BTREE_DISAGGREGATED` and `WT_BTREE_READONLY` checks with `||` instead of `&&`, so it returned true when the dhandle was outdated and only one of the two flags was set.
- Every caller's intent (comments in `evict_page.c`, and the commit that introduced this check in `bt_split.c`) describes a btree that is simultaneously disaggregated, read-only, and outdated — not either/or.
- Changed the operator to `&&` so both flags must be set.

