### PR TITLE
WT-14366 Give test_checkpoint24/25 rows distinct values so VLCS can fast-delete

### DIFF
--- a/test/suite/test_checkpoint24.py
+++ b/test/suite/test_checkpoint24.py
@@ -64,7 +64,7 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri)
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
-            cursor[ds.key(i)] = value
+            cursor[ds.key(i)] = value(i)
             if i % 101 == 0:
                 self.session.commit_transaction()
                 self.session.begin_transaction()
@@ -95,7 +95,8 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         count = 0
         zcount = 0
         for k, v in cursor:
-            self.assertEqual(v, value)
+            i = ds.reverse_key_by_format(k, ds.key_format)
+            self.assertEqual(v, value(i))
             count += 1
         #self.session.rollback_transaction()
         self.assertEqual(count, nrows)
@@ -116,10 +117,14 @@ class test_checkpoint(wttest.WiredTigerTestCase):
             config=self.extraconfig)
         ds.populate()
 
-        value_a = "aaaaa" * 100
+        # Every row gets a distinct value. Variable-length column store run-length encodes
+        # runs of identical values, which packs the whole table into a handful of leaf pages
+        # and leaves the truncate range with no interior page to fast-delete.
+        def value(i):
+            return "{}-{}".format(i, "aaaaa" * 100)
 
         # Write some data at time 10.
-        self.large_updates(uri, ds, nrows, value_a)
+        self.large_updates(uri, ds, nrows, value)
 
         # Reopen the connection (which checkpoints it) so it's all on disk and not in memory.
         self.reopen_conn()
@@ -141,4 +146,4 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         # Read the checkpoint.
         nonzeros = nrows // 2
         zeros = nrows - nonzeros
-        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a)
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value)

--- a/test/suite/test_checkpoint25.py
+++ b/test/suite/test_checkpoint25.py
@@ -73,7 +73,7 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri)
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
-            cursor[ds.key(i)] = value
+            cursor[ds.key(i)] = value(i)
             if i % 101 == 0:
                 self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
                 self.session.begin_transaction()
@@ -105,7 +105,8 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         count = 0
         zcount = 0
         for k, v in cursor:
-            self.assertEqual(v, value)
+            i = ds.reverse_key_by_format(k, ds.key_format)
+            self.assertEqual(v, value(i))
             count += 1
         self.assertEqual(count, nrows)
         self.assertEqual(zcount, 0)
@@ -121,14 +122,18 @@ class test_checkpoint(wttest.WiredTigerTestCase):
             config=self.extraconfig)
         ds.populate()
 
-        value_a = "aaaaa" * 100
+        # Every row gets a distinct value. Variable-length column store run-length encodes
+        # runs of identical values, which packs the whole table into a handful of leaf pages
+        # and leaves the truncate range with no interior page to fast-delete.
+        def value(i):
+            return "{}-{}".format(i, "aaaaa" * 100)
 
         # Pin oldest and stable timestamps to 5.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5) +
             ',stable_timestamp=' + self.timestamp_str(5))
 
         # Write some data at time 10.
-        self.large_updates(uri, ds, nrows, value_a, 10)
+        self.large_updates(uri, ds, nrows, value, 10)
 
         # Mark it stable.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
@@ -160,7 +165,7 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         # Read the checkpoint.
         nonzeros = nrows // 2
         zeros = nrows - nonzeros
-        self.check(ds, self.first_checkpoint, nrows, 0, value_a, 15)
-        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a, 25)
-        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a, None) # default read ts
-        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a, 0) # no read ts
+        self.check(ds, self.first_checkpoint, nrows, 0, value, 15)
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value, 25)
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value, None) # default read ts
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value, 0) # no read ts


### PR DESCRIPTION
The column scenarios of test_checkpoint24 and test_checkpoint25 write 10,000 rows that all share one value. Variable-length column store run-length encodes runs of identical values, so the table collapses into just 4 leaf pages. WT_SESSION.truncate explicitly reads the pages holding the start and stop keys, so only pages strictly interior to the range are eligible for fast-delete — with 4 pages that leaves exactly 1, and any shift in the split points (a different build, a different architecture) takes that to 0 and fails assertGreater(fastdelete_pages, 0). That matches the ppc/zseries/arm64/asan failures on this ticket.

This is the same mechanism WT-14641 hit in test_truncate17, fixed there by giving every row a distinct value so RLE can't collapse the tree. Applying the same fix here: column store now builds 183 leaf pages and fast-deletes 91, matching the row-store scenarios, verified locally against a repro that reproduces the 4-page/1-page margin on the unfixed code and shows 183/91 after the fix.

Full test_checkpoint24 and test_checkpoint25 suites (60 scenarios) pass, 3 runs in a row.