### PR TITLE
WT-18504 Preserve errors recorded on an internal schema session for get_last_error

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -24,29 +24,28 @@
     --(s)->api_call_counter
 
 /* Standard entry points to the API: declares/initializes local variables. */
-#define API_SESSION_INIT(s, struct_name, func_name, dh)                                \
-    WT_TRACK_OP_DECL;                                                                  \
-    API_SESSION_PUSH(s, struct_name, func_name, dh);                                   \
-    /*                                                                                 \
-     * No code before this line, otherwise error handling won't be                     \
-     * correct.                                                                        \
-     */                                                                                \
-    WT_ERR(WT_SESSION_CHECK_PANIC(s));                                                 \
-    __wt_single_thread_check_start(s);                                                 \
-    WT_TRACK_OP_INIT(s);                                                               \
-    /*                                                                                 \
-     * An internal session only saves errors on behalf of the application session that \
-     * spawned it, so its API calls neither reset nor record error information.        \
-     */                                                                                \
-    if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL)) {              \
-        __wt_op_timer_start(s);                                                        \
-        /* Clear any error left behind by the previous API call. */                    \
-        if ((s)->err_info.err != 0)                                                    \
-            __wt_session_reset_last_error((s));                                        \
-    }                                                                                  \
-    /* Reset wait time if this isn't an API reentry. */                                \
-    if ((s)->api_call_counter == 1)                                                    \
-        (s)->cache_wait_us = 0;                                                        \
+#define API_SESSION_INIT(s, struct_name, func_name, dh)                             \
+    WT_TRACK_OP_DECL;                                                               \
+    API_SESSION_PUSH(s, struct_name, func_name, dh);                                \
+    /*                                                                              \
+     * No code before this line, otherwise error handling won't be                  \
+     * correct.                                                                     \
+     */                                                                             \
+    WT_ERR(WT_SESSION_CHECK_PANIC(s));                                              \
+    __wt_single_thread_check_start(s);                                              \
+    WT_TRACK_OP_INIT(s);                                                            \
+    /*                                                                              \
+     * Internal sessions save errors only on behalf of the application session that \
+     * spawned them; leave error information to that session.                       \
+     */                                                                             \
+    if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL)) {           \
+        __wt_op_timer_start(s);                                                     \
+        if ((s)->err_info.err != 0)                                                 \
+            __wt_session_reset_last_error((s));                                     \
+    }                                                                               \
+    /* Reset wait time if this isn't an API reentry. */                             \
+    if ((s)->api_call_counter == 1)                                                 \
+        (s)->cache_wait_us = 0;                                                     \
     __wt_verbose((s), WT_VERB_API, "%s", "CALL: " #struct_name ":" #func_name)
 
 #define API_CALL_NOCONF_NOERRCLEAR(s, struct_name, func_name, dh, set_err) \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -24,26 +24,29 @@
     --(s)->api_call_counter
 
 /* Standard entry points to the API: declares/initializes local variables. */
-#define API_SESSION_INIT(s, struct_name, func_name, dh)                                  \
-    WT_TRACK_OP_DECL;                                                                    \
-    API_SESSION_PUSH(s, struct_name, func_name, dh);                                     \
-    /*                                                                                   \
-     * No code before this line, otherwise error handling won't be                       \
-     * correct.                                                                          \
-     */                                                                                  \
-    WT_ERR(WT_SESSION_CHECK_PANIC(s));                                                   \
-    __wt_single_thread_check_start(s);                                                   \
-    WT_TRACK_OP_INIT(s);                                                                 \
-    if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                  \
-        __wt_op_timer_start(s);                                                          \
-    /* Reset wait time if this isn't an API reentry. */                                  \
-    if ((s)->api_call_counter == 1)                                                      \
-        (s)->cache_wait_us = 0;                                                          \
-    /*                                                                                   \
-     * Reset the err_info struct back to default only if the prior API call had an error \
-     */                                                                                  \
-    if ((s)->api_call_counter == 1 && (s)->err_info.err != 0)                            \
-        __wt_session_reset_last_error((s));                                              \
+#define API_SESSION_INIT(s, struct_name, func_name, dh)                                \
+    WT_TRACK_OP_DECL;                                                                  \
+    API_SESSION_PUSH(s, struct_name, func_name, dh);                                   \
+    /*                                                                                 \
+     * No code before this line, otherwise error handling won't be                     \
+     * correct.                                                                        \
+     */                                                                                \
+    WT_ERR(WT_SESSION_CHECK_PANIC(s));                                                 \
+    __wt_single_thread_check_start(s);                                                 \
+    WT_TRACK_OP_INIT(s);                                                               \
+    /*                                                                                 \
+     * An internal session only saves errors on behalf of the application session that \
+     * spawned it, so its API calls neither reset nor record error information.        \
+     */                                                                                \
+    if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL)) {              \
+        __wt_op_timer_start(s);                                                        \
+        /* Clear any error left behind by the previous API call. */                    \
+        if ((s)->err_info.err != 0)                                                    \
+            __wt_session_reset_last_error((s));                                        \
+    }                                                                                  \
+    /* Reset wait time if this isn't an API reentry. */                                \
+    if ((s)->api_call_counter == 1)                                                    \
+        (s)->cache_wait_us = 0;                                                        \
     __wt_verbose((s), WT_VERB_API, "%s", "CALL: " #struct_name ":" #func_name)
 
 #define API_CALL_NOCONF_NOERRCLEAR(s, struct_name, func_name, dh, set_err) \
@@ -83,7 +86,7 @@
         __wt_single_thread_check_stop(s);                                                          \
         if ((ret) != 0 && __set_err)                                                               \
             __wt_txn_err_set(s, (ret));                                                            \
-        if ((s)->api_call_counter == 1) {                                                          \
+        if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL)) {                      \
             /*                                                                                     \
              * Check that the API return value matches what is stored in the err_info struct.      \
              *                                                                                     \
@@ -103,8 +106,7 @@
                 else                                                                               \
                     (s)->err_info.err = (ret);                                                     \
             };                                                                                     \
-            if (!F_ISSET(s, WT_SESSION_INTERNAL))                                                  \
-                __wt_op_timer_stop(s);                                                             \
+            __wt_op_timer_stop(s);                                                                 \
         }                                                                                          \
         /*                                                                                         \
          * FIXME-WT-7247 Ideally we would not leave any history store cursors open when we         \

--- a/test/suite/test_error_info03.py
+++ b/test/suite/test_error_info03.py
@@ -153,6 +153,22 @@ class test_error_info03(error_info_util):
         self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, None)), "was expecting drop call to fail with EBUSY")
         self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and cannot be closed yet")
 
+    def test_uncommitted_data_partial_drop(self):
+        """
+        Try to drop a table with two column groups while only the second one has uncommitted data.
+        The first column group is dropped and then restored when the second one fails.
+        """
+        self.session.create(self.uri, 'key_format=S,value_format=SS,columns=(k,a,b),colgroups=(c1,c2)')
+        self.session.create('colgroup:test_error_info:c1', 'columns=(a)')
+        self.session.create('colgroup:test_error_info:c2', 'columns=(b)')
+        with open_cursor(self.session, 'colgroup:test_error_info:c2') as cursor:
+            self.session.begin_transaction()
+            cursor.set_key('key')
+            cursor.set_value('value')
+            self.assertEqual(cursor.update(), 0)
+        self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, None)), "was expecting drop call to fail with EBUSY")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and cannot be closed yet")
+
     def test_dirty_data(self):
         """
         Try to drop a table without first performing a checkpoint.

--- a/test/suite/test_error_info03.py
+++ b/test/suite/test_error_info03.py
@@ -159,9 +159,10 @@ class test_error_info03(error_info_util):
         The first column group is dropped and then restored when the second one fails.
         """
         self.session.create(self.uri, 'key_format=S,value_format=SS,columns=(k,a,b),colgroups=(c1,c2)')
-        self.session.create('colgroup:test_error_info:c1', 'columns=(a)')
-        self.session.create('colgroup:test_error_info:c2', 'columns=(b)')
-        with open_cursor(self.session, 'colgroup:test_error_info:c2') as cursor:
+        colgroup_uri = self.uri.replace('table:', 'colgroup:')
+        self.session.create(colgroup_uri + ':c1', 'columns=(a)')
+        self.session.create(colgroup_uri + ':c2', 'columns=(b)')
+        with open_cursor(self.session, colgroup_uri + ':c2') as cursor:
             self.session.begin_transaction()
             cursor.set_key('key')
             cursor.set_value('value')


### PR DESCRIPTION
Treat API calls on an internal session as nested: neither reset nor record error information at entry and exit, matching the behaviour when the same operation runs directly on the application session. Internal sessions not spawned by an application session never save errors, so this only affects the schema session.

Note for reviewers: make sure to switch on "ignore whitespace" mode (`diff -w`) when reviewing the diff.