### PR TITLE
WT-17366 Read a reference's home page before its key when decoding row-store keys

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -105,6 +105,7 @@ __compact_page_replace_addr(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY 
     WT_ADDR *addr;
     WT_CELL_UNPACK_ADDR unpack;
     WT_DECL_RET;
+    WT_PAGE *home;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &S2BT(session)->flush_lock);
 
@@ -115,10 +116,12 @@ __compact_page_replace_addr(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY 
     addr = ref->addr;
     WT_ASSERT(session, addr != NULL);
 
-    if (__wt_off_page(ref->home, addr))
+    /* Read the home page once; the off-page test and the cell it selects have to agree. */
+    home = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
+    if (__wt_off_page(home, addr))
         __wti_ref_addr_safe_free(session, addr->block_cookie, addr->block_cookie_size);
     else {
-        __wt_cell_unpack_addr(session, ref->home->dsk, (WT_CELL *)addr, &unpack);
+        __wt_cell_unpack_addr(session, home->dsk, (WT_CELL *)addr, &unpack);
 
         WT_RET(__wt_calloc_one(session, &addr));
         addr->ta.newest_start_durable_ts = unpack.ta.newest_start_durable_ts;

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -324,7 +324,7 @@ __wt_ref_addr_free(WT_SESSION_IMPL *session, WT_REF *ref)
      * new parent, which would mean that our ref->addr must have been instantiated and thus we are
      * safe to free it at the end of this function.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(home, ref->home);
+    home = (WT_PAGE *)__wt_atomic_load_ptr_acquire(&ref->home);
     do {
         WT_ACQUIRE_READ_WITH_BARRIER(ref_addr, ref->addr);
         if (ref_addr == NULL)

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -993,7 +993,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 
         WT_INTL_INDEX_GET_SAFE(root, pindex);
         ref = pindex->index[0];
-        ref->home = root;
+        __wt_atomic_store_ptr_relaxed(&ref->home, root);
         ref->page = NULL;
         ref->addr = NULL;
         F_SET(ref, WT_REF_FLAG_LEAF);
@@ -1006,7 +1006,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 
         WT_INTL_INDEX_GET_SAFE(root, pindex);
         ref = pindex->index[0];
-        ref->home = root;
+        __wt_atomic_store_ptr_relaxed(&ref->home, root);
         ref->page = NULL;
         ref->addr = NULL;
         F_SET(ref, WT_REF_FLAG_LEAF);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1431,7 +1431,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
     hint = 0;
     WT_CELL_FOREACH_ADDR (session, page->dsk, unpack) {
         ref = *refp;
-        ref->home = page;
+        __wt_atomic_store_ptr_relaxed(&ref->home, page);
         ref->pindex_hint = hint++;
 
         switch (unpack.type) {

--- a/src/btree/bt_prefetch.c
+++ b/src/btree/bt_prefetch.c
@@ -48,7 +48,7 @@ __wti_btree_prefetch(WT_SESSION_IMPL *session, WT_REF *ref)
      * evaluate to false and the counter will be reset, effectively marking the ref as available to
      * pre-fetch from.
      */
-    if (session->pf.prefetch_prev_ref_home == ref->home &&
+    if (session->pf.prefetch_prev_ref_home == (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home) &&
       session->pf.prefetch_skipped_with_parent < WT_PREFETCH_QUEUE_PER_TRIGGER) {
         ++session->pf.prefetch_skipped_with_parent;
         WT_STAT_CONN_INCR(session, prefetch_skipped_same_ref);
@@ -58,7 +58,7 @@ __wti_btree_prefetch(WT_SESSION_IMPL *session, WT_REF *ref)
     session->pf.prefetch_skipped_with_parent = 0;
 
     /* Load and decompress a set of pages into the block cache. */
-    WT_INTL_FOREACH_BEGIN (session, ref->home, next_ref) {
+    WT_INTL_FOREACH_BEGIN (session, (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home), next_ref) {
         /* Don't let the pre-fetch queue get overwhelmed. */
         if (__wt_tsan_suppress_load_uint64(&conn->prefetch.queue_count) > WT_MAX_PREFETCH_QUEUE ||
           block_preload > WT_PREFETCH_QUEUE_PER_TRIGGER)
@@ -89,7 +89,7 @@ __wti_btree_prefetch(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
     WT_INTL_FOREACH_END;
-    session->pf.prefetch_prev_ref_home = ref->home;
+    session->pf.prefetch_prev_ref_home = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
 
     WT_STAT_CONN_INCRV(session, prefetch_pages_queued, block_preload);
     return (ret);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1146,7 +1146,7 @@ __slvg_col_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
             continue;
 
         ref = *refp++;
-        ref->home = page;
+        __wt_atomic_store_ptr_relaxed(&ref->home, page);
         ref->page = NULL;
 
         WT_ERR(__wt_calloc_one(session, &addr));
@@ -1742,7 +1742,7 @@ __slvg_row_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
             continue;
 
         ref = *refp++;
-        ref->home = page;
+        __wt_atomic_store_ptr_relaxed(&ref->home, page);
         ref->page = NULL;
 
         WT_ERR(__wt_calloc_one(session, &addr));
@@ -1882,7 +1882,8 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref, WT_S
      */
     rip = page->pg_row + skip_start;
     WT_ERR(__wt_row_leaf_key(session, page, rip, key, false));
-    WT_ERR(__wti_row_ikey_incr(session, ref->home, 0, key->data, key->size, ref));
+    WT_ERR(__wti_row_ikey_incr(
+      session, (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home), 0, key->data, key->size, ref));
 
     /* Set the referenced flag on overflow pages we're using. */
     if (trk->trk_ovfl_cnt != 0)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -69,7 +69,7 @@ __split_verify_intl_key_order(WT_SESSION_IMPL *session, WT_PAGE *page)
     case WT_PAGE_COL_INT:
         recno = 0; /* Less than any valid record number. */
         WT_INTL_FOREACH_BEGIN (session, page, ref) {
-            WT_ASSERT_ALWAYS(session, ref->home == page,
+            WT_ASSERT_ALWAYS(session, __wt_atomic_load_ptr_relaxed(&ref->home) == page,
               "Internal page in illegal state, child ref is referencing an incorrect page");
             WT_ASSERT_ALWAYS(
               session, ref->ref_recno > recno, "Out of order refs detected in parent index");
@@ -85,7 +85,7 @@ __split_verify_intl_key_order(WT_SESSION_IMPL *session, WT_PAGE *page)
 
         slot = 0;
         WT_INTL_FOREACH_BEGIN (session, page, ref) {
-            WT_ASSERT_ALWAYS(session, ref->home == page,
+            WT_ASSERT_ALWAYS(session, __wt_atomic_load_ptr_relaxed(&ref->home) == page,
               "Internal page in illegal state, child ref is referencing an incorrect page");
 
             /*
@@ -228,7 +228,8 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home, WT_REF **from_ref
         if ((ikey = __wt_ref_key_instantiated(ref)) == NULL) {
             __wt_ref_key(from_home, ref, &key, &size);
             WT_RET(__wti_row_ikey(session, 0, key, size, ref));
-            ikey = ref->ref_ikey;
+            /* Relaxed: this thread published the key immediately above. */
+            ikey = __wt_atomic_load_ptr_relaxed(&ref->ref_ikey);
         } else {
             WT_RET(__split_ovfl_key_cleanup(session, from_home, ref));
             *decrp += sizeof(WT_IKEY) + ikey->size;
@@ -368,10 +369,21 @@ __split_ref_prepare(
 
         WT_PAGE_LOCK(session, child);
 
-        /* Switch the WT_REF's to their new page. */
+        /*
+         * Switch the WT_REF's to their new page. The created children have no disk image, so every
+         * key must already have been instantiated: an encoded key would decode against a NULL image
+         * once a reader picks up the new home page.
+         */
         j = 0;
         WT_INTL_FOREACH_BEGIN (session, child, child_ref) {
-            child_ref->home = child;
+            WT_ASSERT(session,
+              child->type != WT_PAGE_ROW_INT || __wt_ref_key_instantiated(child_ref) != NULL);
+            /*
+             * Publish the new home page with a release so a reader that picks it up also sees the
+             * key and address instantiated above; the created page has no disk image, so an on-page
+             * key or address paired with it would be decoded against nothing.
+             */
+            __wt_atomic_store_ptr_release(&child_ref->home, child);
             child_ref->pindex_hint = j++;
         }
         WT_INTL_FOREACH_END;
@@ -466,7 +478,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
          * Initialize the page's child reference; we need a copy of the page's key.
          */
         ref = *alloc_refp++;
-        ref->home = root;
+        __wt_atomic_store_ptr_relaxed(&ref->home, root);
         ref->page = child;
         ref->addr = NULL;
         if (root->type == WT_PAGE_ROW_INT) {
@@ -672,7 +684,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
 #endif
 
     btree = S2BT(session);
-    parent = ref->home;
+    parent = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
 
     alloc_index = pindex = NULL;
     parent_decr = 0;
@@ -771,7 +783,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
         next_ref = pindex->index[i];
         if (next_ref == ref) {
             for (j = 0; j < new_entries; ++j) {
-                ref_new[j]->home = parent;
+                __wt_atomic_store_ptr_relaxed(&ref_new[j]->home, parent);
                 ref_new[j]->pindex_hint = hint++;
                 *alloc_refp++ = ref_new[j];
             }
@@ -1039,7 +1051,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
          * Initialize the page's child reference; we need a copy of the page's key.
          */
         ref = *alloc_refp++;
-        ref->home = parent;
+        __wt_atomic_store_ptr_relaxed(&ref->home, parent);
         ref->page = child;
         ref->addr = NULL;
         if (page->type == WT_PAGE_ROW_INT) {
@@ -1246,7 +1258,7 @@ __split_internal_lock(WT_SESSION_IMPL *session, WT_REF *ref, bool trylock, WT_PA
      * to use a different lock if we have to block reconciliation anyway.
      */
     for (;;) {
-        parent = ref->home;
+        parent = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
 
         /* Encourage races. */
         __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_7, NULL);
@@ -1258,7 +1270,7 @@ __split_internal_lock(WT_SESSION_IMPL *session, WT_REF *ref, bool trylock, WT_PA
             WT_RET(WT_PAGE_TRYLOCK(session, parent));
         } else
             WT_PAGE_LOCK(session, parent);
-        if (parent == ref->home)
+        if (parent == (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home))
             break;
         WT_PAGE_UNLOCK(session, parent);
     }
@@ -1928,7 +1940,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
     case WT_PAGE_ROW_LEAF:
         delta_enabled = WT_DELTA_ENABLED_FOR_PAGE(session, page->type);
         if (delta_enabled && first) {
-            __wt_ref_key(old_ref->home, old_ref, &key, &key_size);
+            __wt_ref_key_home(old_ref, &key, &key_size);
             WT_RET(__wti_row_ikey(session, 0, key, key_size, ref));
             if (incrp)
                 *incrp += sizeof(WT_IKEY) + key_size;
@@ -1979,7 +1991,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
         WT_REF_SET_STATE(ref, WT_REF_DISK);
     } else if (delta_enabled && multi_entries == 1 && old_ref->addr != NULL) {
         old_addr = (WT_ADDR *)old_ref->addr;
-        if (!__wt_off_page(old_ref->home, old_addr))
+        if (!__wt_off_page((WT_PAGE *)__wt_atomic_load_ptr_relaxed(&old_ref->home), old_addr))
             ref->addr = old_addr;
         else {
             WT_RET(__wt_calloc_one(session, &addr));
@@ -2058,13 +2070,13 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     parent_incr += sizeof(WT_REF);
     child = split_ref[0];
     child->page = ref->page;
-    child->home = ref->home;
+    __wt_atomic_store_ptr_relaxed(&child->home, __wt_atomic_load_ptr_relaxed(&ref->home));
     child->pindex_hint = ref->pindex_hint;
     F_SET(child, WT_REF_FLAG_LEAF);
     WT_REF_SET_STATE(child, WT_REF_MEM); /* Visible as soon as the split completes. */
     child->addr = ref->addr;
     if (type == WT_PAGE_ROW_LEAF) {
-        __wt_ref_key(ref->home, ref, &key, &key_size);
+        __wt_ref_key_home(ref, &key, &key_size);
         WT_ERR(__wti_row_ikey(session, 0, key, key_size, child));
         parent_incr += sizeof(WT_IKEY) + key_size;
     } else

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -300,7 +300,8 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
     /* Ignore internal pages, these are taken care of during reconciliation. */
     if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
-          "%p: skipping internal page with parent: %p", (void *)ref, (void *)ref->home);
+          "%p: skipping internal page with parent: %p", (void *)ref,
+          (void *)__wt_atomic_load_ptr_relaxed(&ref->home));
         return (0);
     }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -838,7 +838,7 @@ __verify_tree(
     WT_BTREE *btree;
     WT_CELL_UNPACK_ADDR *unpack, _unpack;
     WT_DECL_RET;
-    WT_PAGE *page;
+    WT_PAGE *home, *page;
     WT_REF *child_ref;
     size_t my_stack_level, next_stack_level;
     uint32_t entry;
@@ -846,6 +846,7 @@ __verify_tree(
     btree = S2BT(session);
     bm = btree->bm;
     unpack = &_unpack;
+    home = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
     page = ref->page;
 
     /*
@@ -961,11 +962,11 @@ __verify_tree(
          * been completed, the parent page's write generation number must be higher than that of its
          * children.
          */
-        if (!__wt_ref_is_root(ref) && page->dsk->write_gen >= ref->home->dsk->write_gen)
+        if (!__wt_ref_is_root(ref) && page->dsk->write_gen >= home->dsk->write_gen)
             WT_RET_MSG(session, EINVAL,
               "child write generation number %" PRIu64
               " is greater/equal to the parent page write generation number %" PRIu64,
-              page->dsk->write_gen, ref->home->dsk->write_gen);
+              page->dsk->write_gen, home->dsk->write_gen);
 
         switch (page->type) {
         case WT_PAGE_COL_INT:
@@ -1073,7 +1074,9 @@ celltype_err:
             }
 
             /* Unpack the address block and check timestamps */
-            __wt_cell_unpack_addr(session, child_ref->home->dsk, child_ref->addr, unpack);
+            __wt_cell_unpack_addr(session,
+              ((WT_PAGE *)__wt_atomic_load_ptr_relaxed(&child_ref->home))->dsk, child_ref->addr,
+              unpack);
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
 
             /*
@@ -1141,7 +1144,9 @@ celltype_err:
                 WT_RET(__verify_row_int_key_order(session, page, child_ref, entry, vs));
 
             /* Unpack the address block and check timestamps */
-            __wt_cell_unpack_addr(session, child_ref->home->dsk, child_ref->addr, unpack);
+            __wt_cell_unpack_addr(session,
+              ((WT_PAGE *)__wt_atomic_load_ptr_relaxed(&child_ref->home))->dsk, child_ref->addr,
+              unpack);
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
 
             /*

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -90,7 +90,7 @@ __split_prev_race(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pindexp
      * until the page-index is updated, but I'm not willing to debug that
      * one if I'm wrong.)
      */
-    if (pindex->index[pindex->entries - 1]->home != ref->page)
+    if (__wt_atomic_load_ptr_relaxed(&pindex->index[pindex->entries - 1]->home) != ref->page)
         return (true);
 
     *pindexp = pindex;

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -42,7 +42,7 @@ __check_leaf_key_range(WT_SESSION_IMPL *session, uint64_t recno, WT_REF *leaf, W
      * do that latter check before looking at the indx slot of the array
      * for a match to leaf (in other words, our page hint might be wrong).
      */
-    WT_INTL_INDEX_GET(session, leaf->home, pindex);
+    WT_INTL_INDEX_GET(session, (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&leaf->home), pindex);
     indx = leaf->pindex_hint;
     if (indx + 1 < pindex->entries && pindex->index[indx] == leaf)
         if (recno >= pindex->index[indx + 1]->ref_recno) {

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -411,7 +411,8 @@ __wti_row_ikey(
     {
         uintptr_t oldv;
 
-        oldv = (uintptr_t)ref->ref_ikey;
+        /* Relaxed: the compare-and-swap below provides the ordering. */
+        oldv = (uintptr_t)__wt_atomic_load_ptr_relaxed(&ref->ref_ikey);
         WT_DIAGNOSTIC_YIELD;
 
         /*
@@ -424,7 +425,12 @@ __wti_row_ikey(
         WT_ASSERT(session, cas_success);
     }
 #else
-    ref->ref_ikey = ikey;
+    /*
+     * Publish the key before a split can move this reference to a home page with no disk image; a
+     * reader that sees the new home must see the instantiated key. Pairs with the acquire reads of
+     * the key.
+     */
+    __wt_atomic_store_ptr_release(&ref->ref_ikey, ikey);
 #endif
     return (0);
 }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -256,7 +256,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
             WT_ENTER_PAGE_INDEX(session);
             __wt_ref_index_slot(session, cbt->ref, &pindex, &slot);
             if (slot != 0) {
-                __wt_ref_key(cbt->ref->home, cbt->ref, &ref_key.data, &ref_key.size);
+                __wt_ref_key_home(cbt->ref, &ref_key.data, &ref_key.size);
                 WT_IGNORE_RET(__wt_compare(session, S2BT(session)->collator, key, &ref_key, &cmp));
                 WT_ASSERT(session, cmp >= 0);
             }

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -310,7 +310,7 @@ __check_leaf_key_range(
      * First, confirm we have the right parent page-index slot, and quit if we don't. We don't
      * search for the correct slot, that would make this cheap test expensive.
      */
-    WT_INTL_INDEX_GET(session, leaf->home, pindex);
+    WT_INTL_INDEX_GET(session, (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&leaf->home), pindex);
     indx = leaf->pindex_hint;
     if (indx >= pindex->entries || pindex->index[indx] != leaf)
         return (0);
@@ -322,7 +322,7 @@ __check_leaf_key_range(
      * build it, it may not be a valid key.
      */
     if (indx != 0) {
-        __wt_ref_key(leaf->home, leaf, &item->data, &item->size);
+        __wt_ref_key_home(leaf, &item->data, &item->size);
         WT_RET(__wt_compare(session, collator, srch_key, item, &cmp));
         if (cmp < 0) {
             cbt->compare = 1; /* page keys > search key */
@@ -336,7 +336,7 @@ __check_leaf_key_range(
      */
     ++indx;
     if (indx < pindex->entries) {
-        __wt_ref_key(leaf->home, pindex->index[indx], &item->data, &item->size);
+        __wt_ref_key_home(pindex->index[indx], &item->data, &item->size);
         WT_RET(__wt_compare(session, collator, srch_key, item, &cmp));
         if (cmp >= 0) {
             cbt->compare = -1; /* page keys < search key */

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -575,7 +575,7 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
      * have already been freed.
      */
     if (!LF_ISSET(WT_EVICT_CALL_NO_SPLIT | WT_EVICT_CALL_CLOSING)) {
-        parent = ref->home;
+        parent = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
         WT_INTL_INDEX_GET(session, parent, pindex);
         ndeleted = __wt_atomic_add_uint32_v(&pindex->deleted_entries, 1);
 

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1306,7 +1306,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, u_int max_en
     root_pages_skipped = 0;
     for (evict_entry = start, pages_already_queued = pages_queued = pages_seen = refs_walked = 0;
       evict_entry < end && (ret == 0 || ret == WT_NOTFOUND);
-      last_parent = ref == NULL ? NULL : ref->home,
+      last_parent = ref == NULL ? NULL : (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home),
         ret = __wt_tree_walk_count(session, &ref, &refs_walked, walk_flags)) {
 
         if ((give_up = __evict_should_give_up_walk(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1182,7 +1182,7 @@ __wt_page_parent_modify_set(WT_SESSION_IMPL *session, WT_REF *ref, bool page_onl
      * marking the original parent and all of the newly-created children as dirty. In other words,
      * if we have the wrong parent page, everything was marked dirty already.
      */
-    parent = ref->home;
+    parent = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
     WT_RET(__wt_page_modify_init(session, parent));
     if (page_only)
         __wt_page_only_modify_set(session, parent);
@@ -1213,6 +1213,7 @@ static WT_INLINE void
 __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep)
 {
     uintptr_t v;
+    void *ikey;
 
 /*
  * An internal page key is in one of two places: if we instantiated the
@@ -1241,14 +1242,50 @@ __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep)
 #define WT_IK_DECODE_KEY_LEN(v) ((v) >> 32)
 #define WT_IK_ENCODE_KEY_OFFSET(v) ((uintptr_t)(v) << 1)
 #define WT_IK_DECODE_KEY_OFFSET(v) (((v) & 0xFFFFFFFF) >> 1)
-    v = (uintptr_t)ref->ref_ikey;
+    /*
+     * Read the key once: both forms are valid at any instant, but the flag test and the value used
+     * have to agree. A split can instantiate the key underneath us, so a caller handed an
+     * instantiated key has to see its contents. That is consume ordering, which we spell as acquire
+     * because consume is not usable in practice; pairs with the release store that publishes an
+     * instantiated key.
+     *
+     * This says nothing about which page the key belongs to. An encoded key is an offset into the
+     * disk image of the page it was encoded from, so the caller owes us a page it is valid against.
+     */
+    ikey = __wt_atomic_load_ptr_acquire(&ref->ref_ikey);
+    v = (uintptr_t)ikey;
     if (v & WT_IK_FLAG) {
         *(void **)keyp = WT_PAGE_REF_OFFSET(page, WT_IK_DECODE_KEY_OFFSET(v));
         *sizep = WT_IK_DECODE_KEY_LEN(v);
     } else {
-        *(void **)keyp = WT_IKEY_DATA(ref->ref_ikey);
-        *sizep = ((WT_IKEY *)ref->ref_ikey)->size;
+        *(void **)keyp = WT_IKEY_DATA(ikey);
+        *sizep = ((WT_IKEY *)ikey)->size;
     }
+}
+
+/*
+ * __wt_ref_key_home --
+ *     Return a reference to a row-store internal page key, relative to the reference's own home
+ *     page.
+ */
+static WT_INLINE void
+__wt_ref_key_home(WT_REF *ref, void *keyp, size_t *sizep)
+{
+    WT_PAGE *home;
+
+    /*
+     * A split instantiates a moved reference's key before pointing the reference at a newly created
+     * page, which has no disk image. Acquire the home page so the key cannot be read from an
+     * earlier state than it: a new home page paired with a still-encoded key decodes the offset
+     * against a NULL image and yields the offset itself as the key. The acquire belongs on this
+     * read, not on the key, because it has to keep the read that follows from moving ahead of it.
+     * Pairs with the release store that publishes a new home page.
+     *
+     * Callers holding the page a reference was encoded against decode against it directly; a stale
+     * encoded key is still correct there, so they need no ordering.
+     */
+    home = (WT_PAGE *)__wt_atomic_load_ptr_acquire(&ref->home);
+    __wt_ref_key(home, ref, keyp, sizep);
 }
 
 /*
@@ -1275,13 +1312,16 @@ __wt_ref_key_onpage_set(WT_PAGE *page, WT_REF *ref, WT_CELL_UNPACK_ADDR *unpack)
 static WT_INLINE WT_IKEY *
 __wt_ref_key_instantiated(WT_REF *ref)
 {
-    uintptr_t v;
+    void *ikey;
 
     /*
-     * See the comment in __wt_ref_key for an explanation of the magic.
+     * See the comment in __wt_ref_key for an explanation of the magic. Read once so the flag test
+     * and the returned value can't disagree, and acquire so a caller that sees the key can safely
+     * dereference it: consume ordering is what that needs, but acquire is how we spell it. Pairs
+     * with the release store that publishes an instantiated key.
      */
-    v = (uintptr_t)ref->ref_ikey;
-    return (v & WT_IK_FLAG ? NULL : (WT_IKEY *)ref->ref_ikey);
+    ikey = __wt_atomic_load_ptr_acquire(&ref->ref_ikey);
+    return ((uintptr_t)ikey & WT_IK_FLAG ? NULL : (WT_IKEY *)ikey);
 }
 
 /*
@@ -2413,7 +2453,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * matter the size of the key.)
      */
     if (__wt_btree_syncing_by_other_sessions(session) &&
-      F_ISSET_ATOMIC_16(ref->home, WT_PAGE_INTL_OVERFLOW_KEYS)) {
+      F_ISSET_ATOMIC_16(
+        (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home), WT_PAGE_INTL_OVERFLOW_KEYS)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_overflow_keys);
         return (false);
     }
@@ -2634,7 +2675,7 @@ __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX *sa
      * this code, don't re-order that acquisition with this check.
      */
     WT_COMPILER_BARRIER();
-    WT_INTL_INDEX_GET(session, ref->home, pindex);
+    WT_INTL_INDEX_GET(session, (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home), pindex);
     return (pindex != saved_pindex);
 }
 
@@ -2875,7 +2916,7 @@ __wt_ref_index_slot(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pinde
          * Copy the parent page's index value: the page can split at any time, but the index's value
          * is always valid, even if it's not up-to-date.
          */
-        WT_INTL_INDEX_GET(session, ref->home, pindex);
+        WT_INTL_INDEX_GET(session, (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home), pindex);
         entries = pindex->entries;
 
         /*
@@ -2938,7 +2979,7 @@ __wt_ref_ascend(WT_SESSION_IMPL *session, WT_REF **refp, WT_PAGE_INDEX **pindexp
          * Find our parent slot on the next higher internal page, the slot from which we move to a
          * next/prev slot, checking that we haven't reached the root.
          */
-        parent_ref = ref->home->pg_intl_parent_ref;
+        parent_ref = ((WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home))->pg_intl_parent_ref;
         if (__wt_ref_is_root(parent_ref))
             break;
         if (pindexp)
@@ -2982,7 +3023,7 @@ __wt_ref_ascend(WT_SESSION_IMPL *session, WT_REF **refp, WT_PAGE_INDEX **pindexp
          * our search doesn't point to the same page as that initial
          * WT_REF, there's a race and we start over again.
          */
-        if (ref->home == parent_ref->page)
+        if ((WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home) == parent_ref->page)
             break;
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2629,6 +2629,7 @@ static WT_INLINE void __wt_ref_index_slot(
   WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pindexp, uint32_t *slotp);
 static WT_INLINE void __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep);
 static WT_INLINE void __wt_ref_key_clear(WT_REF *ref);
+static WT_INLINE void __wt_ref_key_home(WT_REF *ref, void *keyp, size_t *sizep);
 static WT_INLINE void __wt_ref_key_onpage_set(
   WT_PAGE *page, WT_REF *ref, WT_CELL_UNPACK_ADDR *unpack);
 static WT_INLINE void __wt_row_leaf_key_free(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip);

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -317,12 +317,14 @@ __prepared_discover_tree_walk_skip(
 {
     WT_ADDR *addr;
     WT_CELL_UNPACK_ADDR vpack;
+    WT_PAGE *home;
     WT_PAGE_DELETED *page_del;
     WT_TIME_AGGREGATE *ta;
 
     WT_UNUSED(context);
     WT_UNUSED(visible_all);
     addr = ref->addr;
+    home = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
 
     *skipp = false; /* Default to reading */
 
@@ -360,9 +362,9 @@ __prepared_discover_tree_walk_skip(
     /*
      * Check whether this on-disk page or it's children has any prepared content.
      */
-    if (!__wt_off_page(ref->home, addr)) {
+    if (!__wt_off_page(home, addr)) {
         /* Check if the page is obsolete using the page disk address. */
-        __wt_cell_unpack_addr(session, ref->home->dsk, (WT_CELL *)addr, &vpack);
+        __wt_cell_unpack_addr(session, home->dsk, (WT_CELL *)addr, &vpack);
         /* Retrieve the time aggregate from the unpacked address cell. */
         __wt_cell_get_ta(&vpack, &ta);
         if (!ta->prepare)

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -462,7 +462,7 @@ __rec_row_merge(
          */
         if (i == 0) {
             if (*build_deltap) {
-                __wt_ref_key(ref->home, ref, &old_key, &old_key_size);
+                __wt_ref_key_home(ref, &old_key, &old_key_size);
                 WT_RET(
                   __rec_cell_build_int_key(session, r, old_key, r->cell_zero ? 1 : old_key_size));
             } else

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -630,7 +630,7 @@ __rec_root_write(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 
         WT_ERR(__wt_multi_to_ref(session, NULL, next, &mod->mod_multi[i], mod->mod_multi_entries,
           &pindex->index[i], NULL, false, false));
-        pindex->index[i]->home = next;
+        __wt_atomic_store_ptr_relaxed(&pindex->index[i]->home, next);
     }
 
     /*
@@ -1273,7 +1273,7 @@ __wti_rec_split_init(
         if (__wt_ref_is_root(ref))
             WT_RET(__wt_buf_set(session, &chunk->key, "", 1));
         else
-            __wt_ref_key(ref->home, ref, &chunk->key.data, &chunk->key.size);
+            __wt_ref_key_home(ref, &chunk->key.data, &chunk->key.size);
     } else
         chunk->recno = recno;
 
@@ -2779,7 +2779,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     __rec_write_page_status(session, r);
 
     /* Mark the page's parent and the tree dirty. */
-    parent = r->ref->home;
+    parent = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&r->ref->home);
     WT_ERR(__wt_page_modify_init(session, parent));
     __wt_page_modify_set(session, parent);
 

--- a/src/rollback_to_stable/rts_visibility.c
+++ b/src/rollback_to_stable/rts_visibility.c
@@ -79,6 +79,7 @@ __wti_rts_visibility_page_needs_abort(
     WT_ADDR *addr;
     WT_CELL_UNPACK_ADDR vpack;
     WT_MULTI *multi;
+    WT_PAGE *home;
     WT_PAGE_MODIFY *mod;
     WT_TIME_AGGREGATE *ta;
     wt_timestamp_t durable_ts;
@@ -89,6 +90,7 @@ __wti_rts_visibility_page_needs_abort(
     bool prepared, result;
 
     addr = __wt_tsan_suppress_load_wt_addr_ptr(&ref->addr);
+    home = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
     mod = ref->page == NULL ? NULL : ref->page->modify;
     durable_ts = WT_TS_NONE;
     newest_txn = WT_TXN_NONE;
@@ -138,10 +140,10 @@ __wti_rts_visibility_page_needs_abort(
         newest_txn = ref->page_del->txnid;
         result = (durable_ts > rollback_timestamp) || prepared ||
           WT_CHECK_RECOVERY_FLAG_TXNID(session, newest_txn);
-    } else if (!__wt_off_page(ref->home, addr)) {
+    } else if (!__wt_off_page(home, addr)) {
         tag = "on page cell";
         /* Check if the page is obsolete using the page disk address. */
-        __wt_cell_unpack_addr(session, ref->home->dsk, (WT_CELL *)addr, &vpack);
+        __wt_cell_unpack_addr(session, home->dsk, (WT_CELL *)addr, &vpack);
         /* Retrieve the time aggregate from the unpacked address cell. */
         __wt_cell_get_ta(&vpack, &ta);
         durable_ts = __rts_visibility_get_ref_max_durable_timestamp(session, ta);


### PR DESCRIPTION
A row-store internal page key encoded as an offset/length pair only decodes correctly against the page it was encoded from. A deepen split instantiates a moved reference's key and then points the reference at a new internal page with no disk image; a reader that observed the new home page together with the stale encoded key computed NULL + offset and segfaulted. The fix reads the home page with an acquire before the key, publishes the new home page with a release store, and reads the key once with an acquire paired with a release store in the ikey allocation.

The cherry-pick conflicted only in __compact_page_replace_addr, where develop has an unrelated new_cookie change; the resolution keeps the 9.0 body and adds the single relaxed home load.

Cherry-picked from commit 30849d5fa66575348e8bd0a5878b7f61c7ee99c3 (PR #14409).
