### PR TITLE
WT-18544 Assert fscanf's result in schema_disagg_abort

### DIFF
--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -133,8 +133,9 @@ adopted_lsn_read(void)
     if (fp == NULL)
         return (0);
 
-    uint64_t lsn = 0;
-    (void)fscanf(fp, "%" SCNu64, &lsn);
+    uint64_t lsn;
+    if (fscanf(fp, "%" SCNu64, &lsn) != 1)
+        lsn = 0;
     testutil_check(fclose(fp));
     return (lsn);
 }

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -134,8 +134,7 @@ adopted_lsn_read(void)
         return (0);
 
     uint64_t lsn;
-    if (fscanf(fp, "%" SCNu64, &lsn) != 1)
-        lsn = 0;
+    testutil_assert(fscanf(fp, "%" SCNu64, &lsn) == 1);
     testutil_check(fclose(fp));
     return (lsn);
 }


### PR DESCRIPTION
### Problem

A default GCC build (Ubuntu 24.04, GCC 13.3.0) fails to compile the test:

```
main.c:137:11: error: ignoring return value of 'fscanf' declared with
attribute 'warn_unused_result' [-Werror=unused-result]
```

glibc marks `fscanf` `warn_unused_result`, and GCC accepts neither a `(void)` cast nor `WT_IGNORE_RET` as suppression. The MongoDB toolchain compiler does not enable the attribute, so Evergreen is unaffected.

### Fix

Assert the result. `adopted_lsn_publish` writes a temporary file and `rename()`s it into place, so once the file exists it always holds a complete value — a killed node corrupts the temp file, never the published one. A failed parse is therefore a genuine anomaly, and the writer already dies on a bad write (`testutil_assert(fprintf(...) > 0)`).

Swallowing the failure and returning zero would be read by the only caller, `generator.c`, as "the peer has not adopted the checkpoint yet": the step-down would wait out `MAX_OP_WAIT` and die pointing at a stalled step-down rather than at the unreadable file.

The documented "zero when none yet" contract is unaffected — that case is the `fopen == NULL` early return.

This was the only `fscanf`/`scanf` call in the tree that ignored its result.

### Testing

Builds with the system GCC; a two-node run (`-r lf`), which is the path that reads the file, passes and never trips the assert.

The test still aborts at runtime on `develop` for unrelated reasons — a checkpoint-pickup btree-ID mismatch, WT-18068 — which is independent of this change: a baseline binary built from the unmodified source (warning demoted to non-fatal) aborts identically, 3/3 runs with and without the change.