### PR TITLE
WT-17390 Replace deprecated barrier macros in test/format with atomic operations

### DIFF
--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -253,7 +253,7 @@ stepdown_writers_paused(void)
     if (tinfo_list == NULL)
         return (true);
     for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
-        WT_ACQUIRE_READ_WITH_BARRIER(ack, (*tlp)->pause_ack);
+        ack = __wt_atomic_load_bool_v_acquire(&(*tlp)->pause_ack);
         if (!ack)
             return (false);
     }
@@ -273,8 +273,8 @@ stepdown_pause_worker_writes(void)
 
     if (tinfo_list != NULL)
         for (tlp = tinfo_list; *tlp != NULL; ++tlp)
-            WT_RELEASE_WRITE_WITH_BARRIER((*tlp)->pause_ack, false);
-    WT_RELEASE_WRITE_WITH_BARRIER(g.stepdown_pause_writes, true);
+            __wt_atomic_store_bool_v_release(&(*tlp)->pause_ack, false);
+    __wt_atomic_store_bool_v_release(&g.stepdown_pause_writes, true);
 }
 
 /* !!!
@@ -419,7 +419,7 @@ disagg_async_stepdown(wt_thread_t *checkpoint_tid, wt_thread_t *timestamp_tid)
 
     /* Complete the role transition while the workers are read-only. */
     track_msg("[role change] leader -> follower (async)");
-    WT_RELEASE_WRITE_WITH_BARRIER(g.disagg_leader, false);
+    __wt_atomic_store_bool_v_release(&g.disagg_leader, false);
     testutil_check(g.wts_conn->reconfigure(g.wts_conn, "disaggregated=(role=follower)"));
 
     /*
@@ -428,7 +428,7 @@ disagg_async_stepdown(wt_thread_t *checkpoint_tid, wt_thread_t *timestamp_tid)
     follower_read_latest_checkpoint();
 
     /* Re-enable worker writes; they now run as follower writes into ingest. */
-    WT_RELEASE_WRITE_WITH_BARRIER(g.stepdown_pause_writes, false);
+    __wt_atomic_store_bool_v_release(&g.stepdown_pause_writes, false);
 
     /* Reset the quit flags now that the threads are joined. */
     __wt_atomic_store_bool_v_relaxed(&g.checkpoint_quit, false);
@@ -450,7 +450,7 @@ disagg_stepdown_thread(void *arg)
 
     args = (STEPDOWN_ARGS *)arg;
     disagg_async_stepdown(args->checkpoint_tid, args->timestamp_tid);
-    WT_RELEASE_WRITE_WITH_BARRIER(args->done, true);
+    __wt_atomic_store_bool_v_release(&args->done, true);
     return (WT_THREAD_RET_VALUE);
 }
 
@@ -469,7 +469,7 @@ disagg_switch_roles(void)
     wt_wrap_open_session(g.wts_conn, &sap, NULL, NULL, &session);
 
     /* Perform step-up or step-down. */
-    WT_RELEASE_WRITE_WITH_BARRIER(g.disagg_leader, !g.disagg_leader);
+    __wt_atomic_store_bool_v_release(&g.disagg_leader, !g.disagg_leader);
 
     if (!g.disagg_leader) {
         /* Stepping down: [leader -> follower]. */

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -42,7 +42,7 @@ timestamp_minimum_committed(void)
         return replay_maximum_committed();
 
     /* A barrier additionally prevents using cache values here. */
-    WT_ACQUIRE_READ_WITH_BARRIER(ts, g.timestamp);
+    ts = __wt_atomic_load_uint64_acquire(&g.timestamp);
     if (tinfo_list != NULL)
         for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
             commit_ts = (*tlp)->commit_ts;
@@ -84,9 +84,9 @@ timestamp_sync_threads_commit_ts(void)
     if (tinfo_list == NULL)
         return;
 
-    WT_ACQUIRE_READ_WITH_BARRIER(ts, g.timestamp);
+    ts = __wt_atomic_load_uint64_acquire(&g.timestamp);
     for (tlp = tinfo_list; *tlp != NULL; ++tlp)
-        WT_RELEASE_WRITE_WITH_BARRIER((*tlp)->commit_ts, ts);
+        __wt_atomic_store_uint64_release(&(*tlp)->commit_ts, ts);
 }
 
 /*
@@ -153,7 +153,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
          * For predictable replay, our end state is to have the stable timestamp represent a precise
          * number of operations.
          */
-        WT_ACQUIRE_READ_WITH_BARRIER(stop_timestamp, g.stop_timestamp);
+        stop_timestamp = __wt_atomic_load_uint64_acquire(&g.stop_timestamp);
         if (stable_timestamp > stop_timestamp && stop_timestamp != WT_TS_NONE)
             stable_timestamp = stop_timestamp;
 

--- a/test/format/format_util.c
+++ b/test/format/format_util.c
@@ -123,7 +123,7 @@ track_ops(TINFO *tinfo)
           track_ts_dots(stable_dot_cnt), track_ts_diff(stable_ts, cur_ts),
           track_ts_dots(cur_dot_cnt));
     }
-    WT_ACQUIRE_READ_WITH_BARRIER(disagg_leader, g.disagg_leader);
+    disagg_leader = __wt_atomic_load_bool_v_acquire(&g.disagg_leader);
     testutil_snprintf_len_set(msg, sizeof(msg), &len,
       "ops%s: "
       "S %" PRIu64

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -446,7 +446,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
          */
         if (stepdown_running) {
             bool stepdown_complete;
-            WT_ACQUIRE_READ_WITH_BARRIER(stepdown_complete, stepdown_args.done);
+            stepdown_complete = __wt_atomic_load_bool_v_acquire(&stepdown_args.done);
             if (stepdown_complete) {
                 stepdown_running = false;
                 fourths = DISAGG_SWITCH_FOLLOWER_OPS_SEC * 4;
@@ -738,7 +738,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
      * Remember our oldest commit timestamp. Updating the thread's commit timestamp allows read,
      * oldest and stable timestamps to advance, ensure we don't race.
      */
-    WT_RELEASE_WRITE_WITH_BARRIER(tinfo->commit_ts, ts);
+    __wt_atomic_store_uint64_release(&tinfo->commit_ts, ts);
 
     trace_uri_op(tinfo, NULL, "commit read-ts=%" PRIu64 ", commit-ts=%" PRIu64, tinfo->read_ts,
       tinfo->commit_ts);
@@ -1178,7 +1178,7 @@ ops(void *arg)
          * without a throttle, can monopolize the page log's reader-writer locks and starve the
          * step-down checkpoint's writes.
          */
-        WT_ACQUIRE_READ_WITH_BARRIER(pause_writes, g.stepdown_pause_writes);
+        pause_writes = __wt_atomic_load_bool_v_acquire(&g.stepdown_pause_writes);
         if (GV(OPS_THROTTLE) || pause_writes) {
             /* Sleep first to avoid burst when all threads start. */
             throttle_delay = mmrand(&tinfo->extra_rnd, 0, throttle_delay_max);
@@ -1258,11 +1258,11 @@ rollback_retry:
          * acknowledgment guarantees this thread has no unresolved writes and, because the operation
          * selection below sees the pause, that it will not write again until the pause is lifted.
          */
-        WT_ACQUIRE_READ_WITH_BARRIER(pause_writes, g.stepdown_pause_writes);
+        pause_writes = __wt_atomic_load_bool_v_acquire(&g.stepdown_pause_writes);
         if (!pause_writes)
-            WT_RELEASE_WRITE_WITH_BARRIER(tinfo->pause_ack, false);
+            __wt_atomic_store_bool_v_release(&tinfo->pause_ack, false);
         else if (!intxn)
-            WT_RELEASE_WRITE_WITH_BARRIER(tinfo->pause_ack, true);
+            __wt_atomic_store_bool_v_release(&tinfo->pause_ack, true);
 
         /*
          * If not in a transaction and in a timestamp world, start a transaction (which is always at
@@ -1345,7 +1345,7 @@ rollback_retry:
          */
         max_rows = TV(RUNS_ROWS);
         if (table->type != ROW && !table->mirror)
-            WT_ACQUIRE_READ_WITH_BARRIER(max_rows, table->rows_current);
+            max_rows = __wt_atomic_load_uint32_acquire(&table->rows_current);
         tinfo->keyno = mmrand(&tinfo->data_rnd, 1, (u_int)max_rows);
         if (TV(OPS_PARETO)) {
             tinfo->keyno = testutil_pareto(tinfo->keyno, (u_int)max_rows, TV(OPS_PARETO_SKEW));
@@ -1717,7 +1717,7 @@ apply_bounds(WT_CURSOR *cursor, TABLE *table, WT_RAND_STATE *rnd)
 
     /* Set up the default key buffer. */
     key_gen_init(&key);
-    WT_ACQUIRE_READ_WITH_BARRIER(max_rows, table->rows_current);
+    max_rows = __wt_atomic_load_uint32_acquire(&table->rows_current);
 
     /*
      * Generate a random lower key and apply to the lower bound or upper bound depending on the
@@ -1811,7 +1811,7 @@ wts_read_scan(TABLE *table, void *args)
     wt_wrap_open_cursor(session, table->uri, NULL, &cursor);
 
     /* Scan the first 50 rows for tiny, debugging runs, then scan a random subset of records. */
-    WT_ACQUIRE_READ_WITH_BARRIER(max_rows, table->rows_current);
+    max_rows = __wt_atomic_load_uint32_acquire(&table->rows_current);
     for (keyno = 0; keyno < max_rows;) {
         if (++keyno > 50)
             keyno += mmrand(rnd, 1, WT_THOUSAND);
@@ -2230,7 +2230,7 @@ col_insert_resolve(TABLE *table, void *arg)
      * Process the existing records and advance the last row count until we can't go further.
      */
     do {
-        WT_ACQUIRE_READ_WITH_BARRIER(max_rows, table->rows_current);
+        max_rows = __wt_atomic_load_uint32_acquire(&table->rows_current);
         for (i = 0, p = cip->insert_list; i < WT_ELEMENTS(cip->insert_list); ++i, ++p) {
             /*
              * A thread may have allocated a record number that is now less than or equal to the

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -106,7 +106,7 @@ replay_end_timed_run(void)
      * the intended stop timestamp. We pick a stop timestamp far enough in the future that it's
      * rather unlikely to happen.
      */
-    WT_RELEASE_WRITE_WITH_BARRIER(g.stop_timestamp, g.timestamp + 0x10000);
+    __wt_atomic_store_uint64_release(&g.stop_timestamp, g.timestamp + 0x10000);
 }
 
 /*
@@ -128,7 +128,7 @@ replay_maximum_committed(void)
     if (ts != WT_TS_NONE && __wt_atomic_add_uint32_v(&g.replay_calculate_committed, 1) % 20 != 0)
         return (ts);
 
-    WT_ACQUIRE_READ_WITH_BARRIER(ts, g.timestamp);
+    ts = __wt_atomic_load_uint64_acquire(&g.timestamp);
     any_lane_in_use = false;
     testutil_check(pthread_rwlock_wrlock(&g.lane_lock));
     for (lane = 0; lane < LANE_COUNT; ++lane) {
@@ -249,11 +249,11 @@ replay_pick_timestamp(TINFO *tinfo)
             ts = __wt_atomic_add_uint64_v(&g.timestamp, 1);
             g.timestamp_copy = g.timestamp;
             lane = LANE_NUMBER(ts);
-            WT_ACQUIRE_READ_WITH_BARRIER(in_use, g.lanes[lane].in_use);
+            in_use = __wt_atomic_load_bool_acquire(&g.lanes[lane].in_use);
         } while (in_use);
 
         tinfo->replay_ts = ts;
-        WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].in_use, true);
+        __wt_atomic_store_bool_release(&g.lanes[lane].in_use, true);
         testutil_check(pthread_rwlock_unlock(&g.lane_lock));
         tinfo->lane = lane;
     }
@@ -490,9 +490,9 @@ replay_committed(TINFO *tinfo)
      * Updating the last commit timestamp for a lane in use allows read, oldest and stable
      * timestamps to advance.
      */
-    WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].last_commit_ts, tinfo->replay_ts);
+    __wt_atomic_store_uint64_release(&g.lanes[lane].last_commit_ts, tinfo->replay_ts);
     if (g.timestamp <= tinfo->replay_ts + LANE_COUNT) {
-        WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].in_use, false);
+        __wt_atomic_store_bool_release(&g.lanes[lane].in_use, false);
         tinfo->lane = LANE_NONE;
         tinfo->replay_ts = WT_TS_NONE;
     } else {


### PR DESCRIPTION
Replace WT_ACQUIRE_READ_WITH_BARRIER and WT_RELEASE_WRITE_WITH_BARRIER with the typed `__wt_atomic_load_<type>_acquire` and `__wt_atomic_store_<type>_release` helpers. Volatile bool fields use the `_v_` variants; timestamps use uint64 and rows_current uses uint32.

NOTE that this PR is a pure refactor. The types of barriers need to be revisited later. Followup ticket: WT-18552.