### PR TITLE
WT-17636 Remove dead prepared-key checks from test_checkpoint20

### DIFF
--- a/test/suite/test_checkpoint20.py
+++ b/test/suite/test_checkpoint20.py
@@ -28,7 +28,6 @@
 
 import threading, time
 import wttest
-import wiredtiger
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -97,21 +96,6 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         self.assertEqual(count, nrows)
         cursor.close()
 
-    def checkfail(self, ds, ckpt, key, ts):
-        if ckpt is None:
-            ckpt = 'WiredTigerCheckpoint'
-        cfg = 'checkpoint=' + ckpt
-        if ts is not None:
-            cfg += ',debug=(checkpoint_read_timestamp=' + self.timestamp_str(ts) + ')'
-        cursor = self.session.open_cursor(ds.uri, None, cfg)
-        #self.session.begin_transaction()
-        cursor.set_key(ds.key(key))
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.search(),
-            '/conflict with a prepared/')
-        #self.session.rollback_transaction()
-        cursor.close()
-
     def test_checkpoint(self):
         uri = 'table:checkpoint20'
         nrows = 10000
@@ -159,8 +143,3 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         self.check(ds, self.first_checkpoint, nrows, value_a, 10)
         self.check(ds, self.first_checkpoint, nrows, value_a, 20)
         self.check(ds, self.first_checkpoint, nrows, value_a, None)
-
-        # Without ignore_prepare, we'd want to check that one of the prepared keys fails.
-        #self.checkfail(ds, self.first_checkpoint, nrows // 2 + 1, 20)
-        #if self.stable_ts >= 20:
-        #    self.checkfail(ds, self.first_checkpoint, nrows // 2 + 1, None)


### PR DESCRIPTION
The test asserts that checkpoint cursors always use `ignore_prepare`, which makes the commented-out negative path immediately below it unreachable by design rather than temporarily disabled. Removed it, along with the `checkfail` helper it was the only caller of and the `wiredtiger` import that helper was the only user of.