### PR TITLE
WT-18452 Move WT_DHANDLE_OUTDATED into an atomic dhandle flags word

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -521,7 +521,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
           !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
             return (0);
         /* Skip checkpointing outdated trees. */
-        if (F_ISSET(btree->dhandle, WT_DHANDLE_OUTDATED))
+        if (F_ISSET_ATOMIC_32(btree->dhandle, WT_DHANDLE_OUTDATED))
             return (0);
     }
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -1152,6 +1152,8 @@ __wti_verbose_dump_handles(WT_SESSION_IMPL *session)
         /* Sweep can concurrently update the flags of a handle we're dumping. */
         WT_RET(__wt_msg(
           session, "  Flags: 0x%08" PRIx16, __wt_atomic_load_uint16_relaxed(&dhandle->flags)));
+        WT_RET(__wt_msg(session, "  Atomic flags: 0x%08" PRIx32,
+          __wt_atomic_load_uint32_relaxed(&dhandle->flags_atomic)));
     }
     return (0);
 }

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -293,7 +293,7 @@ __wt_conn_dhandle_find(WT_SESSION_IMPL *session, const char *uri, const char *ch
         TAILQ_FOREACH (dhandle, &conn->dhhash[bucket], hashq) {
             if (F_ISSET(dhandle, WT_DHANDLE_DEAD))
                 continue;
-            if (F_ISSET(dhandle, WT_DHANDLE_OUTDATED)) {
+            if (F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED)) {
                 /*
                  * An outdated read-only stable handle is only safe to reuse in its checkpoint-view
                  * form (a "...wt_stable/WiredTigerCheckpoint.N" name): those checkpoint handles
@@ -317,7 +317,8 @@ __wt_conn_dhandle_find(WT_SESSION_IMPL *session, const char *uri, const char *ch
         }
     } else
         TAILQ_FOREACH (dhandle, &conn->dhhash[bucket], hashq) {
-            if (F_ISSET(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_OUTDATED))
+            if (F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
+              F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED))
                 continue;
             if (dhandle->checkpoint != NULL && strcmp(uri, dhandle->name) == 0 &&
               strcmp(checkpoint, dhandle->checkpoint) == 0) {
@@ -349,7 +350,7 @@ __wti_conn_dhandle_outdated(WT_SESSION_IMPL *session, const char *uri)
       if ((ret = __wt_conn_dhandle_find(session, uri, NULL)) == 0)
         WT_DHANDLE_ACQUIRE(session->dhandle));
     if (ret == 0) {
-        F_SET(session->dhandle, WT_DHANDLE_OUTDATED);
+        F_SET_ATOMIC_32(session->dhandle, WT_DHANDLE_OUTDATED);
         WT_DHANDLE_RELEASE(session->dhandle);
     } else if (ret != WT_NOTFOUND)
         WT_RET(ret);
@@ -796,9 +797,9 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
             if (dhandle == NULL)
                 return (0);
 
-            if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
-              F_ISSET(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_OUTDATED) ||
-              dhandle->checkpoint != NULL || strcmp(uri, dhandle->name) != 0)
+            if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) || F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
+              F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED) || dhandle->checkpoint != NULL ||
+              strcmp(uri, dhandle->name) != 0)
                 continue;
             WT_ERR(__conn_btree_apply_internal(session, dhandle, file_func, name_func, cfg));
         }
@@ -815,10 +816,10 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
             if (dhandle == NULL)
                 goto done;
 
-            if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
-              F_ISSET(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_OUTDATED) ||
-              !WT_DHANDLE_BTREE(dhandle) || dhandle->checkpoint != NULL ||
-              WT_IS_ANY_METADATA(dhandle) || WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
+            if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) || F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
+              F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED) || !WT_DHANDLE_BTREE(dhandle) ||
+              dhandle->checkpoint != NULL || WT_IS_ANY_METADATA(dhandle) ||
+              WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
                 continue;
 
             WT_ERR(__conn_btree_apply_internal(session, dhandle, file_func, name_func, cfg));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1494,7 +1494,7 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
          * prepared cell before the drain resolves it, which reconciliation cannot represent (leaked
          * prepared update).
          */
-        F_SET(dhandle, WT_DHANDLE_OUTDATED);
+        F_SET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED);
 
         WT_WITH_BTREE(session, btree, __wt_evict_file_exclusive_off(session));
     }

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -238,7 +238,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
         if (!__wt_conn_is_disagg(session) && !sweep_non_outdated_handle)
             break;
 
-        if (!F_ISSET(dhandle, WT_DHANDLE_OUTDATED) && !sweep_non_outdated_handle)
+        if (!F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED) && !sweep_non_outdated_handle)
             continue;
         /*
          * For outdated btrees, hold standby node checkpoint handles for a short grace period,
@@ -246,7 +246,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
          * time has elapsed since time of death.
          */
         uint64_t tod = __wt_atomic_load_uint64_relaxed(&dhandle->timeofdeath);
-        if (F_ISSET(dhandle, WT_DHANDLE_OUTDATED)) {
+        if (F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED)) {
             if (__wt_atomic_load_int32_relaxed(&dhandle->session_inuse) > 0)
                 continue;
             if (__wt_conn_is_disagg(session) && WT_URI_IS_STABLE_CHECKPOINT(dhandle->name)) {

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -45,7 +45,7 @@ __wt_btree_is_outdated_disagg(WT_SESSION_IMPL *session)
 {
     return ((F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) ||
               F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY)) &&
-      F_ISSET(session->dhandle, WT_DHANDLE_OUTDATED));
+      F_ISSET_ATOMIC_32(session->dhandle, WT_DHANDLE_OUTDATED));
 }
 
 /*

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -184,9 +184,6 @@ struct __wt_data_handle {
     uint16_t flags;
 
 /*
- * Atomic flags, use F_*_ATOMIC_32. Unlike the flags above, these are set without holding the
- * dhandle exclusively.
- *
  * WT_DHANDLE_OUTDATED means the handle's metadata has been superseded. Once set it is never
  * cleared, and readers take it to mean:
  * - don't hand this handle to a new user,

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -61,10 +61,9 @@ struct __wt_dhandle_clear_log {
     (F_ISSET(dhandle, WT_DHANDLE_DEAD) || !F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_OPEN))
 
 /* Check if a handle could be reopened. */
-#define WT_DHANDLE_CAN_REOPEN(dhandle)                                                           \
-    (F_MASK(                                                                                     \
-       dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_DROPPED | WT_DHANDLE_OPEN | WT_DHANDLE_OUTDATED) == \
-      WT_DHANDLE_OPEN)
+#define WT_DHANDLE_CAN_REOPEN(dhandle)                                                             \
+    (F_MASK(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_DROPPED | WT_DHANDLE_OPEN) == WT_DHANDLE_OPEN && \
+      !F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED))
 
 /* The metadata cursor's data handle. */
 #define WT_SESSION_META_DHANDLE(s) (((WT_CURSOR_BTREE *)((s)->meta_cursor))->dhandle)
@@ -180,10 +179,29 @@ struct __wt_data_handle {
 #define WT_DHANDLE_IS_METADATA 0x080u  /* Metadata handle */
 #define WT_DHANDLE_LOCK_ONLY 0x100u    /* Handle only used as a lock */
 #define WT_DHANDLE_OPEN 0x200u         /* Handle is open */
-#define WT_DHANDLE_OUTDATED 0x400u     /* Handle is outdated */
-#define WT_DHANDLE_SKIP_OPEN 0x800u    /* Do not open a closed handle */
+#define WT_DHANDLE_SKIP_OPEN 0x400u    /* Do not open a closed handle */
                                        /* AUTOMATIC FLAG VALUE GENERATION STOP 12 */
     uint16_t flags;
+
+/*
+ * Atomic flags, use F_*_ATOMIC_32. Unlike the flags above, these are set without holding the
+ * dhandle exclusively.
+ *
+ * WT_DHANDLE_OUTDATED means the handle's metadata has been superseded. Once set it is never
+ * cleared, and readers take it to mean:
+ * - don't hand this handle to a new user,
+ * - let the current users finish,
+ * - never write this handle's content back,
+ * - retire the handle promptly.
+ *
+ * FIXME-WT-18542: that is what the call sites assume, not a specified invariant, and making the
+ * flag atomic may not be enough to establish it -- readers combine it with dhandle->session_inuse
+ * to conclude "no future user", which is not what that counter means.
+ */
+/* AUTOMATIC FLAG VALUE GENERATION START 0 */
+#define WT_DHANDLE_OUTDATED 0x1u /* Handle is outdated */
+                                 /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
+    wt_shared uint32_t flags_atomic;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_DHANDLE_TS_ASSERT_READ_ALWAYS 0x1u /* Assert read always checking. */

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -191,9 +191,14 @@ struct __wt_data_handle {
  * - never write this handle's content back,
  * - retire the handle promptly.
  *
- * FIXME-WT-18542: that is what the call sites assume, not a specified invariant, and making the
- * flag atomic may not be enough to establish it -- readers combine it with dhandle->session_inuse
- * to conclude "no future user", which is not what that counter means.
+ * FIXME-WT-18542: that is what the call sites assume, not a specified invariant, and atomics alone
+ * do not establish it. Two gaps:
+ * - readers combine the flag with dhandle->session_inuse to conclude "no future user", which is
+ *   not what that counter means;
+ * - a predicate over this flag and the lock-protected flags is two loads of two words, so holding
+ *   the dhandle lock does not make it a snapshot. That is benign only because the flag is set-only
+ *   and no writer holds the dhandle lock; clearing it, or publishing it together with an open or
+ *   dead transition, would break the readers that assume otherwise.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_DHANDLE_OUTDATED 0x1u /* Handle is outdated */

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -149,7 +149,7 @@ __session_find_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *ch
 retry:
     TAILQ_FOREACH (dhandle_cache, &session->dhhash[bucket], hashq) {
         dhandle = dhandle_cache->dhandle;
-        if ((WT_DHANDLE_INACTIVE(dhandle) || F_ISSET(dhandle, WT_DHANDLE_OUTDATED)) &&
+        if ((WT_DHANDLE_INACTIVE(dhandle) || F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED)) &&
           !WT_IS_METADATA(dhandle)) {
             __session_discard_dhandle(session, dhandle_cache);
             /* We deleted our entry, retry from the start. */
@@ -864,7 +864,7 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
 
         const uint64_t time_of_death = __wt_atomic_load_uint64_relaxed(&dhandle->timeofdeath);
         const bool is_sweep_candidate = WT_DHANDLE_INACTIVE(dhandle) ||
-          F_ISSET(dhandle, WT_DHANDLE_OUTDATED) ||
+          F_ISSET_ATOMIC_32(dhandle, WT_DHANDLE_OUTDATED) ||
           (time_of_death != 0 && now - time_of_death > conn->sweep.idle_time);
 
         const bool is_evictable = !WT_DHANDLE_BTREE(dhandle) ||


### PR DESCRIPTION
### Problem

`WT_DHANDLE_OUTDATED` lives in `dhandle->flags`, a plain `uint16_t` whose documented rule is that it is only changed while the dhandle is locked exclusively. Two writers break that rule: `__wti_conn_dhandle_outdated` sets the flag holding only a handle-list read lock, and step-down's btree marking loop sets it under the checkpoint and schema locks. Neither excludes the sweep server, which concurrently read-modify-writes the same word to set `WT_DHANDLE_DEAD` and clear `WT_DHANDLE_OPEN`.

Since every write is a read-modify-write of the whole word, the two interleave and one is lost:

- sweep's write drops the newly set `OUTDATED` bit — self-healing, as the flag is never cleared and a later pass sees it; or
- the `OUTDATED` write restores a stale copy of the word, resurrecting `OPEN` or `DEAD` on a handle sweep is closing.

The second is crash-class, though it has not been observed directly.

### Fix

Give the dhandle its own atomic flags word and move `WT_DHANDLE_OUTDATED` into it, following `WT_BTREE`, `WT_CACHE` and `WT_CONNECTION`, which all carry a `flags_atomic` beside their locked `flags`. The bit is alone in the new word and is only ever set, so concurrent setters cannot clobber each other and sweep's non-atomic update of `flags` can no longer touch it.

This fixes the same race at the step-down marking site, WT-18334.

A `FIXME-WT-18542` at the new definition records what readers assume the flag means, and that atomicity alone may not be enough to establish it.