### PR TITLE
WT-18405 Do not drop a table on the follower with uncheckpointed data

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -358,6 +358,43 @@ __wti_conn_dhandle_outdated(WT_SESSION_IMPL *session, const char *uri)
 }
 
 /*
+ * __conn_dhandle_refuse_uncovered_ingest --
+ *     Refuse to close an ingest btree holding writes no checkpoint covers: the tree is in memory,
+ *     so the close would discard the only copy.
+ */
+static int
+__conn_dhandle_refuse_uncovered_ingest(WT_SESSION_IMPL *session, WT_BTREE *btree)
+{
+    /* The discard this guards runs in the same critical section. */
+    WT_ASSERT_SPINLOCK_OWNED(session, &session->dhandle->close_lock);
+
+    /* An ingest tree is the only one a close discards rather than checkpoints. */
+    if (!WT_URI_IS_INGEST(btree->dhandle->name))
+        return (0);
+
+    /*
+     * Return EBUSY if the table has committed writes newer than the newest checkpoint. Suppose a
+     * follower drops such a table and later steps up. The drop's schema epoch can be above a
+     * checkpoint's epoch. Such a checkpoint must still include the table, with every write from
+     * before the drop. Those writes exist only in this ingest tree. Once the tree is closed they
+     * are gone, and that checkpoint cannot be written. So refuse the close until a checkpoint has
+     * covered the writes.
+     *
+     * An alternative design: allow the drop, and at step-up verify that every drop is published and
+     * the stable schema epoch is at or above all of them.
+     *
+     * Compare against the disagg checkpoint: a local one persists nothing of an in-memory tree.
+     */
+    if (__wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts) >
+      __wt_atomic_load_uint64_acquire(
+        &S2C(session)->disaggregated_storage.last_checkpoint_timestamp))
+        WT_RET_SUB(session, EBUSY, WT_DIRTY_DATA,
+          "the table has ingested data that no checkpoint covers and cannot be closed yet");
+
+    return (0);
+}
+
+/*
  * __wt_conn_dhandle_close --
  *     Sync and close the underlying btree handle.
  */
@@ -447,6 +484,10 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
          */
         if (F_ISSET(dhandle, WT_DHANDLE_DEAD))
             discard = true;
+
+        /* Before the mark-dead decision, so a forced drop cannot bypass it. */
+        if (!discard && !final)
+            WT_ERR(__conn_dhandle_refuse_uncovered_ingest(session, btree));
 
         /*
          * Mark the handle dead (letting the tree be discarded later) if it's not already marked

--- a/test/suite/test_layered_async_stepdown04.py
+++ b/test/suite/test_layered_async_stepdown04.py
@@ -26,6 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import errno
 import wiredtiger, wttest
 from wiredtiger import stat
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -106,6 +107,38 @@ class test_layered_async_stepdown04(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.complete_step_down(20)
         self.assertRaisesException(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor(self.uri, None, None))
+
+    # A drop during a planned step-down is refused while the ingest constituent holds committed
+    # writes no checkpoint covers, even though the connection is still the leader: writes that
+    # began after the step-down timestamp route to ingest, and dropping the table would discard
+    # their only copy.
+    def test_drop_refused_for_stepdown_ingest_data(self):
+        self.set_global_ts(1, 1)
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.write_at(self.uri, {'k1': 'stable'}, 10)
+
+        # Checkpoint covering the stable write, so that only the post-cutoff ingest write is
+        # unaccounted for.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        ckpt_session = self.conn.open_session()
+        ckpt_session.checkpoint()
+        ckpt_session.close()
+
+        self.set_step_down_ts(20)
+        self.write_at(self.uri, {'k2': 'ingest'}, 30)
+        self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), {'k2'})
+
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(self.uri))
+        err, sub, msg = self.session.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
+        self.assertTrue('no checkpoint covers' in msg)
+
+        # The refused drop left no partial state.
+        self.assertEqual(self.read_keys_at(self.uri, 40), {'k1', 'k2'})
+        self.complete_step_down(20)
+        self.assertEqual(self.read_keys_at(self.uri, 40), {'k1', 'k2'})
 
     # A cursor reused from the cache picks up the new routing: its writes go to ingest.
     def test_cached_cursor_reuse_across_step_down_ts(self):

--- a/test/suite/test_layered_async_stepdown08.py
+++ b/test/suite/test_layered_async_stepdown08.py
@@ -361,11 +361,14 @@ class test_layered_async_stepdown08(
     def test_window_create_then_drop(self):
         """
         A table created and dropped entirely inside the window never existed for any checkpoint, so
-        the queued create and remove cancel out instead of tripping the violation check.
+        the queued create and remove cancel out instead of tripping the violation check. It holds no
+        data: window writes reach the ingest constituent, which no checkpoint of this phase covers,
+        so a populated table stays undroppable until one is picked up.
         """
         self.enter_window()
 
-        uri, _ = self.create_with_rows('window_drop', 6)
+        uri = self.uri('window_drop')
+        self.session.create(uri, self.table_config)
         self.publish_if_epochs(uri, 20)
         self.dropUntilSuccess(self.session, uri)
         self.publish_if_epochs(uri, 20)

--- a/test/suite/test_layered_async_stepdown10.py
+++ b/test/suite/test_layered_async_stepdown10.py
@@ -90,6 +90,7 @@ class test_layered_async_stepdown10(
         self.tables = {}
         self.seed_uris = set()
         self.drops_to_verify = set()
+        self.refused_drops = set()
         self.op_counts = collections.Counter()
         self.workload_errors = []
         self.step_down_ts = None
@@ -185,6 +186,7 @@ class test_layered_async_stepdown10(
                 (wiredtiger.WT_DIRTY_DATA, wiredtiger.WT_CONFLICT_DHANDLE,
                  wiredtiger.WT_CONFLICT_TABLE_LOCK), f'drop of {uri}')
             self.op_counts['busy_drops'] += 1
+            self.refused_drops.add(uri)
             return
         info = self.tables.pop(uri)
         if self.drop_removal_is_guaranteed():
@@ -407,7 +409,12 @@ class test_layered_async_stepdown10(
     def verify_step_down_checkpoint(self):
         conn_follow, session_follow = self.open_follower()
         for uri, info in self.tables.items():
-            in_checkpoint = not info['window'] and (not self.use_epochs or uri in self.seed_uris)
+            # A refused drop leaves the table live, so the checkpoint may still carry it;
+            # whether it does depends on where its create landed against the boundary.
+            in_checkpoint = not info['window'] and (
+                not self.use_epochs or uri in self.seed_uris
+                or (uri in self.refused_drops
+                    and self.uri_in_shared_metadata(conn_follow, uri)))
             if in_checkpoint:
                 self.assertEqual(
                     self.read_kvs_at(uri, self.step_down_ts, session=session_follow),

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -28,7 +28,8 @@
 
 # Dropping a published but uncheckpointed layered table would discard the only copy of its
 # committed data, since the published CREATE obligates a covering checkpoint to include that
-# data. The drop must be refused until a checkpoint publishes the table.
+# data. The drop must be refused until a checkpoint publishes the table. The same holds for
+# ingest content a checkpoint has not covered, on a follower or in a leader's step-down window.
 
 import errno
 import wiredtiger, wttest
@@ -62,36 +63,49 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
 
-    def write_rows(self, commit_ts=None):
+    def write_rows(self, commit_ts=None, session=None, keys=None, value='value'):
         """Write nrows to the table, then commit at commit_ts or roll back if it is None."""
-        self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
-        for i in range(1, self.nrows + 1):
-            cursor[i] = 'value'
+        if session is None:
+            session = self.session
+        if keys is None:
+            keys = range(1, self.nrows + 1)
+        session.begin_transaction()
+        cursor = session.open_cursor(self.uri)
+        for i in keys:
+            cursor[i] = value
         cursor.close()
         if commit_ts is None:
-            self.session.rollback_transaction()
+            session.rollback_transaction()
         else:
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
-    def assert_all_rows(self, session):
+    def assert_all_rows(self, session, value='value'):
         """Assert that every written row is readable through the given session."""
         cursor = session.open_cursor(self.uri)
         count = 0
         while cursor.next() == 0:
-            self.assertEqual(cursor.get_value(), 'value')
+            self.assertEqual(cursor.get_value(), value)
             count += 1
         cursor.close()
         self.assertEqual(count, self.nrows)
 
-    def assert_drop_refused(self):
-        """Assert that dropping the table is refused with EBUSY / WT_DIRTY_DATA."""
+    def assert_drop_refused(self, expect='unpublished data', sub_err=None, session=None,
+            config=None):
+        """Assert that dropping the table is refused with EBUSY and the given sub-error."""
+        if sub_err is None:
+            sub_err = wiredtiger.WT_DIRTY_DATA
+        if session is None:
+            session = self.session
         self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: self.session.drop(self.uri))
-        err, sub, msg = self.session.get_last_error()
+            lambda: session.drop(self.uri, config))
+        err, sub, msg = session.get_last_error()
         self.assertEqual(err, errno.EBUSY)
-        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
-        self.assertTrue('unpublished data' in msg)
+        self.assertEqual(sub, sub_err)
+        self.assertTrue(expect in msg)
+
+    def assert_drop_refused_uncovered(self, session, config=None):
+        """Assert the drop is refused because no checkpoint covers the ingest content."""
+        self.assert_drop_refused('no checkpoint covers', None, session, config)
 
     def truncate_all_rows(self, commit_ts):
         """Truncate the whole key range at commit_ts."""
@@ -115,6 +129,44 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         """Drop the table and confirm it is gone from local metadata."""
         self.session.drop(self.uri)
         self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+    def count_rows(self, session):
+        """Return the number of rows readable through the given session."""
+        cursor = session.open_cursor(self.uri)
+        count = 0
+        while cursor.next() == 0:
+            count += 1
+        cursor.close()
+        return count
+
+    def publish_and_checkpoint_table(self):
+        """Create, publish and checkpoint the table on the leader."""
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.set_stable_epoch(1)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 5)
+        self.set_stable_epoch(10)
+        self.leader_checkpoint(1)
+
+    def publish_checkpoint_and_open_follower(self):
+        """Publish and checkpoint the table on the leader, then open a follower holding it."""
+        self.publish_and_checkpoint_table()
+        return self.open_follower()
+
+    def leader_write_and_checkpoint(self, commit_ts, keys=None):
+        """Write the same rows on the leader and checkpoint them, covering the follower's copy."""
+        self.write_rows(commit_ts=commit_ts, keys=keys)
+        self.leader_checkpoint(commit_ts)
+
+    def set_follower_stable(self, conn, stable_ts):
+        """Advance a follower's stable timestamp without delivering a checkpoint to it."""
+        conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable_ts))
+
+    def assert_follower_drop_succeeds(self, conn, session):
+        """Drop the table on a follower and confirm its ingest constituent is gone."""
+        session.drop(self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn, self.uri))
 
     #
     # Drop lifecycle tests
@@ -314,3 +366,226 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         session_follower.close()
         conn_follower.close()
         self.assert_drop_succeeds()
+
+    #
+    # Follower drop tests
+    #
+    # A follower's writes land in its in-memory ingest constituent, so the drop is bounded by the
+    # checkpoint the follower has picked up.
+    #
+
+    def test_drop_on_follower_with_uncheckpointed_data_is_refused(self):
+        # The follower's rows exist only in its ingest constituent until a checkpoint covers them.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.assert_drop_refused_uncovered(session_follower)
+
+        self.assert_all_rows(session_follower)
+        self.assertTrue(self.uri_in_local_metadata(conn_follower, self.uri))
+
+        # A picked-up checkpoint covering the same rows makes it a normal drop.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_before_pickup_is_refused(self):
+        # The bound is the checkpoint the follower picked up, not the newest the leader took.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.leader_write_and_checkpoint(3)
+        self.assert_drop_refused_uncovered(session_follower)
+
+        # The pickup is what makes the difference.
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_with_partially_covered_data_is_refused(self):
+        # Partial coverage leaves the rest as the only copy, so it must not unblock the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        early_keys = range(1, self.nrows // 2 + 1)
+        late_keys = range(self.nrows // 2 + 1, self.nrows + 1)
+        self.write_rows(commit_ts=3, session=session_follower, keys=early_keys)
+        self.write_rows(commit_ts=7, session=session_follower, keys=late_keys)
+
+        # The picked-up checkpoint covers the timestamp-3 rows but not the timestamp-7 rows.
+        self.leader_write_and_checkpoint(3, keys=early_keys)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_drop_refused_uncovered(session_follower)
+        self.assertEqual(self.count_rows(session_follower), self.nrows)
+
+        # Covering the timestamp-7 rows as well releases the drop.
+        self.leader_write_and_checkpoint(7, keys=late_keys)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_empty_on_follower_is_allowed(self):
+        # A follower that never wrote holds nothing to protect.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_rolled_back_on_follower_is_allowed(self):
+        # Rolled-back writes never reach a durable timestamp, so they leave nothing to protect.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=None, session=session_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_force_on_follower_with_uncheckpointed_data_is_refused(self):
+        # force only turns a missing table into a success; it does not weaken the guard.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.assert_drop_refused_uncovered(session_follower, 'force=true')
+        self.assert_all_rows(session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_leader_in_step_down_window_is_refused(self):
+        # Past the step-down boundary a leader's commits land in the ingest constituent, which the
+        # final step-down checkpoint cannot cover, so the same guard refuses the drop.
+        self.publish_and_checkpoint_table()
+
+        self.conn.set_timestamp('step_down_timestamp=' + self.timestamp_str(20) +
+            ',step_down_disaggregated_schema_epoch=' + self.timestamp_str(10))
+        self.write_rows(commit_ts=30)
+        self.assert_drop_refused_uncovered(self.session)
+
+        # The window writes stay readable. Layered reads need an explicit snapshot while the
+        # step-down boundary is set.
+        self.session.begin_transaction()
+        self.assert_all_rows(self.session)
+        self.session.rollback_transaction()
+        # The stable constituent is dropped before the ingest one, so its metadata removal must
+        # have unrolled: both constituents are back.
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri, leader=True))
+
+    def test_refused_drop_keeps_the_history_reads_depend_on(self):
+        # A refused drop must leave the table exactly as it was. The drop destroys the stable
+        # constituent before it reaches the ingest one that refuses, and the rows a snapshot below
+        # the newest checkpoint must see live only in the history store.
+        self.publish_and_checkpoint_table()
+        self.write_rows(commit_ts=10, value='old')
+        self.leader_checkpoint(10)
+        self.write_rows(commit_ts=20, value='new')
+        self.leader_checkpoint(20)
+
+        # Past the step-down boundary the commits land in the ingest constituent, which no
+        # checkpoint covers, so the drop is refused.
+        self.conn.set_timestamp('step_down_timestamp=' + self.timestamp_str(30) +
+            ',step_down_disaggregated_schema_epoch=' + self.timestamp_str(10))
+        self.write_rows(commit_ts=40, value='window')
+        self.assert_drop_refused_uncovered(self.session)
+
+        # Every snapshot still reads what it read before the drop was attempted.
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
+        self.assert_all_rows(self.session, value='old')
+        self.session.rollback_transaction()
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
+        self.assert_all_rows(self.session, value='new')
+        self.session.rollback_transaction()
+        self.session.begin_transaction()
+        self.assert_all_rows(self.session, value='window')
+        self.session.rollback_transaction()
+
+    def test_drop_on_follower_of_leader_only_data_is_allowed(self):
+        # Rows the follower only reads live in the picked-up checkpoint, not in its ingest tree.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_all_rows(session_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_ingest_constituent_directly_is_refused(self):
+        # The guard lives in the close path, so dropping the ingest constituent URI directly hits
+        # it too, not only a layered drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        ingest_uri = 'file:' + self.test_name + '.wt_ingest'
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: session_follower.drop(ingest_uri))
+        err, sub, msg = session_follower.get_last_error()
+        self.assertEqual(err, errno.EBUSY)
+        self.assertEqual(sub, wiredtiger.WT_DIRTY_DATA)
+        self.assertTrue('no checkpoint covers' in msg)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_waits_for_commit_then_requires_coverage(self):
+        # The two guards apply in order: an uncommitted write is refused as uncommitted data, and
+        # once committed it is refused as uncovered until a checkpoint accounts for it.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        session_a = conn_follower.open_session('')
+        session_a.begin_transaction()
+        cursor = session_a.open_cursor(self.uri)
+        for i in range(1, self.nrows + 1):
+            cursor[i] = 'value'
+        cursor.close()
+
+        # The uncommitted transaction blocks the drop even though its cursor is closed.
+        self.assert_drop_refused('uncommitted data', wiredtiger.WT_UNCOMMITTED_DATA,
+            session_follower)
+
+        session_a.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+        session_a.close()
+        self.assert_drop_refused_uncovered(session_follower)
+        self.assert_all_rows(session_follower)
+
+        # A covering picked-up checkpoint releases the drop.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    #
+    # Follower drop tests where only the stable timestamp advances
+    #
+    # The stable timestamp moves independently of checkpoint pickup, and must not shift the bound
+    # in either direction.
+    #
+
+    def test_drop_on_follower_after_stable_timestamp_only_is_refused(self):
+        # A stable timestamp past the writes says no checkpoint holds them, so it cannot unblock.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.set_follower_stable(conn_follower, 100)
+        self.assert_drop_refused_uncovered(session_follower)
+
+        self.assert_all_rows(session_follower)
+        self.assertTrue(self.uri_in_local_metadata(conn_follower, self.uri))
+
+        # The pickup still releases the drop, though the stable timestamp is well past the writes.
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_after_stable_timestamp_past_leader_checkpoint_is_refused(self):
+        # A covering checkpoint plus a caught-up stable timestamp must not substitute for pickup.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.write_rows(commit_ts=3, session=session_follower)
+        self.leader_write_and_checkpoint(3)
+        self.set_follower_stable(conn_follower, 3)
+        self.assert_drop_refused_uncovered(session_follower)
+
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_after_stable_timestamp_with_no_data_is_allowed(self):
+        # The reverse direction: a stable timestamp on an empty follower must not refuse the drop.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.set_follower_stable(conn_follower, 100)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)
+
+    def test_drop_on_follower_after_stable_timestamp_with_leader_only_data_is_allowed(self):
+        # Rows from a picked-up checkpoint stay covered when the stable timestamp passes them.
+        conn_follower, session_follower = self.publish_checkpoint_and_open_follower()
+        self.leader_write_and_checkpoint(3)
+        self.disagg_advance_checkpoint_and_wait(conn_follower)
+        self.set_follower_stable(conn_follower, 100)
+        self.assert_all_rows(session_follower)
+        self.assert_follower_drop_succeeds(conn_follower, session_follower)
+        self.close_follower(conn_follower, session_follower)

--- a/test/suite/test_layered_schema28.py
+++ b/test/suite/test_layered_schema28.py
@@ -39,12 +39,14 @@
 # create sits above the checkpoint's schema epoch, so this checkpoint predates the local
 # incarnation, and a later checkpoint that covers the create supplies the right constituent.
 
+import os
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema28(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+class test_layered_schema28(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin, suite_subprocess):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -121,3 +123,70 @@ class test_layered_schema28(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         cursor.close()
 
         self.close_follower(conn_follow, session_follow)
+
+    def subprocess_stable_data_above_pre_drop_schema_epoch(self):
+        """
+        Build a checkpoint whose stable schema epoch predates a drop while its stable
+        timestamp covers data written to the table recreated after that drop. The epoch
+        selects the first incarnation while the timestamp makes the second incarnation's
+        rows durable, so the checkpoint must not be written.
+        """
+        # First incarnation, published and checkpointed.
+        self.set_stable_epoch(1)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 10)
+        self.set_stable_epoch(10)
+        self.leader_checkpoint(10)
+
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'first'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
+        cursor.close()
+        self.leader_checkpoint(15)
+
+        # Drop and recreate at later epochs.
+        self.dropUntilSuccess(self.session, self.uri)
+        self.publish(self.uri, 20)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 30)
+
+        # Stable data written only to the second incarnation, whose create is still unstable.
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[2] = 'second'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor.close()
+
+        # A schema epoch below the drop paired with a stable timestamp above the second
+        # incarnation's writes.
+        self.set_stable_epoch(15)
+        self.leader_checkpoint(25)
+
+    def test_stable_data_above_pre_drop_schema_epoch(self):
+        """
+        A checkpoint may not pair a schema epoch from before a drop with a stable timestamp
+        that covers the recreated table's data.
+        """
+        # The checkpoint cannot be rolled back once it has refused the unpublished stable
+        # table, so WiredTiger panics rather than leaving the epoch and the timestamp
+        # disagreeing on which incarnation is durable. A panic takes the connection down, so run
+        # it apart.
+        #
+        # The subprocess works in its own home directory, so this connection stays open; it
+        # only needs a stable timestamp for the closing checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
+
+        subdir = 'SUBPROCESS_stable_data_above_pre_drop_schema_epoch'
+        func = (f'{self.test_name}.{self.test_name}.'
+                'subprocess_stable_data_above_pre_drop_schema_epoch')
+        returncode, home = self.run_subprocess_function(subdir, func, silent=True,
+            scenario=getattr(self, 'scenario_number', None))
+
+        # A panic drops core only in a diagnostic build, so require an abnormal exit rather than a
+        # signal.
+        self.assertNotEqual(returncode, 0)
+
+        with open(os.path.join(home, 'stderr.txt'), 'r') as f:
+            err = f.read()
+        self.assertIn('stable data checkpointed for unpublished table', err)


### PR DESCRIPTION
- Dirty ingest returns `EBUSY` if drop is attempted,
- Fix tests to accommodate new behaviour.