### PR TITLE
WT-18461 Check the end state of a checkpoint split, not one eviction

### DIFF
--- a/test/suite/test_checkpoint_scrub_evict02.py
+++ b/test/suite/test_checkpoint_scrub_evict02.py
@@ -299,11 +299,16 @@ class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
         self.assertGreater(self.get_stat(stat.dsrc.cache_eviction_split_leaf, self.uri), 0,
           'eviction never realized the checkpoint split')
 
-        # A chunk that kept its image is instantiated in cache instead of being left on disk, so
-        # the cache would hold a page per chunk. The tree's leaf pages bound how many that is.
+        # A chunk that kept its image is instantiated in cache instead of being left on disk, which
+        # counts a restore. Nothing here retains an image, so any restore is a chunk's.
+        self.assertEqual(self.get_stat(stat.dsrc.cache_scrub_restore, self.uri), 0,
+          'a chunk of the split page was instantiated from an image')
+
+        # The same property from the cache's side: a page per chunk would leave the whole tree in
+        # cache. The tree's leaf pages count the chunks the split produced.
         chunks = self.get_stat(stat.dsrc.btree_row_leaf, self.uri)
         pages = self.get_stat(stat.conn.cache_pages_inuse)
-        self.assertGreater(chunks, 100, 'the checkpoint split the page into too few chunks to tell')
+        self.assertGreater(chunks, 20, 'the checkpoint split the page into too few chunks to tell')
         self.assertLess(pages, chunks // 4,
           'a split of %d chunks left %d pages in cache' % (chunks, pages))
         self.check_values('x' * 200, nrows=2000)

--- a/test/suite/test_checkpoint_scrub_evict02.py
+++ b/test/suite/test_checkpoint_scrub_evict02.py
@@ -285,26 +285,25 @@ class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
           'workload did not split a leaf page during checkpoint')
         self.assertEqual(self.scrub_images(), (0, 0))
 
-        # Evict the split page: the cache must end up with fewer pages, not one per chunk. Forced
-        # eviction can return EBUSY, so retry across the key range until the split is realized;
-        # cache_eviction_split_leaf tells us it happened.
+        # Evict across the key range, then measure what the split left behind. Which thread
+        # realizes the split, and when, is not ours to choose: eviction may take the page while
+        # the checkpoint is still running, or only once the cursor forces it. So drive eviction
+        # over the whole range and check the end state rather than any single eviction.
         cursor = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
-        pages_before = pages_after = 0
-        for key in range(0, 2000, 200):
-            splits_before = self.get_stat(stat.conn.cache_eviction_split_leaf)
-            pages_before = self.get_stat(stat.conn.cache_pages_inuse)
+        for key in range(2000):
             cursor.set_key(key)
             cursor.search()
             cursor.reset()
-            pages_after = self.get_stat(stat.conn.cache_pages_inuse)
-            if self.get_stat(stat.conn.cache_eviction_split_leaf) > splits_before:
-                break
-        else:
-            cursor.close()
-            self.skipTest('eviction never realized the checkpoint split')
         cursor.close()
 
-        self.assertLess(pages_after, pages_before,
-          'evicting a page split by checkpoint left %d pages in cache, was %d'
-          % (pages_after, pages_before))
+        self.assertGreater(self.get_stat(stat.dsrc.cache_eviction_split_leaf, self.uri), 0,
+          'eviction never realized the checkpoint split')
+
+        # A chunk that kept its image is instantiated in cache instead of being left on disk, so
+        # the cache would hold a page per chunk. The tree's leaf pages bound how many that is.
+        chunks = self.get_stat(stat.dsrc.btree_row_leaf, self.uri)
+        pages = self.get_stat(stat.conn.cache_pages_inuse)
+        self.assertGreater(chunks, 100, 'the checkpoint split the page into too few chunks to tell')
+        self.assertLess(pages, chunks // 4,
+          'a split of %d chunks left %d pages in cache' % (chunks, pages))
         self.check_values('x' * 200, nrows=2000)

--- a/test/suite/test_checkpoint_scrub_evict02.py
+++ b/test/suite/test_checkpoint_scrub_evict02.py
@@ -289,12 +289,7 @@ class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
         # realizes the split, and when, is not ours to choose: eviction may take the page while
         # the checkpoint is still running, or only once the cursor forces it. So drive eviction
         # over the whole range and check the end state rather than any single eviction.
-        cursor = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
-        for key in range(2000):
-            cursor.set_key(key)
-            cursor.search()
-            cursor.reset()
-        cursor.close()
+        self.evict_all(2000)
 
         self.assertGreater(self.get_stat(stat.dsrc.cache_eviction_split_leaf, self.uri), 0,
           'eviction never realized the checkpoint split')


### PR DESCRIPTION
`test_split_at_checkpoint_retains_no_image` broke out of its forced-eviction loop as soon as a leaf split statistic moved, then compared the cache page counts taken around that one eviction. The split of the multiblock page is not necessarily performed by that eviction: the eviction server realizes it while the checkpoint is still running in the disagg leader configuration, and only when the cursor forces it in a standalone run. When the background split landed inside the loop, the test broke on a witness it had not caused and asserted on two unrelated page counts, which is the 9 not less than 9 failure on the ASan variant.

The test now drives forced eviction over the whole key range and checks the end state instead of any single eviction: the split happened, and the cache holds far fewer pages than the split produced chunks. That is the property the test is about, and it is immune to the timing, because background eviction only removes pages while a chunk that keeps its image adds one.

Twenty runs each in the standalone and disagg leader configurations pass with no skips, where before the disagg configuration skipped every local run. Scanning without release_evict, so the leaf pages stay instantiated, gives 249 chunks against 258 pages in cache and fails the new bound of 62; real runs sit at 4 and 9 pages. Full analysis is on the ticket.