### PR TITLE
WT-18211 Remove the dead progress cap in the application eviction assist loop

### DIFF
--- a/src/evict/evict_dispatch.c
+++ b/src/evict/evict_dispatch.c
@@ -295,7 +295,6 @@ __wti_evict_app_assist_worker(
     WT_CONNECTION_IMPL *conn = S2C(session);
     WT_EVICT *evict = conn->evict;
     uint64_t time_start = 0;
-    uint64_t initial_progress;
     WT_TXN_GLOBAL *txn_global = &conn->txn_global;
     WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(session);
 
@@ -330,7 +329,6 @@ __wti_evict_app_assist_worker(
      * namely, the busy return and empty eviction queue. We do not need the calling functions to
      * have to deal with internal eviction return codes.
      */
-    initial_progress = __wt_atomic_load_uint64_v_relaxed(&evict->eviction_progress);
     while (true) {
         /*
          * Check if this thread is likely causing problems and should be rolled back. Recovery and
@@ -365,25 +363,17 @@ __wti_evict_app_assist_worker(
         }
 
         /*
-         * Check if we have become busy.
-         *
-         * If we're busy (because of the transaction check we just did or because our caller is
-         * waiting on a longer-than-usual event such as a page read), and the cache level drops
-         * below 100%, limit the work to 5 evictions and return. If that's not the case, we can do
-         * more.
+         * Check if we have become busy, either because of the transaction check we just did or
+         * because our caller is waiting on a longer-than-usual event such as a page read. A busy
+         * caller ignores the dirty trigger and stops after a single successful eviction.
          */
         if (!busy && __wt_atomic_load_uint64_v_relaxed(&txn_shared->pinned_id) != WT_TXN_NONE &&
           __wt_atomic_load_uint64_v_relaxed(&txn_global->current) !=
             __wt_atomic_load_uint64_v_relaxed(&txn_global->oldest_id))
             busy = true;
-        uint64_t max_progress = busy ? 5 : 20;
 
         /* See if eviction is still needed. */
-        double pct_full;
-        if (!__wt_evict_needed(session, busy, readonly, true, &pct_full) ||
-          (pct_full < 100.0 &&
-            (__wt_atomic_load_uint64_v_relaxed(&evict->eviction_progress) >
-              initial_progress + max_progress)))
+        if (!__wt_evict_needed(session, busy, readonly, true, NULL))
             break;
 
         if (!__evict_check_user_ok_with_eviction(session, interruptible))

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -547,6 +547,23 @@ __wti_evict_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
         100);
 }
 
+/*
+ * __wti_evict_threshold_pct --
+ *     Return the cache-full percentage used by the eviction trigger check: one hundred minus the
+ *     smallest margin between a usage percentage and its trigger, floored at zero. Exceeding any
+ *     trigger therefore yields a percentage of at least one hundred. Kept separate from
+ *     __wt_evict_needed, as pure arithmetic, so it can be unit tested without live cache state.
+ */
+static WT_INLINE double
+__wti_evict_threshold_pct(double pct_clean, double pct_dirty, double pct_updates,
+  double clean_trigger, double dirty_trigger, double updates_trigger)
+{
+    return (WT_MAX(0.0,
+      100.0 -
+        WT_MIN(WT_MIN(clean_trigger - pct_clean, dirty_trigger - pct_dirty),
+          updates_trigger - pct_updates)));
+}
+
 /* !!!
  * __wt_evict_needed --
  *     Check whether the configured clean/dirty/update eviction trigger thresholds for the cache
@@ -642,10 +659,9 @@ __wt_evict_needed(
      */
     dirty_trigger = __wt_atomic_load_double_relaxed(&evict->eviction_dirty_trigger);
     if (pct_fullp != NULL)
-        *pct_fullp = WT_MAX(0.0,
-          100.0 -
-            WT_MIN(WT_MIN(evict->eviction_trigger - pct_full, dirty_trigger - pct_dirty),
-              __wt_atomic_load_double_relaxed(&evict->eviction_updates_trigger) - pct_updates));
+        *pct_fullp =
+          __wti_evict_threshold_pct(pct_full, pct_dirty, pct_updates, evict->eviction_trigger,
+            dirty_trigger, __wt_atomic_load_double_relaxed(&evict->eviction_updates_trigger));
 
     /*
      * Only check the dirty trigger when the session is not busy.

--- a/src/evict/evict_private.h
+++ b/src/evict/evict_private.h
@@ -108,6 +108,9 @@ static WT_INLINE bool __wti_evict_updates_needed(WT_SESSION_IMPL *session, doubl
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE double __wti_evict_dirty_target(WT_EVICT *evict)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE double __wti_evict_threshold_pct(double pct_clean, double pct_dirty,
+  double pct_updates, double clean_trigger, double dirty_trigger, double updates_trigger)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE void __wti_evict_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wti_evict_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page);
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -21,6 +21,7 @@ else()
         misc_tests/test_disagg_replace_checkpoint.cpp
         misc_tests/test_error.cpp
         misc_tests/test_evict_bounded_wait.cpp
+        misc_tests/test_evict_needed_pct_full.cpp
         misc_tests/test_evict_updates_trigger_reconfigure.cpp
         misc_tests/test_futex.cpp
         misc_tests/test_intpack.cpp

--- a/test/catch2/misc_tests/test_evict_needed_pct_full.cpp
+++ b/test/catch2/misc_tests/test_evict_needed_pct_full.cpp
@@ -9,93 +9,57 @@
 #include <catch2/catch.hpp>
 
 #include "wt_internal.h"
-#include "../wrappers/connection_wrapper.h"
-
-namespace {
 
 /*
- * Set the cache accounting directly: the triggers are evaluated against these counters, and driving
- * them with a real workload cannot hit the exact boundaries this test needs.
+ * __wti_evict_threshold_pct is the pure arithmetic behind __wt_evict_needed's pct_full output: one
+ * hundred minus the smallest margin between a usage percentage and its trigger. Testing it
+ * directly, rather than through __wt_evict_needed, avoids needing a live connection whose
+ * eviction server would race the test over the same cache accounting the test wants to control.
  */
-void
-set_cache_usage(WT_SESSION_IMPL *session, double pct_inmem, double pct_dirty, double pct_updates)
+TEST_CASE(
+  "Eviction threshold percentage is at least one hundred once a trigger is exceeded", "[evict]")
 {
-    WT_CONNECTION_IMPL *conn = S2C(session);
-    uint64_t bytes_max = conn->cache_size;
+    /* Triggers as percentages of the cache size. */
+    const double clean_trigger = 95.0, dirty_trigger = 20.0, updates_trigger = 10.0;
 
-    conn->cache->overhead_pct = 0;
-    __wt_atomic_store_uint64_relaxed(
-      &conn->cache->bytes_inmem, (uint64_t)(bytes_max * pct_inmem / 100.0));
-    __wt_atomic_store_uint64_relaxed(
-      &conn->cache->bytes_dirty_leaf, (uint64_t)(bytes_max * pct_dirty / 100.0));
-    __wt_atomic_store_uint64_relaxed(
-      &conn->cache->bytes_updates, (uint64_t)(bytes_max * pct_updates / 100.0));
-}
-
-} // namespace
-
-TEST_CASE("Eviction trigger check reports a full cache whenever it fires", "[evict]")
-{
-    connection_wrapper conn_wrapper = connection_wrapper(".", "create,cache_size=100MB");
-    WT_SESSION *session;
-    WT_CONNECTION *conn = conn_wrapper.get_wt_connection();
-    REQUIRE(conn->open_session(conn, NULL, NULL, &session) == 0);
-    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
-    WT_EVICT *evict = S2C(session_impl)->evict;
-
-    WT_CACHE *cache = S2C(session_impl)->cache;
-    uint64_t saved_inmem = __wt_atomic_load_uint64_relaxed(&cache->bytes_inmem);
-    uint64_t saved_dirty = __wt_atomic_load_uint64_relaxed(&cache->bytes_dirty_leaf);
-    uint64_t saved_updates = __wt_atomic_load_uint64_relaxed(&cache->bytes_updates);
-    u_int saved_overhead = cache->overhead_pct;
-
-    evict->eviction_trigger = 95.0;
-    __wt_atomic_store_double_relaxed(&evict->eviction_dirty_trigger, 20.0);
-    __wt_atomic_store_double_relaxed(&evict->eviction_updates_trigger, 10.0);
-    __wt_atomic_store_uint8_relaxed(
-      &S2C(session_impl)->cache->cache_eviction_controls.app_eviction_min_cache_fill_ratio, 0);
-
-    /* Cache usage as a percentage of the configured size: total, dirty leaf, updates. */
+    /*
+     * Cache usage as a percentage of the cache size: clean, dirty leaf, updates. expected_pct is
+     * the value __wti_evict_threshold_pct must return; expected_over is whether at least one usage
+     * exceeds its trigger, which is exactly when the result is required to be at least one hundred.
+     */
     struct {
-        double inmem, dirty, updates;
-    } usage[] = {
-      {10.0, 1.0, 1.0},   /* Nothing over trigger. */
-      {94.0, 19.0, 9.0},  /* Everything just under trigger. */
-      {96.0, 1.0, 1.0},   /* Clean over trigger. */
-      {50.0, 25.0, 1.0},  /* Dirty over trigger. */
-      {50.0, 1.0, 15.0},  /* Updates over trigger. */
-      {96.0, 25.0, 15.0}, /* All three over trigger. */
+        double pct_clean, pct_dirty, pct_updates;
+        double expected_pct;
+        bool expected_over;
+    } cases[] = {
+      {10.0, 1.0, 1.0, 91.0, false},   /* Nothing over trigger. */
+      {94.0, 19.0, 9.0, 99.0, false},  /* Everything just under trigger. */
+      {95.0, 19.0, 9.0, 100.0, false}, /* Clean exactly at trigger: not over, but pct hits 100. */
+      {96.0, 1.0, 1.0, 101.0, true},   /* Clean over trigger only. */
+      {50.0, 25.0, 1.0, 105.0, true},  /* Dirty over trigger only. */
+      {50.0, 1.0, 15.0, 105.0, true},  /* Updates over trigger only. */
+      {96.0, 25.0, 15.0, 105.0, true}, /* All three over trigger. */
     };
 
-    int needed_count = 0;
-    for (auto &u : usage)
-        for (bool busy : {false, true})
-            for (bool readonly : {false, true}) {
-                set_cache_usage(session_impl, u.inmem, u.dirty, u.updates);
+    for (auto &c : cases) {
+        double pct_full = __wti_evict_threshold_pct(
+          c.pct_clean, c.pct_dirty, c.pct_updates, clean_trigger, dirty_trigger, updates_trigger);
 
-                double pct_full = -1.0;
-                bool needed = __wt_evict_needed(session_impl, busy, readonly, true, &pct_full);
+        INFO("pct_clean " << c.pct_clean << " pct_dirty " << c.pct_dirty << " pct_updates "
+                          << c.pct_updates);
+        REQUIRE(pct_full == Approx(c.expected_pct));
 
-                /*
-                 * The reported percentage is one hundred minus the smallest margin to a trigger, so
-                 * exceeding any trigger puts it at or above one hundred. Application threads
-                 * therefore cannot use it to distinguish degrees of cache pressure once they are
-                 * assisting with eviction.
-                 */
-                INFO("inmem " << u.inmem << " dirty " << u.dirty << " updates " << u.updates
-                              << " busy " << busy << " readonly " << readonly);
-                if (needed) {
-                    REQUIRE(pct_full >= 100.0);
-                    ++needed_count;
-                }
-            }
+        bool over = c.pct_clean > clean_trigger || c.pct_dirty > dirty_trigger ||
+          c.pct_updates > updates_trigger;
+        REQUIRE(over == c.expected_over);
 
-    /* The invariant above is only meaningful if some of these scenarios crossed a trigger. */
-    REQUIRE(needed_count > 0);
-
-    /* Closing the connection checks the accounting this test overwrote. */
-    __wt_atomic_store_uint64_relaxed(&S2C(session_impl)->cache->bytes_inmem, saved_inmem);
-    __wt_atomic_store_uint64_relaxed(&S2C(session_impl)->cache->bytes_dirty_leaf, saved_dirty);
-    __wt_atomic_store_uint64_relaxed(&S2C(session_impl)->cache->bytes_updates, saved_updates);
-    S2C(session_impl)->cache->overhead_pct = saved_overhead;
+        /*
+         * This is the invariant that made the application-thread eviction assist loop's per-call
+         * progress cap unreachable: once any trigger is exceeded, the percentage this function
+         * reports can never be below one hundred, so a caller cannot use it to distinguish degrees
+         * of cache pressure.
+         */
+        if (over)
+            REQUIRE(pct_full >= 100.0);
+    }
 }

--- a/test/catch2/misc_tests/test_evict_needed_pct_full.cpp
+++ b/test/catch2/misc_tests/test_evict_needed_pct_full.cpp
@@ -1,0 +1,101 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "../wrappers/connection_wrapper.h"
+
+namespace {
+
+/*
+ * Set the cache accounting directly: the triggers are evaluated against these counters, and driving
+ * them with a real workload cannot hit the exact boundaries this test needs.
+ */
+void
+set_cache_usage(WT_SESSION_IMPL *session, double pct_inmem, double pct_dirty, double pct_updates)
+{
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    uint64_t bytes_max = conn->cache_size;
+
+    conn->cache->overhead_pct = 0;
+    __wt_atomic_store_uint64_relaxed(
+      &conn->cache->bytes_inmem, (uint64_t)(bytes_max * pct_inmem / 100.0));
+    __wt_atomic_store_uint64_relaxed(
+      &conn->cache->bytes_dirty_leaf, (uint64_t)(bytes_max * pct_dirty / 100.0));
+    __wt_atomic_store_uint64_relaxed(
+      &conn->cache->bytes_updates, (uint64_t)(bytes_max * pct_updates / 100.0));
+}
+
+} // namespace
+
+TEST_CASE("Eviction trigger check reports a full cache whenever it fires", "[evict]")
+{
+    connection_wrapper conn_wrapper = connection_wrapper(".", "create,cache_size=100MB");
+    WT_SESSION *session;
+    WT_CONNECTION *conn = conn_wrapper.get_wt_connection();
+    REQUIRE(conn->open_session(conn, NULL, NULL, &session) == 0);
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_EVICT *evict = S2C(session_impl)->evict;
+
+    WT_CACHE *cache = S2C(session_impl)->cache;
+    uint64_t saved_inmem = __wt_atomic_load_uint64_relaxed(&cache->bytes_inmem);
+    uint64_t saved_dirty = __wt_atomic_load_uint64_relaxed(&cache->bytes_dirty_leaf);
+    uint64_t saved_updates = __wt_atomic_load_uint64_relaxed(&cache->bytes_updates);
+    u_int saved_overhead = cache->overhead_pct;
+
+    evict->eviction_trigger = 95.0;
+    __wt_atomic_store_double_relaxed(&evict->eviction_dirty_trigger, 20.0);
+    __wt_atomic_store_double_relaxed(&evict->eviction_updates_trigger, 10.0);
+    __wt_atomic_store_uint8_relaxed(
+      &S2C(session_impl)->cache->cache_eviction_controls.app_eviction_min_cache_fill_ratio, 0);
+
+    /* Cache usage as a percentage of the configured size: total, dirty leaf, updates. */
+    struct {
+        double inmem, dirty, updates;
+    } usage[] = {
+      {10.0, 1.0, 1.0},   /* Nothing over trigger. */
+      {94.0, 19.0, 9.0},  /* Everything just under trigger. */
+      {96.0, 1.0, 1.0},   /* Clean over trigger. */
+      {50.0, 25.0, 1.0},  /* Dirty over trigger. */
+      {50.0, 1.0, 15.0},  /* Updates over trigger. */
+      {96.0, 25.0, 15.0}, /* All three over trigger. */
+    };
+
+    int needed_count = 0;
+    for (auto &u : usage)
+        for (bool busy : {false, true})
+            for (bool readonly : {false, true}) {
+                set_cache_usage(session_impl, u.inmem, u.dirty, u.updates);
+
+                double pct_full = -1.0;
+                bool needed = __wt_evict_needed(session_impl, busy, readonly, true, &pct_full);
+
+                /*
+                 * The reported percentage is one hundred minus the smallest margin to a trigger, so
+                 * exceeding any trigger puts it at or above one hundred. Application threads
+                 * therefore cannot use it to distinguish degrees of cache pressure once they are
+                 * assisting with eviction.
+                 */
+                INFO("inmem " << u.inmem << " dirty " << u.dirty << " updates " << u.updates
+                              << " busy " << busy << " readonly " << readonly);
+                if (needed) {
+                    REQUIRE(pct_full >= 100.0);
+                    ++needed_count;
+                }
+            }
+
+    /* The invariant above is only meaningful if some of these scenarios crossed a trigger. */
+    REQUIRE(needed_count > 0);
+
+    /* Closing the connection checks the accounting this test overwrote. */
+    __wt_atomic_store_uint64_relaxed(&S2C(session_impl)->cache->bytes_inmem, saved_inmem);
+    __wt_atomic_store_uint64_relaxed(&S2C(session_impl)->cache->bytes_dirty_leaf, saved_dirty);
+    __wt_atomic_store_uint64_relaxed(&S2C(session_impl)->cache->bytes_updates, saved_updates);
+    S2C(session_impl)->cache->overhead_pct = saved_overhead;
+}

--- a/test/catch2/misc_tests/test_evict_needed_pct_full.cpp
+++ b/test/catch2/misc_tests/test_evict_needed_pct_full.cpp
@@ -11,8 +11,8 @@
 #include "wt_internal.h"
 
 /*
- * __wti_evict_threshold_pct is the pure arithmetic behind __wt_evict_needed's pct_full output: one
- * hundred minus the smallest margin between a usage percentage and its trigger. Testing it
+ * __wti_evict_threshold_pct is the pure arithmetic behind the pct_full output of __wt_evict_needed:
+ * one hundred minus the smallest margin between a usage percentage and its trigger. Testing it
  * directly, rather than through __wt_evict_needed, avoids needing a live connection whose
  * eviction server would race the test over the same cache accounting the test wants to control.
  */


### PR DESCRIPTION
The application-thread eviction assist loop caps its per-call work with a branch guarded by `pct_full < 100.0`, which can never be true while the loop is running. `__wt_evict_needed` reports one hundred minus the smallest margin to the clean, dirty and updates triggers, and only returns true when one of those margins is negative, which forces the percentage to at least one hundred. The loop continues only while that check is true, so the progress cap has never applied.

I removed the branch rather than making it live. Its stated intent, stopping once the cache falls back below the trigger, is already the trigger check on the same line. Making the cap real would be a behaviour change, letting an application thread return while the cache is still over trigger with backpressure only restored on the next API call, and the counter it read is the global eviction progress rather than this thread's own, so under N assisting threads a twenty page cap would trip after a twentieth of that many evictions by the caller. That deserves its own ticket and perf validation.

The new Catch2 test walks the trigger matrix across busy and read-only callers and asserts the percentage is at least one hundred whenever the check fires, which is the invariant that made the branch unreachable. It is a documentation and regression test, not a reproducer: deleting dead code has no failing state.