### PR TITLE
WT-16152 Document tiered storage removal

### DIFF
--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -27,6 +27,24 @@ The steps are as follows:
 -# Finally drop the FLCS table.
 
 </dd>
+
+<dt>Tiered storage is removed</dt>
+<dd>
+Tiered storage is no longer supported. Checkpoint configuration
+<code>flush_tier</code> is an unknown configuration key. The
+<code>WT_STORAGE_SOURCE</code> interface and
+<code>WT_CONNECTION.add_storage_source</code> have been removed.
+Opening a <code>tiered:</code>, <code>object:</code>, or <code>tier:</code>
+URI is refused. The connection verbose choice \c tiered is no longer
+recognized. The \c dir_store extension is no longer provided.
+
+Connection and table or file <code>tiered_storage</code> configuration, and
+the file <code>tiered_object</code> setting, still parse so leftover keys in
+existing metadata are not an error. A non-none
+<code>tiered_storage.name</code> on connection open or on table or file create
+returns ENOTSUP.
+</dd>
+</dl> <hr>
 @section version_1131 Upgrading to Version 11.3.1
 <dl>
 

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -40,10 +40,10 @@ URI is refused. The connection verbose choice \c tiered is no longer
 recognized. The \c dir_store extension is no longer provided.
 
 Connection and table or file <code>tiered_storage</code> configuration, and
-the file <code>tiered_object</code> setting, still parse so leftover keys in
-existing metadata are not an error. A non-none
-<code>tiered_storage.name</code> on connection open or on table or file create
-returns ENOTSUP.
+the file <code>tiered_object</code> setting, still parse, so leftover keys in
+existing metadata do not cause an error. A
+<code>tiered_storage.name</code> value other than \c none on connection open
+or on table or file create returns ENOTSUP.
 </dd>
 </dl> <hr>
 @section version_1131 Upgrading to Version 11.3.1

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -32,8 +32,9 @@ The steps are as follows:
 <dd>
 Tiered storage is no longer supported. Checkpoint configuration
 <code>flush_tier</code> is an unknown configuration key. The
-<code>WT_STORAGE_SOURCE</code> interface and
-<code>WT_CONNECTION.add_storage_source</code> have been removed.
+<code>WT_STORAGE_SOURCE</code> interface,
+<code>WT_CONNECTION.add_storage_source</code>, and
+<code>WT_CONNECTION.get_storage_source</code> have been removed.
 Opening a <code>tiered:</code>, <code>object:</code>, or <code>tier:</code>
 URI is refused. The connection verbose choice \c tiered is no longer
 recognized. The \c dir_store extension is no longer provided.


### PR DESCRIPTION
> This PR was created by an automated coding agent.

Documents the 12.0 removal of tiered storage in the upgrading notes: gone APIs and config, leftover parse stubs, and ENOTSUP for a non-none storage source name.

## Testing
- `cd dist && ./s_fast` (pass; `s_export` skipped because libwiredtiger was not built)

Made with [Cursor](https://cursor.com)