### PR TITLE
WT-15907 Publish a set statistic before clearing its remaining buckets

### DIFF
--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -563,7 +563,8 @@ __wti_size_stat_page(WT_SESSION_IMPL *session, WT_PAGE *page)
     uint64_t ceiling = 0;
     if (session->dhandle != NULL && session->dhandle->stat_array != NULL &&
       session->dhandle->stats[0] != NULL)
-        ceiling = (uint64_t)session->dhandle->stats[0]->btree_size_leaf_hist_ceiling;
+        ceiling = (uint64_t)__wt_atomic_load_int64_relaxed(
+          &session->dhandle->stats[0]->btree_size_leaf_hist_ceiling);
     if (ceiling == 0) {
         ceiling = S2BT(session)->maxleafpage_precomp;
         if (ceiling == 0)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -110,7 +110,7 @@ __wt_stats_aggregate_internal(void *stats_arg, int slot, u_int num_slots)
 
     stats = (int64_t **)stats_arg;
     for (aggr_v = 0, i = 0; i < num_slots; i++)
-        aggr_v += stats[i][slot];
+        aggr_v += __wt_atomic_load_int64_relaxed(&stats[i][slot]);
 
     /*
      * This can race. However, any implementation with a single value can race as well, different
@@ -143,31 +143,39 @@ __wt_stats_aggregate_dsrc(void *stats_arg, int slot)
 }
 
 /*
- * Clear the values in all structures in the array for connection statistics.
+ * Set a connection statistic. The value is read back as the sum of the buckets, so it lives in the
+ * first bucket and the rest are emptied. Publish the value before emptying the others: aggregation
+ * is not synchronized against gathering, so a reader summing the buckets in between would otherwise
+ * total zero.
+ *
+ * Relaxed is the ordering we want throughout: a statistic guards no other state, so the accesses
+ * need to be free of tearing and of reloads the compiler invented, nothing more.
  */
 static WT_INLINE void
-__wt_stats_clear_conn(void *stats_arg, int slot)
+__wt_stats_set_conn(void *stats_arg, int slot, int64_t value)
 {
     int64_t **stats;
     int i;
 
     stats = (int64_t **)stats_arg;
-    for (i = 0; i < WT_STAT_CONN_COUNTER_SLOTS; i++)
-        stats[i][slot] = 0;
+    __wt_atomic_store_int64_relaxed(&stats[0][slot], value);
+    for (i = 1; i < WT_STAT_CONN_COUNTER_SLOTS; i++)
+        __wt_atomic_store_int64_relaxed(&stats[i][slot], 0);
 }
 
 /*
- * Clear the values in all structures in the array for data-source statistics.
+ * Set a data-source statistic, ordered as the connection version above.
  */
 static WT_INLINE void
-__wt_stats_clear_dsrc(void *stats_arg, int slot)
+__wt_stats_set_dsrc(void *stats_arg, int slot, int64_t value)
 {
     int64_t **stats;
     int i;
 
     stats = (int64_t **)stats_arg;
-    for (i = 0; i < WT_STAT_DSRC_COUNTER_SLOTS; i++)
-        stats[i][slot] = 0;
+    __wt_atomic_store_int64_relaxed(&stats[0][slot], value);
+    for (i = 1; i < WT_STAT_DSRC_COUNTER_SLOTS; i++)
+        __wt_atomic_store_int64_relaxed(&stats[i][slot], 0);
 }
 
 /*
@@ -247,12 +255,10 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
 #define WT_STAT_CONN_INCR(session, fld) WT_STAT_CONN_INCRV(session, fld, 1)
 
 /* FIXME-WT-15961 Introduce thread-safe stats interfaces. */
-#define WT_STATP_CONN_SET(session, stats, fld, value)                           \
-    do {                                                                        \
-        if (WT_STAT_ENABLED(session)) {                                         \
-            __wt_stats_clear_conn(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld)); \
-            WT_STAT_SET_BASE(session, (stats)[0], fld, value);                  \
-        }                                                                       \
+#define WT_STATP_CONN_SET(session, stats, fld, value)                                           \
+    do {                                                                                        \
+        if (WT_STAT_ENABLED(session))                                                           \
+            __wt_stats_set_conn(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld), (int64_t)(value)); \
     } while (0)
 #define WT_STAT_CONN_SET(session, fld, value) \
     WT_STATP_CONN_SET(session, S2C(session)->stats, fld, value)
@@ -288,12 +294,10 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
     } while (0)
 #define WT_STAT_DSRC_DECR(session, fld) WT_STAT_DSRC_DECRV(session, fld, 1)
 
-#define WT_STATP_DSRC_SET(session, stats, fld, value)                           \
-    do {                                                                        \
-        if (WT_STAT_ENABLED(session)) {                                         \
-            __wt_stats_clear_dsrc(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld)); \
-            WT_STAT_SET_BASE(session, (stats)[0], fld, value);                  \
-        }                                                                       \
+#define WT_STATP_DSRC_SET(session, stats, fld, value)                                           \
+    do {                                                                                        \
+        if (WT_STAT_ENABLED(session))                                                           \
+            __wt_stats_set_dsrc(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld), (int64_t)(value)); \
     } while (0)
 #define WT_STAT_DSRC_SET(session, fld, value)                                     \
     do {                                                                          \

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -412,6 +412,14 @@ define_c_test(
 )
 
 define_c_test(
+    TARGET test_wt15907_conn_stat_race
+    SOURCES wt15907_conn_stat_race/main.c
+    DIR_NAME wt15907_conn_stat_race
+    ARGUMENTS
+    DEPENDS "WT_POSIX"
+)
+
+define_c_test(
     TARGET test_wt16990_disagg_checkpoint_panic
     SOURCES wt16990_disagg_checkpoint_panic/main.c
     DIR_NAME wt16990_disagg_checkpoint_panic

--- a/test/csuite/wt15907_conn_stat_race/main.c
+++ b/test/csuite/wt15907_conn_stat_race/main.c
@@ -49,7 +49,12 @@ static const char table_config[] = "key_format=i,value_format=S";
 static const char *const uri = "table:wt15907-conn-stat-race";
 
 static WT_CONNECTION *conn;
-static volatile bool done;
+
+/*
+ * Nothing is published through this flag, so the gather thread only has to observe it eventually
+ * and a relaxed access is enough. It still has to be atomic: the store races the load.
+ */
+static bool done;
 
 /* Forward declarations. */
 static int64_t read_cache_bytes_dirty(WT_SESSION *);
@@ -89,7 +94,7 @@ thread_func_gather(void *arg)
     (void)arg;
 
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    while (!done)
+    while (!__wt_atomic_load_bool_relaxed(&done))
         (void)read_cache_bytes_dirty(session);
     testutil_check(session->close(session, NULL));
 
@@ -111,7 +116,7 @@ run_test(const char *home, uint64_t reads)
     int64_t value;
     char buf[VALUE_SIZE + 1];
 
-    done = false;
+    __wt_atomic_store_bool_relaxed(&done, false);
     zero_reads = 0;
 
     memset(buf, 'a', sizeof(buf) - 1);
@@ -140,7 +145,7 @@ run_test(const char *home, uint64_t reads)
         if (read_cache_bytes_dirty(session) == 0)
             ++zero_reads;
 
-    done = true;
+    __wt_atomic_store_bool_relaxed(&done, true);
     (void)pthread_join(thread_gather, NULL);
 
     if (zero_reads != 0)

--- a/test/csuite/wt15907_conn_stat_race/main.c
+++ b/test/csuite/wt15907_conn_stat_race/main.c
@@ -1,0 +1,182 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+/*
+ * A connection statistic that is set rather than accumulated is read back as the sum of its
+ * buckets. Gathering such a statistic must therefore leave the buckets summing to the value at
+ * every instant, because opening a statistics cursor gathers into the shared array and then
+ * aggregates it without holding anything against a concurrent gatherer.
+ *
+ * Two threads open statistics cursors here. A transaction holds dirty data in the cache the whole
+ * time, so a zero for the dirty-bytes statistic can only come from a reader catching the buckets
+ * mid-update. The statistics-log server is the gatherer that exposes this in practice - the Python
+ * test framework enables it for every test configured with statistics=(all) - but it samples once a
+ * second, far too rarely to make the window observable, so a thread stands in for it.
+ */
+
+#define NUM_RECORDS 400
+#define READS_DEFAULT (500 * WT_THOUSAND)
+#define VALUE_SIZE 2000
+
+static const char conn_config[] = "create,cache_size=1GB,statistics=(all)";
+static const char table_config[] = "key_format=i,value_format=S";
+static const char *const uri = "table:wt15907-conn-stat-race";
+
+static WT_CONNECTION *conn;
+static volatile bool done;
+
+/* Forward declarations. */
+static int64_t read_cache_bytes_dirty(WT_SESSION *);
+static void run_test(const char *, uint64_t);
+static void *thread_func_gather(void *);
+
+/*
+ * read_cache_bytes_dirty --
+ *     Return the connection's dirty-bytes statistic, gathering and aggregating it as any statistics
+ *     cursor open does.
+ */
+static int64_t
+read_cache_bytes_dirty(WT_SESSION *session)
+{
+    WT_CURSOR *cursor;
+    int64_t value;
+    const char *desc, *pvalue;
+
+    testutil_check(session->open_cursor(session, "statistics:", NULL, NULL, &cursor));
+    cursor->set_key(cursor, WT_STAT_CONN_CACHE_BYTES_DIRTY);
+    testutil_check(cursor->search(cursor));
+    testutil_check(cursor->get_value(cursor, &desc, &pvalue, &value));
+    testutil_check(cursor->close(cursor));
+
+    return (value);
+}
+
+/*
+ * thread_func_gather --
+ *     Stand in for the statistics-log server, gathering connection statistics in a loop.
+ */
+static void *
+thread_func_gather(void *arg)
+{
+    WT_SESSION *session;
+
+    (void)arg;
+
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    while (!done)
+        (void)read_cache_bytes_dirty(session);
+    testutil_check(session->close(session, NULL));
+
+    return (NULL);
+}
+
+/*
+ * run_test --
+ *     Hold dirty data in the cache and check that concurrent gathering never makes the statistic
+ *     read as zero.
+ */
+static void
+run_test(const char *home, uint64_t reads)
+{
+    WT_CURSOR *cursor;
+    WT_SESSION *session;
+    pthread_t thread_gather;
+    uint64_t i, zero_reads;
+    int64_t value;
+    char buf[VALUE_SIZE + 1];
+
+    done = false;
+    zero_reads = 0;
+
+    memset(buf, 'a', sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    testutil_recreate_dir(home);
+    testutil_check(wiredtiger_open(home, NULL, conn_config, &conn));
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    testutil_check(session->create(session, uri, table_config));
+    testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
+
+    /* Leave the transaction open so the data stays dirty and uncommitted for every read. */
+    testutil_check(session->begin_transaction(session, NULL));
+    for (i = 1; i <= NUM_RECORDS; i++) {
+        cursor->set_key(cursor, (int)i);
+        cursor->set_value(cursor, buf);
+        testutil_check(cursor->insert(cursor));
+    }
+
+    value = read_cache_bytes_dirty(session);
+    testutil_assert(value > 0);
+
+    testutil_check(pthread_create(&thread_gather, NULL, thread_func_gather, NULL));
+
+    for (i = 0; i < reads; i++)
+        if (read_cache_bytes_dirty(session) == 0)
+            ++zero_reads;
+
+    done = true;
+    (void)pthread_join(thread_gather, NULL);
+
+    if (zero_reads != 0)
+        testutil_die(EINVAL,
+          "cache_bytes_dirty read as zero on %" PRIu64 " of %" PRIu64
+          " reads while a transaction held dirty data",
+          zero_reads, reads);
+
+    testutil_check(session->rollback_transaction(session, NULL));
+    testutil_check(session->close(session, NULL));
+    testutil_check(conn->close(conn, NULL));
+    conn = NULL;
+}
+
+/*
+ * main --
+ *     Methods implementation.
+ */
+int
+main(int argc, char *argv[])
+{
+    TEST_OPTS *opts, _opts;
+    uint64_t reads;
+
+    opts = &_opts;
+    memset(opts, 0, sizeof(*opts));
+    testutil_check(testutil_parse_opts(argc, argv, opts));
+
+    reads = opts->nrecords == 0 ? READS_DEFAULT : opts->nrecords;
+
+    printf("Running test with %" PRIu64 " statistics reads ...\n", reads);
+    run_test(opts->home, reads);
+
+    if (!opts->preserve)
+        testutil_remove(opts->home);
+
+    testutil_cleanup(opts);
+    return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
A statistic that is set rather than accumulated is read back as the sum of its buckets, so gathering one cleared every bucket and then wrote the value into the first. Aggregation is not synchronized against gathering, so a reader that summed the buckets between those two steps totalled zero. The statistics-log server gathers once a second and the Python test framework enables it automatically for every test configured with `statistics=(all)`, which is how `test_stat08` intermittently compared its transaction's dirty bytes against a `cache_bytes_dirty` of zero. This is not specific to that statistic — any set statistic can read as zero while another thread gathers, including through `serverStatus`.

The fix writes the value before emptying the other buckets. The end state is identical, so no statistic reports a different value; only the window in which the buckets sum to zero disappears. I confirmed the reported values are byte-identical before and after.

The same path was also pairing a relaxed atomic store with a plain load in the aggregate, and `bt_stat.c` had the one remaining direct plain read of a shared bucket. Both now use relaxed atomics. Relaxed is the right ordering here: a statistic guards no other state, so the accesses only need to be free of tearing and of compiler-invented reloads.

The new csuite test holds a transaction with dirty data and reads `cache_bytes_dirty` while a second thread gathers connection statistics. It fails reliably without the fix (2-12 zeros per 500k reads across runs) and passes with it. A thread stands in for the statistics-log server because 1 Hz sampling is far too rare to make the window observable.