### PR TITLE
WT-18120 Prevent eviction walk starvation (#14298)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -450,6 +450,8 @@ conn_stats = [
     EvictStat('eviction_server_skip_unwanted_pages', 'eviction server skips pages that we do not want to evict'),
     EvictStat('eviction_server_skip_unwanted_tree', 'eviction server skips tree that we do not want to evict'),
     EvictStat('eviction_server_slept', 'eviction server slept, because we did not make progress with eviction'),
+    EvictStat('eviction_server_walk_dominating_cache', 'eviction server walks trees within their walk period because they dominate the cache'),
+    EvictStat('eviction_server_walk_dominating_cache_unproductive', 'eviction server walks trees within their walk period because they dominate the cache but queues no pages'),
     EvictStat('eviction_slow', 'eviction server unable to reach eviction goal'),
     EvictStat('eviction_stable_state_workers', 'eviction worker thread stable number', 'no_clear'),
     EvictStat('eviction_state', 'eviction state', 'no_clear,no_scale'),

--- a/src/evict/evict_private.h
+++ b/src/evict/evict_private.h
@@ -16,6 +16,12 @@
 #define WTI_EVICT_WALK_BASE 300         /* Pages tracked across file visits */
 #define WTI_EVICT_WALK_INCR 100         /* Pages added each walk */
 
+/*
+ * The walk period doubles on every unproductive walk of a tree, so saturation means the tree has
+ * been unproductive for many consecutive walks.
+ */
+#define WTI_EVICT_WALK_PERIOD_MAX 100 /* Ceiling on walks skipped for one tree */
+
 /* True if there are eviction worker threads beyond the server thread itself. */
 #define WT_EVICT_HAS_WORKERS(s) \
     (__wt_atomic_load_uint32_relaxed(&S2C(s)->evict_config.threads.current_threads) > 1)

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -266,10 +266,11 @@ __evict_walk_choose_dhandle(WT_SESSION_IMPL *session, WT_DATA_HANDLE **dhandle_p
 
 /*
  * __evict_btree_dominating_cache --
- *     Return if a single btree is occupying at least half of any of our target's cache usage.
+ *     Return if a single btree is occupying at least half of any of our target's cache usage. Only
+ *     the dimensions selected by the given eviction flags are considered.
  */
 static WT_INLINE bool
-__evict_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree)
+__evict_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree, uint32_t flags)
 {
     WT_CACHE *cache;
     WT_EVICT *evict;
@@ -280,21 +281,24 @@ __evict_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree)
     evict = S2C(session)->evict;
     bytes_max = S2C(session)->cache_size + 1;
 
-    if (__wt_cache_bytes_plus_overhead(
-          cache, __wt_atomic_load_uint64_relaxed(&btree->bytes_inmem)) >
-      (uint64_t)(0.5 * evict->eviction_target *
-        (bytes_max + __wt_atomic_load_uint64_relaxed(&cache->bytes_shared_dsk_duplicate))) /
-        100)
+    if (LF_ISSET(WT_EVICT_CACHE_CLEAN) &&
+      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load_uint64_relaxed(&btree->bytes_inmem)) >
+        (uint64_t)(0.5 * evict->eviction_target *
+          (bytes_max + __wt_atomic_load_uint64_relaxed(&cache->bytes_shared_dsk_duplicate))) /
+          100)
         return (true);
 
-    bytes_dirty = __wt_atomic_load_uint64_relaxed(&btree->bytes_dirty_intl) +
-      __wt_atomic_load_uint64_relaxed(&btree->bytes_dirty_leaf);
-    if (__wt_cache_bytes_plus_overhead(cache, bytes_dirty) >
-      (uint64_t)(0.5 * evict->eviction_dirty_target * bytes_max) / 100)
-        return (true);
-    if (__wt_cache_bytes_plus_overhead(
-          cache, __wt_atomic_load_uint64_relaxed(&btree->bytes_updates)) >
-      (uint64_t)(0.5 * evict->eviction_updates_target * bytes_max) / 100)
+    if (LF_ISSET(WT_EVICT_CACHE_DIRTY)) {
+        bytes_dirty = __wt_atomic_load_uint64_relaxed(&btree->bytes_dirty_intl) +
+          __wt_atomic_load_uint64_relaxed(&btree->bytes_dirty_leaf);
+        if (__wt_cache_bytes_plus_overhead(cache, bytes_dirty) >
+          (uint64_t)(0.5 * evict->eviction_dirty_target * bytes_max) / 100)
+            return (true);
+    }
+    if (LF_ISSET(WT_EVICT_CACHE_UPDATES) &&
+      __wt_cache_bytes_plus_overhead(
+        cache, __wt_atomic_load_uint64_relaxed(&btree->bytes_updates)) >
+        (uint64_t)(0.5 * evict->eviction_updates_target * bytes_max) / 100)
         return (true);
 
     return (false);
@@ -329,7 +333,7 @@ __wti_evict_walk(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue)
     WT_DECL_RET;
     WT_EVICT *evict;
     WT_TRACK_OP_DECL;
-    uint32_t evict_walk_period;
+    uint32_t dominating_flags, evict_walk_flags, evict_walk_period;
     u_int loop_count, max_entries, retries, slot, start_slot;
     u_int total_candidates;
     bool aggressive, dhandle_list_locked;
@@ -454,7 +458,7 @@ retry:
          * its pages.
          */
         if (btree->evict_priority != 0 && !aggressive &&
-          !__evict_btree_dominating_cache(session, btree)) {
+          !__evict_btree_dominating_cache(session, btree, WT_EVICT_CACHE_ALL)) {
             WT_STAT_CONN_INCR(session, eviction_server_skip_trees_stick_in_cache);
             __evict_disagg_btree_skip_count(session, btree);
             continue;
@@ -481,23 +485,50 @@ retry:
          * If the cache walk flags have changed since the prior eviction pass on this tree then
          * reset the walk effectiveness tracking. Imagine a case where only dirty content has been
          * looked for and this tree doesn't have much dirty content. Then eviction starts looking
-         * for clean content - this tree might be a cornucopia of good clean candidate pages.
-         * Specific for disaggregated connections, where we are using WT_EVICT_MODIFY_COUNT_MIN and
-         * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD values to change the priority for this heuristic.
+         * for clean content - this tree might be a cornucopia of good clean candidate pages. This
+         * is particularly important for disaggregated connections, where we are using
+         * WT_EVICT_MODIFY_COUNT_MIN and WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD values to change the
+         * priority for this heuristic.
+         *
+         * Compare only the dimensions being evicted. The remaining flags track pressure levels and
+         * the urgent queue, which turn over almost every pass, and resetting on those would leave
+         * no effectiveness history at all.
          */
-        if (__wt_conn_is_disagg(session) && btree->last_evict_walk_flags != evict->flags) {
+        evict_walk_flags = evict->flags & WT_EVICT_CACHE_ALL;
+        if (btree->last_evict_walk_flags != evict_walk_flags) {
             __wt_atomic_store_uint32_relaxed(&btree->evict_walk_period, 0);
-            btree->last_evict_walk_flags = evict->flags;
+            btree->last_evict_walk_flags = evict_walk_flags;
         }
 
         /*
-         * If we are filling the queue, skip files that haven't been useful in the past.
+         * Consider every dimension eviction is targeting, except dirty content in a tree that is
+         * syncing: every modified page in such a tree is rejected, so its dirty footprint cannot
+         * translate into candidates.
+         */
+        dominating_flags = evict_walk_flags;
+        if (WT_BTREE_SYNCING(btree))
+            FLD_CLR(dominating_flags, WT_EVICT_CACHE_DIRTY);
+
+        /*
+         * If we are filling the queue, skip files that haven't been useful in the past. The walk
+         * period only records that previous walks found few candidates, not what the tree holds
+         * now: if the tree dominates the cache usage for a dimension eviction is currently
+         * targeting, skipping it can stall eviction entirely, so walk it regardless.
+         *
+         * A saturated walk period is excluded from that override because it means many consecutive
+         * walks of this tree came up short, so the tree's size is not translating into candidates.
          */
         evict_walk_period = __wt_atomic_load_uint32_relaxed(&btree->evict_walk_period);
+        btree->evict_walk_dominating = false;
         if (evict_walk_period != 0 && btree->evict_walk_skips++ < evict_walk_period) {
-            WT_STAT_CONN_INCR(session, eviction_server_skip_trees_not_useful_before);
-            __evict_disagg_btree_skip_count(session, btree);
-            continue;
+            if (evict_walk_period >= WTI_EVICT_WALK_PERIOD_MAX ||
+              !__evict_btree_dominating_cache(session, btree, dominating_flags)) {
+                WT_STAT_CONN_INCR(session, eviction_server_skip_trees_not_useful_before);
+                __evict_disagg_btree_skip_count(session, btree);
+                continue;
+            }
+            btree->evict_walk_dominating = true;
+            WT_STAT_CONN_INCR(session, eviction_server_walk_dominating_cache);
         }
 
         /*
@@ -1403,11 +1434,18 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, u_int max_en
       "%s walk: target %" PRIu32 ", seen %" PRIu64 ", queued %" PRIu64, session->dhandle->name,
       target_pages, pages_seen, pages_queued);
 
+    /*
+     * A walk that only happened because the tree dominates the cache and queued nothing is the cost
+     * of that override, so track it separately.
+     */
+    if (btree->evict_walk_dominating && pages_queued == 0)
+        WT_STAT_CONN_INCR(session, eviction_server_walk_dominating_cache_unproductive);
+
     /* If we couldn't find the number of pages we were looking for, skip the tree next time. */
     evict_walk_period = __wt_atomic_load_uint32_relaxed(&btree->evict_walk_period);
     if (pages_queued < target_pages / 2 && !urgent_queued)
-        __wt_atomic_store_uint32_relaxed(
-          &btree->evict_walk_period, WT_MIN(WT_MAX(1, 2 * evict_walk_period), 100));
+        __wt_atomic_store_uint32_relaxed(&btree->evict_walk_period,
+          WT_MIN(WT_MAX(1, 2 * evict_walk_period), WTI_EVICT_WALK_PERIOD_MAX));
     else if (pages_queued == target_pages) {
         __wt_atomic_store_uint32_relaxed(&btree->evict_walk_period, 0);
         /*

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -334,6 +334,7 @@ struct __wt_btree {
     u_int evict_walk_skips;                    /* Number of walks skipped */
     wt_shared int32_t evict_disabled;          /* Eviction disabled count */
     bool evict_disabled_open;                  /* Eviction disabled on open */
+    bool evict_walk_dominating;                /* Current walk overrode the walk period */
     wt_shared volatile uint32_t evict_busy;    /* Count of threads in eviction */
     wt_shared volatile uint32_t prefetch_busy; /* Count of threads in prefetch */
     WT_EVICT_WALK_TYPE evict_start_type;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -604,6 +604,8 @@ struct __wt_connection_stats {
     int64_t eviction_server_slept;
     int64_t eviction_slow;
     int64_t eviction_walk_leaf_notfound;
+    int64_t eviction_server_walk_dominating_cache;
+    int64_t eviction_server_walk_dominating_cache_unproductive;
     int64_t eviction_state;
     int64_t eviction_threshold_cache_full_target;
     int64_t eviction_threshold_cache_full_trigger;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6818,2278 +6818,2288 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_EVICTION_SLOW			1176
 /*! cache: eviction server waiting for a leaf page */
 #define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1177
+/*!
+ * cache: eviction server walks trees within their walk period because
+ * they dominate the cache
+ */
+#define	WT_STAT_CONN_EVICTION_SERVER_WALK_DOMINATING_CACHE	1178
+/*!
+ * cache: eviction server walks trees within their walk period because
+ * they dominate the cache but queues no pages
+ */
+#define	WT_STAT_CONN_EVICTION_SERVER_WALK_DOMINATING_CACHE_UNPRODUCTIVE	1179
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1178
+#define	WT_STAT_CONN_EVICTION_STATE			1180
 /*!
  * cache: eviction threshold cache full target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1179
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1181
 /*!
  * cache: eviction threshold cache full trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1180
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1182
 /*! cache: eviction threshold dirty target multiplied by 100 for precision */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1181
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1183
 /*!
  * cache: eviction threshold dirty trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1182
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1184
 /*!
  * cache: eviction threshold updates target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1183
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1185
 /*!
  * cache: eviction threshold updates trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1184
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1186
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1185
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1187
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1186
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1188
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1187
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1189
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1188
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1190
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1189
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1191
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1190
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1192
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1191
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1193
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1192
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1194
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1193
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1195
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1194
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1196
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1197
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1196
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1198
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1197
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1199
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1198
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1200
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1199
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1201
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1200
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1202
 /*! cache: eviction walk target strategy clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1201
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1203
 /*! cache: eviction walk target strategy dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1202
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1204
 /*! cache: eviction walk target strategy pages with updates */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1203
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1205
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1204
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1206
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1205
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1207
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1206
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1208
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1207
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1209
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1208
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1210
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1209
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1211
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1210
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1212
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1211
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1213
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1212
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1214
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1213
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1215
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1214
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1216
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1215
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1217
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1216
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1218
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1217
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1219
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1218
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1220
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1219
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1221
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1220
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1222
 /*!
  * cache: forced eviction - pages evicted belonging to ingest btrees
  * count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1221
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1223
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1222
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1224
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1223
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1225
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1224
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1226
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1225
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1227
 /*!
  * cache: forced eviction - pages selected belonging to ingest btrees
  * unable to be evicted count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1226
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1228
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1227
+#define	WT_STAT_CONN_EVICTION_FORCE			1229
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1228
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1230
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1229
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1231
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1230
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1232
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1231
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1233
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1232
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1234
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1233
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1235
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1234
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1236
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1235
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1237
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1236
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1238
 /*! cache: history store table key to be processed */
-#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1237
+#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1239
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1238
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1240
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1239
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1241
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1240
+#define	WT_STAT_CONN_CACHE_HS_READ			1242
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1241
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1243
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1242
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1244
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1243
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1245
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1244
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1246
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1245
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1247
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1246
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1248
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1247
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1249
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1248
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1250
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1249
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1251
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1250
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1252
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1251
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1253
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1252
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1254
 /*! cache: history store table update to be processed */
-#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1253
+#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1255
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1254
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1256
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1255
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1257
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1256
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1258
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1257
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1259
 /*! cache: in-memory page splits performed on ingest btree pages */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1258
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1260
 /*! cache: ingest pages evicted */
-#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1259
+#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1261
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1260
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1262
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1261
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1263
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1262
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1264
 /*! cache: internal pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1263
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1265
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1264
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1266
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1265
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1267
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1266
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1268
 /*! cache: leaf pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1267
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1269
 /*! cache: leaf pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_LEAF			1268
+#define	WT_STAT_CONN_CACHE_READ_LEAF			1270
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1269
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1271
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1270
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1272
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1271
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1273
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1272
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1274
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1273
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1275
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1274
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1276
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1275
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1277
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1276
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1278
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1277
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1279
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1278
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1280
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1279
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1281
 /*!
  * cache: maximum number of times a page tried to be added to eviction
  * queue but fail
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1280
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1282
 /*! cache: maximum number of times a page tried to be evicted */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1281
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1283
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1282
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1284
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1283
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1285
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1284
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1286
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1285
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1287
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1286
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1288
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1287
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1289
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1288
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1290
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1289
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1291
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1290
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1292
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1291
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1293
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1292
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1294
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1293
+#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1295
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1294
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1296
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1295
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1297
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1296
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1298
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1297
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1299
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1298
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1300
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1299
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1301
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1300
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1302
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1301
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1303
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1302
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1304
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1303
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1305
 /*! cache: pages already in queue when topping up */
-#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1304
+#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1306
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1305
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1307
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1306
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1308
 /*! cache: pages currently held in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1307
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1309
 /*! cache: pages currently held in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1308
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1310
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1309
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1311
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1310
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1312
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1311
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1313
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1312
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1314
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1313
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1315
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1314
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1316
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1315
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1317
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1316
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1318
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1317
+#define	WT_STAT_CONN_CACHE_READ				1319
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1318
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1320
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1319
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1321
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1320
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1322
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1321
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1323
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1322
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1324
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1323
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1325
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1324
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1326
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1325
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1327
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1326
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1328
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1327
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1329
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1328
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1330
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1329
+#define	WT_STAT_CONN_EVICTION_FAIL			1331
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1330
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1332
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1331
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1333
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1332
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1334
 /*!
  * cache: pages selected for eviction unable to be evicted belonging to
  * ingest btrees
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1333
+#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1335
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1334
+#define	WT_STAT_CONN_EVICTION_WALK			1336
 /*!
  * cache: pages with an unresolved multiblock split flagged by checkpoint
  * to be evicted soon
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1335
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1337
 /*!
  * cache: pages with an unresolved multiblock split re-reconciled by
  * checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1336
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1338
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1337
+#define	WT_STAT_CONN_CACHE_WRITE			1339
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1338
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1340
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1339
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1341
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1340
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1342
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1341
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1343
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1342
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1344
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1343
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1345
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1344
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1346
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1345
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1347
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1346
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1348
 /*! cache: shared disk bucket lock contention count */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1347
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1349
 /*! cache: shared disk bytes saved by sharing duplicate disk images */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1348
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1350
 /*! cache: shared disk hash table size */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1349
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1351
 /*! cache: shared disk hit */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1350
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1352
 /*! cache: shared disk miss */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1351
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1353
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1352
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1354
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1353
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1355
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1354
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1356
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1355
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1357
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1356
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1358
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1357
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1359
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1358
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1360
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1359
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1361
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1360
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1362
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1361
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1363
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1362
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1364
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1363
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1365
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1364
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1366
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1365
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1367
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1366
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1368
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1367
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1369
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1368
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1370
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1369
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1371
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1370
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1372
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1371
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1373
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1372
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1374
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1373
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1375
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1374
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1376
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1375
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1377
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1376
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1378
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1377
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1379
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1378
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1380
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1379
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1381
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1380
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1382
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1381
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1383
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1382
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1384
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1383
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1385
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1384
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1386
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1385
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1387
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1386
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1388
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1387
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1389
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1388
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1390
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1389
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1391
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1390
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1392
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1391
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1393
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1392
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1394
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1393
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1395
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1394
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1396
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1395
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1397
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1396
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1398
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1397
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1399
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1398
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1400
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1399
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1401
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1400
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1402
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1401
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1403
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1402
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1404
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1403
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1405
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1404
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1406
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1405
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1407
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1406
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1408
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1407
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1409
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1408
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1410
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1409
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1411
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1410
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1412
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1411
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1413
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1412
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1414
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1413
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1415
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1414
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1416
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1415
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1417
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1416
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1418
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1417
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1419
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1418
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1420
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1419
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1421
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1420
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1422
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1421
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1423
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1422
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1424
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1423
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1425
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1424
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1426
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1425
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1427
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1426
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1428
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1427
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1429
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1428
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1430
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1429
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1431
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1430
+#define	WT_STAT_CONN_CHECKPOINTS_API			1432
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1431
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1433
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1432
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1434
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1433
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1435
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1434
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1436
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1435
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1437
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1436
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1438
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1437
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1439
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1438
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1440
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1439
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1441
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1440
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1442
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1441
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1443
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1442
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1444
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1443
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1445
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1444
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1446
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1445
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1447
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1446
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1448
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1447
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1449
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1448
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1450
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1449
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1451
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1450
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1452
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1451
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1453
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1452
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1454
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1453
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1455
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1454
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1456
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1455
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1457
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1456
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1458
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1457
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1459
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1458
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1460
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1459
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1461
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1460
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1462
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1461
+#define	WT_STAT_CONN_BTREE_OPEN				1463
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1462
+#define	WT_STAT_CONN_TIME_TRAVEL			1464
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1463
+#define	WT_STAT_CONN_FILE_OPEN				1465
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1464
+#define	WT_STAT_CONN_BUCKETS_DH				1466
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1465
+#define	WT_STAT_CONN_BUCKETS				1467
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1466
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1468
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1467
+#define	WT_STAT_CONN_MEMORY_FREE			1469
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1468
+#define	WT_STAT_CONN_MEMORY_GROW			1470
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1469
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1471
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1470
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1472
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1471
+#define	WT_STAT_CONN_COND_WAIT				1473
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1472
+#define	WT_STAT_CONN_RWLOCK_READ			1474
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1473
+#define	WT_STAT_CONN_RWLOCK_WRITE			1475
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1474
+#define	WT_STAT_CONN_FSYNC_IO				1476
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1475
+#define	WT_STAT_CONN_READ_IO				1477
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1476
+#define	WT_STAT_CONN_WRITE_IO				1478
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1477
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1479
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1478
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1480
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1479
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1481
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1480
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1482
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1481
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1483
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1482
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1484
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1483
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1485
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1484
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1486
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1485
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1487
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1486
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1488
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1487
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1489
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1488
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1490
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1489
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1491
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1490
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1492
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1491
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1493
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1492
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1494
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1493
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1495
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1494
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1496
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1495
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1497
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1496
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1498
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1497
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1499
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1498
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1500
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1499
+#define	WT_STAT_CONN_CURSOR_CACHE			1501
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1500
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1502
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1501
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1503
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1502
+#define	WT_STAT_CONN_CURSOR_CREATE			1504
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1503
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1505
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1504
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1506
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1505
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1507
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1506
+#define	WT_STAT_CONN_CURSOR_INSERT			1508
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1507
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1509
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1508
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1510
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1509
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1511
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1510
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1512
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1511
+#define	WT_STAT_CONN_CURSOR_MODIFY			1513
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1512
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1514
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1513
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1515
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1514
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1516
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1515
+#define	WT_STAT_CONN_CURSOR_NEXT			1517
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1516
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1518
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1517
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1519
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1518
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1520
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1519
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1521
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1520
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1522
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1521
+#define	WT_STAT_CONN_CURSOR_RESTART			1523
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1522
+#define	WT_STAT_CONN_CURSOR_PREV			1524
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1523
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1525
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1524
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1526
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1525
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1527
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1526
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1528
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1527
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1529
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1528
+#define	WT_STAT_CONN_CURSOR_REMOVE			1530
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1529
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1531
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1530
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1532
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1531
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1533
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1532
+#define	WT_STAT_CONN_CURSOR_RESERVE			1534
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1533
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1535
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1534
+#define	WT_STAT_CONN_CURSOR_RESET			1536
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1535
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1537
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1536
+#define	WT_STAT_CONN_CURSOR_SEARCH			1538
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1537
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1539
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1538
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1540
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1539
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1541
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1540
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1542
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1541
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1543
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1542
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1544
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1543
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1545
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1544
+#define	WT_STAT_CONN_CURSOR_SWEEP			1546
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1545
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1547
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1546
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1548
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1547
+#define	WT_STAT_CONN_CURSOR_UPDATE			1549
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1548
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1550
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1549
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1551
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1550
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1552
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1551
+#define	WT_STAT_CONN_CURSOR_REOPEN			1553
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1552
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1554
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1553
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1555
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1554
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1556
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1555
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1557
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1556
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1558
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1557
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1559
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1558
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1560
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1559
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1561
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1560
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1562
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1561
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1563
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1562
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1564
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1563
+#define	WT_STAT_CONN_DH_SWEEP_REF			1565
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1564
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1566
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1565
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1567
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1566
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1568
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1567
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1569
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1568
+#define	WT_STAT_CONN_DH_SWEEPS				1570
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1569
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1571
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1570
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1572
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1571
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1573
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1572
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1574
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1573
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1575
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1574
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1576
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1575
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1577
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1576
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1578
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1577
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1579
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1578
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1580
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1579
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1581
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1580
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1582
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1581
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1583
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1582
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1584
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1583
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1585
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1584
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1586
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1585
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1587
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1586
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1588
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1587
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1589
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1588
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1590
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1589
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1591
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1590
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1592
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1591
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1593
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1592
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1594
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1593
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1595
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1594
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1596
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1595
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1597
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1596
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1598
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1597
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1599
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1598
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1600
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1599
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1601
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1600
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1602
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a non-tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1601
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1603
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1602
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1604
 /*!
  * layered: Layered table stable values equal to the tombstone byte
  * sequence
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1603
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1605
 /*! layered: Layered table stable values equal to three tombstone bytes */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1604
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1606
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1605
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1607
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1606
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1608
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1607
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1609
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1608
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1610
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1609
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1611
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1610
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1612
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1611
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1613
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1612
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1614
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1613
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1615
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1614
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1616
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1615
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1617
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1616
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1618
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1617
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1619
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1618
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1620
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1619
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1621
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1620
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1622
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1621
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1623
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1622
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1624
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1623
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1625
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1624
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1626
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1625
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1627
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1626
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1628
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1627
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1629
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1628
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1630
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1629
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1631
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1630
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1632
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1631
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1633
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1632
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1634
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1633
+#define	WT_STAT_CONN_READ_LOAD				1635
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1634
+#define	WT_STAT_CONN_WRITE_LOAD				1636
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1635
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1637
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1636
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1638
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1637
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1639
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1638
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1640
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1639
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1641
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1640
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1642
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1641
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1643
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1642
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1644
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1643
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1645
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1644
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1646
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1645
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1647
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1646
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1648
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1647
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1649
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1648
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1650
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1649
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1651
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1650
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1652
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1651
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1653
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1652
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1654
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1653
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1655
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1654
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1656
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1655
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1657
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1656
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1658
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1657
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1659
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1658
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1660
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1659
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1661
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1660
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1662
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1661
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1663
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1662
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1664
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1663
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1665
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1664
+#define	WT_STAT_CONN_LOG_FLUSH				1666
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1665
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1667
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1666
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1668
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1667
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1669
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1668
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1670
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1669
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1671
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1670
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1672
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1671
+#define	WT_STAT_CONN_LOG_SCANS				1673
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1672
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1674
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1673
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1675
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1674
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1676
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1675
+#define	WT_STAT_CONN_LOG_SYNC				1677
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1676
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1678
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1677
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1679
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1678
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1680
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1679
+#define	WT_STAT_CONN_LOG_WRITES				1681
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1680
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1682
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1681
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1683
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1682
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1684
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1683
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1685
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1684
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1686
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1685
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1687
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1686
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1688
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1687
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1689
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1688
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1690
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1689
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1691
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1690
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1692
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1691
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1693
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1692
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1694
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1693
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1695
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1694
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1696
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1695
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1697
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1696
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1698
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1697
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1699
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1698
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1700
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1699
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1701
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1700
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1702
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1701
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1703
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1702
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1704
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1703
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1705
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1704
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1706
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1705
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1707
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1706
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1708
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1707
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1709
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1708
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1710
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1709
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1711
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1710
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1712
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1711
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1713
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1712
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1714
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1713
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1715
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1714
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1716
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1715
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1717
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1716
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1718
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1717
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1719
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1718
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1720
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1719
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1721
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1720
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1722
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1721
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1723
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1722
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1724
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1723
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1725
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1724
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1726
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1725
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1727
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1726
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1728
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1727
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1729
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1728
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1730
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1729
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1731
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1730
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1732
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1731
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1733
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1732
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1734
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1733
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1735
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1734
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1736
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1735
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1737
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1736
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1738
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1737
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1739
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1738
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1740
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1739
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1741
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1740
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1742
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1741
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1743
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1742
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1744
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1743
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1745
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1744
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1746
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1745
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1747
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1746
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1748
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1747
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1749
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1748
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1750
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1749
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1751
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1750
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1752
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1751
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1753
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1752
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1754
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1753
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1755
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1754
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1756
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1755
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1757
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1756
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1758
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1757
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1759
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1758
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1760
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1759
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1761
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1760
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1762
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1761
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1763
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1762
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1764
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1763
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1765
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1764
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1766
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1765
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1767
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1766
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1768
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1767
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1769
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1768
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1770
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1769
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1771
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1770
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1772
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1771
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1773
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1772
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1774
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1773
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1775
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1774
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1776
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1775
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1777
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1776
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1778
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1777
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1779
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1778
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1780
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1779
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1781
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1780
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1782
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1781
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1783
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1782
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1784
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1783
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1785
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1784
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1786
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1785
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1787
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1786
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1788
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1787
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1789
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1788
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1790
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1789
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1791
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1790
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1792
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1791
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1793
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1792
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1794
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1793
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1795
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1794
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1796
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1795
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1797
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1796
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1798
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1797
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1799
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1798
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1800
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1799
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1801
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1800
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1802
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1801
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1803
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1802
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1804
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1803
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1805
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1804
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1806
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1805
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1807
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1806
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1808
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1807
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1809
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1808
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1810
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1809
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1811
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1810
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1812
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1811
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1813
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1812
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1814
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1813
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1815
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1814
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1816
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1815
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1817
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1816
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1818
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1817
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1819
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1818
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1820
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1819
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1821
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1820
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1822
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1821
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1823
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1822
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1824
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1823
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1825
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1824
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1826
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1825
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1827
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1826
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1828
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1827
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1829
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1828
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1830
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1829
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1831
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1830
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1832
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1831
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1833
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1832
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1834
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1833
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1835
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1834
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1836
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1835
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1837
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1836
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1838
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1837
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1839
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1838
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1840
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1839
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1841
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1840
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1842
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1841
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1843
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1842
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1844
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1843
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1845
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1844
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1846
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1845
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1847
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1846
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1848
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1847
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1849
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1848
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1850
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1849
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1851
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1850
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1852
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1851
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1853
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1852
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1854
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1853
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1855
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1854
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1856
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1855
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1857
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1856
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1858
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1857
+#define	WT_STAT_CONN_REC_PAGES				1859
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1858
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1860
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1859
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1861
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1860
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1862
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1861
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1863
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1862
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1864
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1863
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1865
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1864
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1866
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1865
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1867
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1866
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1868
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1867
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1869
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1868
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1870
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1869
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1871
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1870
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1872
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1871
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1873
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1872
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1874
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1873
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1875
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1874
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1876
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1875
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1877
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1876
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1878
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1877
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1879
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1878
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1880
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1879
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1881
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1880
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1882
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1881
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1883
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1882
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1884
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1883
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1885
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1884
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1886
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1885
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1887
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1886
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1888
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1887
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1889
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1888
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1890
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1889
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1891
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1890
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1892
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1891
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1893
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1892
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1894
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1893
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1895
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1894
+#define	WT_STAT_CONN_SESSION_OPEN			1896
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1895
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1897
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1896
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1898
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1897
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1899
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1898
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1900
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1899
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1901
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1900
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1902
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1901
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1903
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1902
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1904
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1903
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1905
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1904
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1906
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1905
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1907
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1906
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1908
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1907
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1909
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1908
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1910
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1909
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1911
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1910
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1912
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1911
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1913
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1912
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1914
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1913
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1915
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1914
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1916
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1915
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1917
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1916
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1918
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1917
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1919
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1918
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1920
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1919
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1921
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1920
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1922
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1921
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1923
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1922
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1924
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1923
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1925
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1924
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1926
 /*! session: table verify number of keys checked against the history store */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1925
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1927
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1926
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1928
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1927
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1929
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1928
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1930
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1929
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1931
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1930
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1932
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1931
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1933
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1932
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1934
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1933
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1935
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1934
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1936
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1935
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1937
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1936
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1938
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1937
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1939
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1938
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1940
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1939
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1941
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1940
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1942
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1941
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1943
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1942
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1944
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1943
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1945
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1944
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1946
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1945
+#define	WT_STAT_CONN_PAGE_SLEEP				1947
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1946
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1948
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1947
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1949
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1948
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1950
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1949
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1951
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1950
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1952
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1951
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1953
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1952
+#define	WT_STAT_CONN_FLUSH_TIER				1954
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1953
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1955
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1954
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1956
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1955
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1957
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1956
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1958
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1957
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1959
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1958
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1960
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1959
+#define	WT_STAT_CONN_TIERED_RETENTION			1961
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1960
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1962
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1961
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1963
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1962
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1964
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1963
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1965
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1964
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1966
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1965
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1967
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1966
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1968
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1967
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1969
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1968
+#define	WT_STAT_CONN_TXN_PREPARE			1970
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1969
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1971
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1970
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1972
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1971
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1973
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1972
+#define	WT_STAT_CONN_TXN_QUERY_TS			1974
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1973
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1975
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1974
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1976
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1975
+#define	WT_STAT_CONN_TXN_RTS				1977
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1976
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1978
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1977
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1979
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1978
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1980
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1979
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1981
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1980
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1982
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1981
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1983
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1982
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1984
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1983
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1985
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1984
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1986
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1985
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1987
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1986
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1988
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1987
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1989
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1988
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1990
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1989
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1991
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1990
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1992
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1991
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1993
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1992
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1994
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1993
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1995
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1994
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1996
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1995
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1997
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1996
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1998
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1997
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1999
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1998
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2000
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1999
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2001
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				2000
+#define	WT_STAT_CONN_TXN_SET_TS				2002
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2001
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2003
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2002
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2004
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2003
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2005
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2004
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2006
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2005
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2007
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2006
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2008
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2007
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2009
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2008
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2010
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2009
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2011
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2010
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2012
 /*! transaction: set timestamp step down updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STEP_DOWN_UPD		2011
+#define	WT_STAT_CONN_TXN_SET_TS_STEP_DOWN_UPD		2013
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				2012
+#define	WT_STAT_CONN_TXN_BEGIN				2014
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2013
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2015
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2014
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2016
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2015
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2017
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2016
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2018
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2017
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2019
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2018
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2020
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2019
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2021
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2020
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2022
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2021
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2023
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2022
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2024
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2023
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2025
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2024
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2026
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2025
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2027
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2026
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2028
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2027
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2029
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2028
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2030
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2029
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2031
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2030
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2032
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2031
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2033
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2032
+#define	WT_STAT_CONN_TXN_COMMIT				2034
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2033
+#define	WT_STAT_CONN_TXN_ROLLBACK			2035
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2034
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2036
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2116,6 +2116,9 @@ static const char *const __stats_connection_desc[] = {
   "cache: eviction server slept, because we did not make progress with eviction",
   "cache: eviction server unable to reach eviction goal",
   "cache: eviction server waiting for a leaf page",
+  "cache: eviction server walks trees within their walk period because they dominate the cache",
+  "cache: eviction server walks trees within their walk period because they dominate the cache but "
+  "queues no pages",
   "cache: eviction state",
   "cache: eviction threshold cache full target multiplied by 100 for precision",
   "cache: eviction threshold cache full trigger multiplied by 100 for precision",
@@ -3225,6 +3228,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->eviction_server_slept = 0;
     stats->eviction_slow = 0;
     stats->eviction_walk_leaf_notfound = 0;
+    stats->eviction_server_walk_dominating_cache = 0;
+    stats->eviction_server_walk_dominating_cache_unproductive = 0;
     /* not clearing eviction_state */
     stats->eviction_threshold_cache_full_target = 0;
     stats->eviction_threshold_cache_full_trigger = 0;
@@ -4341,6 +4346,10 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->eviction_server_slept += WT_STAT_CONN_READ(from, eviction_server_slept);
     to->eviction_slow += WT_STAT_CONN_READ(from, eviction_slow);
     to->eviction_walk_leaf_notfound += WT_STAT_CONN_READ(from, eviction_walk_leaf_notfound);
+    to->eviction_server_walk_dominating_cache +=
+      WT_STAT_CONN_READ(from, eviction_server_walk_dominating_cache);
+    to->eviction_server_walk_dominating_cache_unproductive +=
+      WT_STAT_CONN_READ(from, eviction_server_walk_dominating_cache_unproductive);
     to->eviction_state += WT_STAT_CONN_READ(from, eviction_state);
     to->eviction_threshold_cache_full_target +=
       WT_STAT_CONN_READ(from, eviction_threshold_cache_full_target);

--- a/test/suite/test_eviction06.py
+++ b/test/suite/test_eviction06.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger
+import wttest
+
+
+@wttest.skip_for_hook("disagg", "Layout and eviction targets differ under disaggregated storage.")
+@wttest.skip_for_hook("tiered", "Layout and eviction targets differ under tiered storage.")
+class test_eviction06(wttest.WiredTigerTestCase):
+    conn_config = (
+        'cache_size=10MB,statistics=(all),eviction=(threads_min=1,threads_max=1),'
+        'eviction_updates_trigger=20,eviction_updates_target=10,'
+        'eviction_dirty_trigger=95,eviction_dirty_target=90')
+    uri = 'table:eviction06'
+    nrows = 20000
+
+    def dominating_walks(self):
+        return self.get_stat(wiredtiger.stat.conn.eviction_server_walk_dominating_cache)
+
+    def test_walk_dominating_tree(self):
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        value = 'a' * 1024
+        for i in range(self.nrows):
+            cursor[i] = value
+        cursor.close()
+
+        # Only count walks driven by this tree's own cache footprint.
+        baseline = self.dominating_walks()
+
+        # Keep updating in place so the tree dominates the cache in the updates dimension. The dirty
+        # targets are set high so that eviction is working on updates rather than dirty content.
+        # Sample the statistics as we go: once the eviction server is idle they stop advancing, so
+        # waiting until after the workload would leave nothing to observe.
+        for _ in range(10):
+            for start in range(0, self.nrows, 1000):
+                cursor = self.session.open_cursor(self.uri)
+                self.session.begin_transaction()
+                for i in range(start, start + 1000, 2):
+                    cursor[i] = value
+                self.session.commit_transaction()
+                cursor.close()
+            if self.dominating_walks() > baseline:
+                break
+
+        # The statistic is only incremented from inside the walk-period check, so growth here is
+        # also evidence that the period was throttling the tree at the time.
+        self.assertStatGreaterSoon(
+            wiredtiger.stat.conn.eviction_server_walk_dominating_cache, baseline, timeout=5)
+
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Eviction can bench a tree after unproductive walks even when that tree becomes the dominant source of clean or update cache pressure. This change keeps the walk-period heuristic dimension-aware, walks dominant clean/update trees despite the skip period, and resets walk tracking whenever the eviction goal changes for all connection types. A workload regression test verifies the dominant update-tree walk path.

Backport of #14298 (commit 5ad9d39adf40914c3dbbe5f94fe81cb62399d933) to 9.0 for BACKPORT-29452. The cherry-pick was clean apart from the generated statistics numbering in `wiredtiger.h.in`, which was regenerated on the 9.0 base.
