### PR TITLE
WT-17901 format-predictable-test: runs.ops=114599213 exceeds max 100000000, abort in config_single

### DIFF
--- a/test/format/config.sh
+++ b/test/format/config.sh
@@ -325,7 +325,7 @@ CONFIG configuration_list[] = {
 
 {"runs.mirror", "mirror tables", C_BOOL | C_IGNORE | C_TABLE, 0, 0, 0}
 
-{"runs.ops", "operations per run", 0x0, 0, M(2), M(100)}
+{"runs.ops", "operations per run", 0x0, 0, M(2), UINT_MAX}
 
 {"runs.predictable_replay", "configure predictable replay", C_BOOL, 0, 0, 0}
 

--- a/test/format/format_config_def.c
+++ b/test/format/format_config_def.c
@@ -347,7 +347,7 @@ CONFIG configuration_list[] = {{"assert.read_timestamp", "assert read_timestamp"
 
   {"runs.mirror", "mirror tables", C_BOOL | C_IGNORE | C_TABLE, 0, 0, 0, V_TABLE_RUNS_MIRROR},
 
-  {"runs.ops", "operations per run", 0x0, 0, M(2), M(100), V_GLOBAL_RUNS_OPS},
+  {"runs.ops", "operations per run", 0x0, 0, M(2), UINT_MAX, V_GLOBAL_RUNS_OPS},
 
   {"runs.predictable_replay", "configure predictable replay", C_BOOL, 0, 0, 0,
     V_GLOBAL_RUNS_PREDICTABLE_REPLAY},


### PR DESCRIPTION
Raise the explicit-set maximum to UINT_MAX, consistent with the other unbounded numeric options. The random default range is unchanged.