### PR TITLE
WT-18543 Move the checkpoint pickup btree id validation into file metadata update

### DIFF
--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -15,6 +15,8 @@ static int __disagg_check_meta_fields(
 
 static int __disagg_adopt_deferred_checkpoint_meta(WT_SESSION_IMPL *, const char *, size_t);
 
+#define WT_DISAGG_URI_IS_SYSTEM(uri) (WT_IS_URI_METADATA(uri) || WT_IS_URI_HS(uri))
+
 /*
  * __layered_create_missing_ingest_table --
  *     Create a missing ingest table from an existing layered table configuration.
@@ -576,30 +578,6 @@ err:
     __wt_free(session, sh_merge);
     return (ret);
 }
-#else
-/*
- * __disagg_check_meta_id --
- *     Compare the btree id of a file entry between the local and the shared metadata, panicking
- *     when they differ.
- */
-static int
-__disagg_check_meta_id(
-  WT_SESSION_IMPL *session, const char *uri, const char *md_value, const char *sh_value)
-{
-    WT_CONFIG_ITEM md_cval, sh_cval;
-
-    WT_RET(__wt_config_getones(session, sh_value, "id", &sh_cval));
-    WT_RET(__wt_config_getones(session, md_value, "id", &md_cval));
-
-    /* An id mismatch means the checkpoint would be read under the wrong btree identity. */
-    if (sh_cval.val != md_cval.val)
-        WT_RET_PANIC(session, EINVAL,
-          "checkpoint pickup metadata mismatch for \"%s\": the value of \"id\" differs between "
-          "the local (\"%.*s\") and the shared (\"%.*s\") metadata",
-          uri, (int)md_cval.len, md_cval.str, (int)sh_cval.len, sh_cval.str);
-    return (0);
-}
-#endif /* HAVE_DIAGNOSTIC */
 
 /*
  * __disagg_check_meta_match --
@@ -620,17 +598,8 @@ __disagg_check_meta_match(WT_SESSION_IMPL *session, WT_CURSOR *sh_cursor, WT_CUR
      * Skip system tables with fixed identities: their local entries are created on each node rather
      * than copied from the shared metadata, so their fields can legitimately differ.
      */
-    if (WT_IS_URI_METADATA(sh_key) || WT_IS_URI_HS(sh_key))
+    if (WT_DISAGG_URI_IS_SYSTEM(sh_key))
         return (0);
-
-    /*
-     * Non-diagnostic builds validate only the btree id of file entries; diagnostic builds compare
-     * every field of every entry.
-     */
-#ifndef HAVE_DIAGNOSTIC
-    if (!WT_PREFIX_MATCH(sh_key, "file:"))
-        return (0);
-#endif
 
     WT_RET(sh_cursor->get_value(sh_cursor, &sh_value));
     WT_RET(md_cursor->get_value(md_cursor, &md_value));
@@ -639,12 +608,9 @@ __disagg_check_meta_match(WT_SESSION_IMPL *session, WT_CURSOR *sh_cursor, WT_CUR
     if (strcmp(sh_value, md_value) == 0)
         return (0);
 
-#ifdef HAVE_DIAGNOSTIC
     return (__disagg_check_meta_all_fields(session, sh_key, md_value, sh_value));
-#else
-    return (__disagg_check_meta_id(session, sh_key, md_value, sh_value));
-#endif
 }
+#endif /* HAVE_DIAGNOSTIC */
 
 /*
  * The btree IDs of every stable file the local metadata will hold once this pickup has applied the
@@ -706,15 +672,51 @@ err:
 }
 
 /*
+ * __disagg_file_meta_fields --
+ *     Extract the checkpoint and id fields from a file's configuration in a single pass, stopping
+ *     as soon as both are found: stored metadata is collapsed, so keys are unique.
+ */
+static int
+__disagg_file_meta_fields(
+  WT_SESSION_IMPL *session, const char *value, WT_CONFIG_ITEM *ckpt, WT_CONFIG_ITEM *id)
+{
+    WT_CONFIG parser;
+    WT_CONFIG_ITEM ckey, cval;
+    WT_DECL_RET;
+    bool ckpt_found, id_found;
+
+    WT_CLEAR(*ckpt);
+    WT_CLEAR(*id);
+    ckpt_found = id_found = false;
+
+    __wt_config_init(session, &parser, value);
+    while ((ret = __wt_config_next(&parser, &ckey, &cval)) == 0) {
+        if (WT_CONFIG_LIT_MATCH("checkpoint", ckey)) {
+            *ckpt = cval;
+            ckpt_found = true;
+        } else if (WT_CONFIG_LIT_MATCH("id", ckey)) {
+            *id = cval;
+            id_found = true;
+        }
+        if (ckpt_found && id_found)
+            break;
+    }
+    WT_RET_NOTFOUND_OK(ret);
+
+    return (ckpt_found && id_found ? 0 : WT_NOTFOUND);
+}
+
+/*
  * __disagg_update_file_meta --
  *     Update an existing file: entry in the local metadata table with checkpoint information from
- *     the shared metadata, then mark stale data handles as outdated.
+ *     the shared metadata, then mark stale data handles as outdated. Panics when the btree id
+ *     differs between the local and the shared entry.
  */
 static int
 __disagg_update_file_meta(
   WT_SESSION_IMPL *session, WT_CURSOR *sh_file_cursor, WT_CURSOR *md_file_cursor)
 {
-    WT_CONFIG_ITEM cval, cval_cur;
+    WT_CONFIG_ITEM cval, cval_cur, md_id, sh_id;
     WT_DECL_ITEM(old_uri_buf);
     WT_DECL_RET;
     char *cfg_ret, *current_value_copy;
@@ -729,7 +731,7 @@ __disagg_update_file_meta(
     WT_ERR(__wt_scr_alloc(session, 0, &old_uri_buf));
     WT_ERR(sh_file_cursor->get_key(sh_file_cursor, &sh_file_key));
     WT_ERR(sh_file_cursor->get_value(sh_file_cursor, &metadata_value));
-    WT_ERR(__wt_config_getones(session, metadata_value, "checkpoint", &cval));
+    WT_ERR(__disagg_file_meta_fields(session, metadata_value, &cval, &sh_id));
 
     /* Check that the local metadata cursor is positioned at the same key. */
     WT_ERR(md_file_cursor->get_key(md_file_cursor, &md_file_key));
@@ -738,7 +740,18 @@ __disagg_update_file_meta(
     WT_ERR(md_file_cursor->get_value(md_file_cursor, &current_value));
     /* Copy before further cursor ops; also used as discard-check input. */
     WT_ERR(__wt_strdup(session, current_value, &current_value_copy));
-    WT_ERR(__wt_config_getones(session, current_value_copy, "checkpoint", &cval_cur));
+    WT_ERR(__disagg_file_meta_fields(session, current_value_copy, &cval_cur, &md_id));
+
+    /*
+     * An id mismatch means the checkpoint would be read under the wrong btree identity, except for
+     * system tables whose ids can legitimately differ between nodes.
+     */
+    if (sh_id.val != md_id.val && !WT_DISAGG_URI_IS_SYSTEM(sh_file_key))
+        WT_ERR_PANIC(session, EINVAL,
+          "checkpoint pickup metadata mismatch for \"%s\": the value of \"id\" differs between "
+          "the local (\"%.*s\") and the shared (\"%.*s\") metadata",
+          sh_file_key, (int)md_id.len, md_id.str, (int)sh_id.len, sh_id.str);
+
     /* Nothing to do if the local checkpoint already matches the shared one. */
     if (__wt_string_slice_cmp(cval_cur.str, cval_cur.len, cval.str, cval.len) == 0)
         goto err;
@@ -982,10 +995,11 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
             }
         }
 
-        /* Verify that the immutable metadata fields agree before adopting the new checkpoint. */
+#ifdef HAVE_DIAGNOSTIC
         for (i = 0; i < WT_DISAGG_CURSOR_COUNT; i++)
             if (md_has[i] && sh_has[i])
                 WT_ERR(__disagg_check_meta_match(session, sh_cursors[i], md_cursors[i]));
+#endif
 
         /*
          * Reconcile entries for this URI scheme and table.


### PR DESCRIPTION
[WT-14730](https://jira.mongodb.org/browse/WT-14730) added validation of immutable metadata fields on disagg checkpoint pickup. In non-diagnostic builds it validates the btree id of every file: entry present in both the local and the shared metadata, it compares the two configuration strings, and when they differ, extracts  id from each with a separate __wt_config_getones scan.

This caused [WT-18502](https://jira.mongodb.org/browse/WT-18502), a ~13% regression in disagg follower reconfigure pickup. When the leader has dirtied a table, its metadata entry always differs(new checkpoint), so the byte-compare fast path never helps and every dirtied entry pays two extra full config scans — work that duplicates the parsing  __disagg_update_file_meta does immediately afterwards, which already extracts the checkpoint field from both values.

This PR is to extract checkpoint and id from each metadata value in a single config walk inside  __disagg_update_file_meta to avoid the cost of __wt_config_getones scan.