### PR TITLE
WT-17986 Push disagg_page_free_required into the block manager to simplify rec_write_wrapup

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -638,7 +638,7 @@ __split_parent_discard_ref(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *paren
     __wt_free(session, ref->page_del);
 
     /* Free the backing block and address. */
-    WT_TRET(__wt_ref_block_free(session, ref, true));
+    WT_TRET(__wt_ref_block_free(session, ref, true, false));
 
     /*
      * We cannot discard any ref in the prefetch queue, otherwise, the prefetch thread would read

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2071,17 +2071,6 @@ __wt_ref_block_free(
     WT_ADDR_COPY addr;
     WT_DECL_RET;
 
-    /*
-     * The chain is tracked against the page id in the shared store, so obsolete it whenever the
-     * page id survives, including for a page rebuilt in memory that carries a page id but no local
-     * address.
-     */
-    if (!disagg_free_block && disagg_delta_chain_end && ref->page != NULL &&
-      ref->page->disagg_info != NULL &&
-      ref->page->disagg_info->block_meta.page_id != WT_BLOCK_INVALID_PAGE_ID)
-        __wt_block_disagg_decrease_size(
-          session, ref->page->disagg_info->block_meta.cumulative_size);
-
     WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
     if (!__wt_ref_addr_copy(session, ref, &addr))
         goto err;
@@ -2098,6 +2087,17 @@ __wt_ref_block_free(
     __wt_ref_addr_free(session, ref);
 
 err:
+    /*
+     * The chain is tracked against the page id in the shared store, so obsolete it whenever the
+     * page id survives, including for a page rebuilt in memory that carries a page id but no local
+     * address. Only adjust the accounting once nothing can fail.
+     */
+    if (ret == 0 && !disagg_free_block && disagg_delta_chain_end && ref->page != NULL &&
+      ref->page->disagg_info != NULL &&
+      ref->page->disagg_info->block_meta.page_id != WT_BLOCK_INVALID_PAGE_ID)
+        __wt_block_disagg_decrease_size(
+          session, ref->page->disagg_info->block_meta.cumulative_size);
+
     WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
     return (ret);
 }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2079,7 +2079,7 @@ __wt_ref_block_free(
         WT_ERR(__wt_btree_block_free(session, addr.addr, addr.size));
     else if (disagg_free_block) {
         WT_ERR(__wt_btree_block_free(session, addr.addr, addr.size));
-        if (ref->page != NULL)
+        if (ref->page != NULL && ref->page->disagg_info != NULL)
             ref->page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
     }
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2059,13 +2059,28 @@ __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page, WT_TIME_AGGREGA
 
 /*
  * __wt_ref_block_free --
- *     Free the on-disk block for a reference and clear the address.
+ *     Free the on-disk block for a reference and clear the address. A disaggregated block is only
+ *     freed when asked for, the page id is otherwise reused by the next write. When the block
+ *     survives and the caller has written a full page image, the delta chain it headed is obsolete
+ *     and its cumulative size stops counting toward the tree.
  */
 static WT_INLINE int
-__wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref, bool disagg_free_block)
+__wt_ref_block_free(
+  WT_SESSION_IMPL *session, WT_REF *ref, bool disagg_free_block, bool disagg_delta_chain_end)
 {
     WT_ADDR_COPY addr;
     WT_DECL_RET;
+
+    /*
+     * The chain is tracked against the page id in the shared store, so obsolete it whenever the
+     * page id survives, including for a page rebuilt in memory that carries a page id but no local
+     * address.
+     */
+    if (!disagg_free_block && disagg_delta_chain_end && ref->page != NULL &&
+      ref->page->disagg_info != NULL &&
+      ref->page->disagg_info->block_meta.page_id != WT_BLOCK_INVALID_PAGE_ID)
+        __wt_block_disagg_decrease_size(
+          session, ref->page->disagg_info->block_meta.cumulative_size);
 
     WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
     if (!__wt_ref_addr_copy(session, ref, &addr))

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2359,8 +2359,9 @@ static WT_INLINE int __wt_pending_prepared_next_op(
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_read(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len,
   void *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref,
-  bool disagg_free_block) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_ref_block_free(
+  WT_SESSION_IMPL *session, WT_REF *ref, bool disagg_free_block, bool disagg_delta_chain_end)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_row_leaf_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
   WT_ITEM *key, bool instantiate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_row_leaf_key_instantiate(WT_SESSION_IMPL *session, WT_PAGE *page)

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -33,7 +33,7 @@ __rec_child_deleted(
      * underlying disk blocks and don't write anything in the internal page.
      */
     if (page_del == NULL)
-        return (__wt_ref_block_free(session, ref, true));
+        return (__wt_ref_block_free(session, ref, true, false));
 
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
@@ -181,7 +181,7 @@ __rec_child_deleted(
      * is ever a read into this part of the name space again, the cache read function instantiates
      * an entirely new page.)
      */
-    WT_RET(__wt_ref_block_free(session, ref, true));
+    WT_RET(__wt_ref_block_free(session, ref, true, false));
 
     /* Globally visible fast-truncate information is never used again, a NULL value is identical. */
     __wt_overwrite_and_free(session, ref->page_del);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3042,8 +3042,9 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
 /*
  * __rec_wrapup_decrease_disagg_size --
  *     The prior delta chain is obsolete, so its cumulative size must stop counting toward the
- *     tree's byte total. The replacement cookie records the size being obsoleted; diagnostic builds
- *     check the two agree.
+ *     tree's byte total. Only call this once the chain has terminated, that is, this reconciliation
+ *     wrote a single full page image with no deltas. The replacement cookie records the size being
+ *     obsoleted; diagnostic builds check the two agree.
  */
 static int
 __rec_wrapup_decrease_disagg_size(
@@ -3052,6 +3053,11 @@ __rec_wrapup_decrease_disagg_size(
     WT_PAGE *page;
 
     page = r->page;
+
+    /* The caller gates on disagg_delta_chain_end; verify the chain has in fact terminated. */
+    WT_ASSERT(session,
+      r->multi_next == 1 && r->multi->block_meta != NULL &&
+        !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE) && r->multi->block_meta->delta_count == 0);
 
 #ifdef HAVE_DIAGNOSTIC
     if (cookie != NULL) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3041,11 +3041,9 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
 
 /*
  * __rec_wrapup_decrease_disagg_size --
- *     A newly written full page image terminates the on-disk delta chain, so the prior chain's
- *     cumulative size must stop counting toward the tree's byte total. Decrease the size when this
- *     reconciliation wrote a single full image and did not skip the write. Callers gate on their
- *     own page id conditions before establishing there is a chain to obsolete. When a replacement
- *     cookie is supplied it records the size being obsoleted; diagnostic builds check they agree.
+ *     The prior delta chain is obsolete, so its cumulative size must stop counting toward the
+ *     tree's byte total. The replacement cookie records the size being obsoleted; diagnostic builds
+ *     check the two agree.
  */
 static int
 __rec_wrapup_decrease_disagg_size(
@@ -3054,10 +3052,6 @@ __rec_wrapup_decrease_disagg_size(
     WT_PAGE *page;
 
     page = r->page;
-
-    /* Only a full page image (no deltas) that was actually written terminates the chain. */
-    if (F_ISSET(r->multi, WT_MULTI_SKIP_WRITE) || r->multi->block_meta->delta_count != 0)
-        return (0);
 
 #ifdef HAVE_DIAGNOSTIC
     if (cookie != NULL) {
@@ -3092,6 +3086,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIME
     WT_REF_STATE previous_ref_state;
     WT_TIME_AGGREGATE stop_ta, *stop_tap, ta;
     uint32_t i;
+    bool disagg_delta_chain_end;
     bool disagg_page_free_required;
     bool disagg_page_is_valid;
 
@@ -3135,6 +3130,14 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIME
           (r->multi_next != 1 || r->multi->block_meta->page_id == WT_BLOCK_INVALID_PAGE_ID);
 
     /*
+     * A newly written full page image terminates the on-disk delta chain, so the size the chain
+     * accumulated stops counting toward the tree. The block manager applies this when it keeps the
+     * page id rather than freeing the block.
+     */
+    disagg_delta_chain_end = r->multi_next == 1 && r->multi->block_meta != NULL &&
+      !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE) && r->multi->block_meta->delta_count == 0;
+
+    /*
      * Wrap up overflow tracking. If we are about to create a checkpoint, the system must be
      * entirely consistent at that point (the underlying block manager is presumably going to do
      * some action to resolve the list of allocated/free/whatever blocks that are associated with
@@ -3167,10 +3170,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIME
             break;
         }
 
-        WT_RET(__wt_ref_block_free(session, ref, disagg_page_free_required));
-        /* Update the size accounting if we keep the page id and terminate the delta chain. */
-        if (disagg_page_is_valid && !disagg_page_free_required)
-            WT_RET(__rec_wrapup_decrease_disagg_size(session, r, NULL, 0));
+        WT_RET(
+          __wt_ref_block_free(session, ref, disagg_page_free_required, disagg_delta_chain_end));
         break;
     case WT_PM_REC_EMPTY: /* Page deleted */
         break;
@@ -3196,7 +3197,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIME
                  */
                 if (ref->addr != NULL) {
                     if (page->disagg_info == NULL)
-                        WT_RET(__wt_ref_block_free(session, ref, true));
+                        WT_RET(__wt_ref_block_free(session, ref, true, false));
                     /*
                      * r->multi_next may be 0; check it to avoid block_meta is NULL.
                      * WT_PM_REC_REPLACE only indicates previous reconciliation generated one page.
@@ -3207,17 +3208,11 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIME
                          * If we write an empty page for update restore eviction, we need to free
                          * the page id.
                          */
-                        WT_RET(__wt_ref_block_free(session, ref, true));
-                    else if (r->multi_next != 1 || !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
+                        WT_RET(__wt_ref_block_free(session, ref, true, false));
+                    else if (r->multi_next != 1 || !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE))
                         /* Only free a disagg page if we don't skip writing the page. */
-                        WT_RET(__wt_ref_block_free(session, ref, disagg_page_free_required));
-                        /*
-                         * Update the tree size accounting if we don't free the page id and we
-                         * terminate the delta chain.
-                         */
-                        if (disagg_page_is_valid && !disagg_page_free_required)
-                            WT_RET(__rec_wrapup_decrease_disagg_size(session, r, NULL, 0));
-                    }
+                        WT_RET(__wt_ref_block_free(
+                          session, ref, disagg_page_free_required, disagg_delta_chain_end));
                 }
             } else {
                 /*
@@ -3241,7 +3236,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_RECONCILE_TIME
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi_next == 1 && r->multi->block_meta != NULL)
+                    if (disagg_delta_chain_end)
                         WT_RET(__rec_wrapup_decrease_disagg_size(session, r,
                           mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
                 }


### PR DESCRIPTION
### Summary

- `__rec_write_wrapup()` computed a disagg_page_free_required flag and then branched on it in three places, mostly because the decision was made in reconciliation and used to skip the free call, stranding the size accounting that belongs with the free at the call site.
- `__wt_ref_block_free()` now takes a disagg_delta_chain_end argument alongside the existing disagg_free_block and owns both outcomes: free the block and invalidate the page id when asked, otherwise obsolete the delta chain the surviving page id headed. Both if (`disagg_page_is_valid` && !`disagg_page_free_required`) blocks in wrapup go away, and `__rec_wrapup_decrease_disagg_size()` is left with the one case that genuinely differs — freeing a replacement cookie rather than ref->addr.
- Worth a reviewer's eye: the accounting deliberately runs before `__wt_ref_addr_copy()` and independently of whether it succeeds. The chain is tracked against the page id in the shared store, not the local ref address, and __split_multi_inmem() can produce a page carrying a valid page id with a NULL ref->addr. Behind the address copy's early exit, those pages would keep counting a dead chain, which is the bytes_total drift test_disagg_checkpoint_size03 guards against.