### PR TITLE
WT-18538 Use built-in testutil ret ignoration

### DIFF
--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -134,7 +134,7 @@ adopted_lsn_read(void)
         return (0);
 
     uint64_t lsn = 0;
-    (void)fscanf(fp, "%" SCNu64, &lsn);
+    testutil_ignore_ret(fscanf(fp, "%" SCNu64, &lsn));
     testutil_check(fclose(fp));
     return (lsn);
 }


### PR DESCRIPTION
The previous version wouldn't compile in newer GCCs.