### PR TITLE
WT-17319 Provide more information when failing to pick up a checkpoint in disagg

### DIFF
--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1818,7 +1818,7 @@ __disagg_pick_up_checkpoint(
 
     /* Load crypt key data with the key provider extension, if any. */
     WT_ERR_MSG_CHK(session, __wti_disagg_load_crypt_key(session, &metadata),
-      "Failed to load the encryption key for checkpoint metadata_lsn=%" PRIu64,
+      "Failed to set up encryption keys for checkpoint metadata_lsn=%" PRIu64,
       ckpt_meta->metadata_lsn);
 
     /*

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1772,8 +1772,12 @@ __disagg_pick_up_checkpoint(
      * Part 1: Get the metadata of the shared metadata table.
      */
 
-    WT_ERR(__wti_disagg_fetch_shared_meta(session, ckpt_meta, &metadata_buf));
-    WT_ERR(__wt_disagg_parse_meta(session, &metadata_buf, &metadata));
+    WT_ERR_MSG_CHK(session, __wti_disagg_fetch_shared_meta(session, ckpt_meta, &metadata_buf),
+      "Failed to fetch the shared metadata for checkpoint metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
+    WT_ERR_MSG_CHK(session, __wt_disagg_parse_meta(session, &metadata_buf, &metadata),
+      "Failed to parse the shared metadata for checkpoint metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64 ", timestamp=%" PRIu64
@@ -1813,7 +1817,9 @@ __disagg_pick_up_checkpoint(
         conn->disaggregated_storage.base_write_gen_missing = true;
 
     /* Load crypt key data with the key provider extension, if any. */
-    WT_ERR(__wti_disagg_load_crypt_key(session, &metadata));
+    WT_ERR_MSG_CHK(session, __wti_disagg_load_crypt_key(session, &metadata),
+      "Failed to load the encryption key for checkpoint metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
 
     /*
      * Part 2: Merge the checkpoint's metadata into the local metadata. The merge runs under
@@ -1824,7 +1830,9 @@ __disagg_pick_up_checkpoint(
      */
     WT_WITH_SCHEMA_LOCK(
       session, ret = __disagg_adopt_checkpoint_meta(session, ckpt_meta, &metadata, is_startup));
-    WT_ERR(ret);
+    WT_ERR_MSG_CHK(session, ret,
+      "Failed to merge the metadata of checkpoint metadata_lsn=%" PRIu64 " into the local metadata",
+      ckpt_meta->metadata_lsn);
 
     /*
      * A no-epoch checkpoint clears the whole queue. An epoch-world node never picks up a no-epoch
@@ -1877,8 +1885,9 @@ err:
     } else {
         WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_failed);
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_ERROR,
-          "Failed to pick up disaggregated storage checkpoint for metadata_lsn=%" PRIu64 ": ret=%d",
-          ckpt_meta->metadata_lsn, ret);
+          "Failed to pick up disaggregated storage checkpoint for metadata_lsn=%" PRIu64
+          ": ret=%d (%s)",
+          ckpt_meta->metadata_lsn, ret, __wt_strerror(session, ret, NULL, 0));
     }
 
     __wt_buf_free(session, &metadata_buf);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1772,12 +1772,9 @@ __disagg_pick_up_checkpoint(
      * Part 1: Get the metadata of the shared metadata table.
      */
 
-    WT_ERR_MSG_CHK(session, __wti_disagg_fetch_shared_meta(session, ckpt_meta, &metadata_buf),
-      "Failed to fetch the shared metadata for checkpoint metadata_lsn=%" PRIu64,
-      ckpt_meta->metadata_lsn);
+    WT_ERR(__wti_disagg_fetch_shared_meta(session, ckpt_meta, &metadata_buf));
     WT_ERR_MSG_CHK(session, __wt_disagg_parse_meta(session, &metadata_buf, &metadata),
-      "Failed to parse the shared metadata for checkpoint metadata_lsn=%" PRIu64,
-      ckpt_meta->metadata_lsn);
+      "Failed to parse shared metadata for checkpoint %" PRIu64, ckpt_meta->metadata_lsn);
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64 ", timestamp=%" PRIu64
@@ -1818,8 +1815,7 @@ __disagg_pick_up_checkpoint(
 
     /* Load crypt key data with the key provider extension, if any. */
     WT_ERR_MSG_CHK(session, __wti_disagg_load_crypt_key(session, &metadata),
-      "Failed to set up encryption keys for checkpoint metadata_lsn=%" PRIu64,
-      ckpt_meta->metadata_lsn);
+      "Failed to load encryption keys for checkpoint %" PRIu64, ckpt_meta->metadata_lsn);
 
     /*
      * Part 2: Merge the checkpoint's metadata into the local metadata. The merge runs under
@@ -1830,8 +1826,7 @@ __disagg_pick_up_checkpoint(
      */
     WT_WITH_SCHEMA_LOCK(
       session, ret = __disagg_adopt_checkpoint_meta(session, ckpt_meta, &metadata, is_startup));
-    WT_ERR_MSG_CHK(session, ret,
-      "Failed to merge the metadata of checkpoint metadata_lsn=%" PRIu64 " into the local metadata",
+    WT_ERR_MSG_CHK(session, ret, "Failed to merge checkpoint %" PRIu64 " into local metadata",
       ckpt_meta->metadata_lsn);
 
     /*
@@ -1885,9 +1880,7 @@ err:
     } else {
         WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_failed);
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_ERROR,
-          "Failed to pick up disaggregated storage checkpoint for metadata_lsn=%" PRIu64
-          ": ret=%d (%s)",
-          ckpt_meta->metadata_lsn, ret, __wt_strerror(session, ret, NULL, 0));
+          "Failed to pick up checkpoint %" PRIu64, ckpt_meta->metadata_lsn);
     }
 
     __wt_buf_free(session, &metadata_buf);

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -259,19 +259,27 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
      * key provider decide about the appropriate key.
      */
     if (metadata->key_provider == NULL) {
-        WT_ERR(key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt));
+        WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
+          "Key provider failed to load a key for a checkpoint without persisted encryption key "
+          "data");
         return (0);
     }
 
     /* Parse crypt key metadata to get page ID and LSN. */
     uint64_t page_id, lsn;
-    WT_ERR(__wti_disagg_parse_crypt_meta(session, metadata, &page_id, &lsn));
+    WT_ERR_MSG_CHK(session, __wti_disagg_parse_crypt_meta(session, metadata, &page_id, &lsn),
+      "Failed to parse the key provider metadata: \"%.*s\"", (int)metadata->key_provider_len,
+      metadata->key_provider);
 
     /* Read the encryption key data from disaggregated storage. */
-    WT_ERR(__disagg_get_crypt_key(session, page_id, lsn, &key_item));
+    WT_ERR_MSG_CHK(session, __disagg_get_crypt_key(session, page_id, lsn, &key_item),
+      "Failed to read the encryption key data from disaggregated storage: page_id=%" PRIu64
+      ", lsn=%" PRIu64,
+      page_id, lsn);
 
     /* Validate the crypt data. */
-    WT_ERR(__disagg_validate_crypt(session, &key_item, &crypt_header));
+    WT_ERR_MSG_CHK(session, __disagg_validate_crypt(session, &key_item, &crypt_header),
+      "Invalid encryption key data: page_id=%" PRIu64 ", lsn=%" PRIu64, page_id, lsn);
 
     /* Prepare the crypt keys for loading. */
     crypt.keys.data = (uint8_t *)key_item.data + crypt_header->header_size;
@@ -283,7 +291,10 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
       "Loading persisted crypt key: lsn=%" PRIu64 ", timestamp=%" PRIu64, lsn, crypt.timestamp);
 
     /* Callback to load the encryption key data into the key provider. */
-    WT_ERR(key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt));
+    WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
+      "Key provider failed to load the persisted encryption key: lsn=%" PRIu64
+      ", timestamp=%" PRIu64,
+      lsn, crypt.timestamp);
 
     /* Prune the in-memory list on every checkpoint pickup. */
     __disagg_prune_pending_crypt_keys(session, crypt_header->timestamp);

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -260,26 +260,20 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
      */
     if (metadata->key_provider == NULL) {
         WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
-          "Key provider load_key callback failed when called without a persisted encryption key "
-          "record (the checkpoint metadata has none)");
+          "key provider: load-key: no persisted key in checkpoint");
         return (0);
     }
 
     /* Parse crypt key metadata to get page ID and LSN. */
     uint64_t page_id, lsn;
-    WT_ERR_MSG_CHK(session, __wti_disagg_parse_crypt_meta(session, metadata, &page_id, &lsn),
-      "Failed to parse the key provider metadata: \"%.*s\"", (int)metadata->key_provider_len,
-      metadata->key_provider);
+    WT_ERR(__wti_disagg_parse_crypt_meta(session, metadata, &page_id, &lsn));
 
     /* Read the encryption key data from disaggregated storage. */
     WT_ERR_MSG_CHK(session, __disagg_get_crypt_key(session, page_id, lsn, &key_item),
-      "Failed to read the persisted encryption key record from the key provider page log: "
-      "page_id=%" PRIu64 ", lsn=%" PRIu64,
-      page_id, lsn);
+      "key provider: page-read: page_id=%" PRIu64 ", lsn=%" PRIu64, page_id, lsn);
 
     /* Validate the crypt data. */
-    WT_ERR_MSG_CHK(session, __disagg_validate_crypt(session, &key_item, &crypt_header),
-      "Invalid encryption key data: page_id=%" PRIu64 ", lsn=%" PRIu64, page_id, lsn);
+    WT_ERR(__disagg_validate_crypt(session, &key_item, &crypt_header));
 
     /* Prepare the crypt keys for loading. */
     crypt.keys.data = (uint8_t *)key_item.data + crypt_header->header_size;
@@ -292,9 +286,7 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
 
     /* Callback to load the encryption key data into the key provider. */
     WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
-      "Key provider load_key callback failed for the persisted encryption key record: lsn=%" PRIu64
-      ", timestamp=%" PRIu64,
-      lsn, crypt.timestamp);
+      "key provider: load-key: lsn=%" PRIu64 ", timestamp=%" PRIu64, lsn, crypt.timestamp);
 
     /* Prune the in-memory list on every checkpoint pickup. */
     __disagg_prune_pending_crypt_keys(session, crypt_header->timestamp);

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -260,8 +260,7 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
      */
     if (metadata->key_provider == NULL) {
         WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
-          "Key provider failed to load a key for a checkpoint without persisted encryption key "
-          "data");
+          "Key provider failed to load a key with no persisted encryption key data");
         return (0);
     }
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -260,7 +260,8 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
      */
     if (metadata->key_provider == NULL) {
         WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
-          "Key provider failed to load a key with no persisted encryption key data");
+          "Key provider load_key callback failed when called without a persisted encryption key "
+          "record (the checkpoint metadata has none)");
         return (0);
     }
 
@@ -272,8 +273,8 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
 
     /* Read the encryption key data from disaggregated storage. */
     WT_ERR_MSG_CHK(session, __disagg_get_crypt_key(session, page_id, lsn, &key_item),
-      "Failed to read the encryption key data from disaggregated storage: page_id=%" PRIu64
-      ", lsn=%" PRIu64,
+      "Failed to read the persisted encryption key record from the key provider page log: "
+      "page_id=%" PRIu64 ", lsn=%" PRIu64,
       page_id, lsn);
 
     /* Validate the crypt data. */
@@ -291,7 +292,7 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
 
     /* Callback to load the encryption key data into the key provider. */
     WT_ERR_MSG_CHK(session, key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt),
-      "Key provider failed to load the persisted encryption key: lsn=%" PRIu64
+      "Key provider load_key callback failed for the persisted encryption key record: lsn=%" PRIu64
       ", timestamp=%" PRIu64,
       lsn, crypt.timestamp);
 


### PR DESCRIPTION
Each step of checkpoint pickup and encryption key loading now reports which step failed and with what identifiers, so a bare error code such as EINVAL from the key provider can be traced to its origin.