### PR TITLE
WT-17810 compatibility_version.py: "this" branch incorrectly rejected due to if/else instead of if/elif

### DIFF
--- a/test/compatibility/common/compatibility_version.py
+++ b/test/compatibility/common/compatibility_version.py
@@ -47,7 +47,7 @@ class WTVersion:
         self.minor = 0
         if name == "this":
             self.group = 2
-        if name == "develop":
+        elif name == "develop":
             self.group = 1
         else:
             # Match patterns like mongodb-8.0, without prefix and suffix


### PR DESCRIPTION
Use elif for the "develop" check so the regex fallback and its is_valid = False no longer run for the "this" branch.