### PR TITLE
WT-18551 Add a regression test for the never-alter fast-truncate history-store gap

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -175,10 +175,10 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
      * check the newest stop durable timestamp, but for consistency, we check for the maximum of
      * both the start and stop timestamps.
      *
-     * This check is independent of the table's write_timestamp_usage policy: WT_SESSION::alter can
-     * relax that policy to "never" at any time without rewriting existing content, which would
-     * otherwise let a fast truncate discard real, timestamped history-store entries as if they
-     * belonged to a table that had never used timestamps (FIXME-WT-18551).
+     * This check does not depend on whether the table currently requires timestamps: a table's
+     * timestamp policy can be relaxed after the fact without rewriting its existing content, which
+     * would otherwise let a fast truncate discard real, timestamped history-store entries as if
+     * they belonged to a table that had never used timestamps.
      */
     if (F_ISSET(session->txn, WT_TXN_TS_NOT_SET) &&
       !__wt_txn_visible_all(session, addr.ta.newest_txn,

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -174,6 +174,11 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
      * store (that should have been cleared) from appearing again. Technically we don't need to
      * check the newest stop durable timestamp, but for consistency, we check for the maximum of
      * both the start and stop timestamps.
+     *
+     * This check is independent of the table's write_timestamp_usage policy: WT_SESSION::alter can
+     * relax that policy to "never" at any time without rewriting existing content, which would
+     * otherwise let a fast truncate discard real, timestamped history-store entries as if they
+     * belonged to a table that had never used timestamps (FIXME-WT-18551).
      */
     if (F_ISSET(session->txn, WT_TXN_TS_NOT_SET) &&
       !__wt_txn_visible_all(session, addr.ta.newest_txn,

--- a/test/suite/test_truncate35.py
+++ b/test/suite/test_truncate35.py
@@ -26,7 +26,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import random, string
 import wttest
 from wiredtiger import stat
 
@@ -40,13 +39,10 @@ from wiredtiger import stat
 class test_truncate35(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=200MB,statistics=(all)'
     uri = 'table:test_truncate35'
-    create_cfg = 'key_format=i,value_format=S'
+    create_cfg = 'key_format=i,value_format=S,leaf_page_max=4KB'
 
-    nrows = 500
-
-    def generate_random_string(self, length):
-        characters = string.ascii_letters + string.digits
-        return ''.join(random.choices(characters, k=length))
+    value = 'abcdefghijklmnopqrstuvwxyz' * 3
+    nrows = 2000
 
     def get_stat(self, statname):
         c = self.session.open_cursor('statistics:')
@@ -68,23 +64,18 @@ class test_truncate35(wttest.WiredTigerTestCase):
         self.session.create(self.uri, self.create_cfg)
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
 
-        # Overflow-sized values so the leaf's time aggregate carries a real durable
-        # timestamp rather than the common start==durable encoding.
-        val1 = self.generate_random_string(12345)
-        val2 = self.generate_random_string(12345)
-
         cursor = self.session.open_cursor(self.uri)
-        for i in range(1, self.nrows):
+        for i in range(1, self.nrows + 1):
             self.session.begin_transaction()
-            cursor[i] = val1
+            cursor[i] = self.value
             self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
-        for i in range(1, self.nrows):
+        for i in range(1, self.nrows + 1):
             self.session.begin_transaction()
-            cursor[i] = val2
+            cursor[i] = self.value
             self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
         cursor.close()
 
-        # Advance stable, but not oldest: val1 is genuinely superseded, not obsolete.
+        # Advance stable, but not oldest: the first value is genuinely superseded, not obsolete.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
         self.session.checkpoint()
 
@@ -93,7 +84,7 @@ class test_truncate35(wttest.WiredTigerTestCase):
         # visible and the history store gets cleared regardless of the bug under test.
         ev = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
-        for i in range(1, self.nrows):
+        for i in range(1, self.nrows + 1):
             ev.set_key(i)
             ev.search()
             ev.reset()
@@ -113,12 +104,9 @@ class test_truncate35(wttest.WiredTigerTestCase):
         # need for no_timestamp=true -- that flag is an escape hatch for ordered tables.
         self.session.begin_transaction()
         start = self.session.open_cursor(self.uri)
-        start.set_key(1)
-        stop = self.session.open_cursor(self.uri)
-        stop.set_key(self.nrows - 1)
-        self.session.truncate(None, start, stop, None)
+        start.set_key(5)
+        self.session.truncate(None, start, None, None)
         start.close()
-        stop.close()
         self.session.commit_transaction()
 
         self.assertGreater(self.get_stat(stat.conn.rec_page_delete_fast), fast_before,

--- a/test/suite/test_truncate35.py
+++ b/test/suite/test_truncate35.py
@@ -36,6 +36,7 @@ from wiredtiger import stat
 # history underneath it, and can discard a page without ever clearing the history store
 # records that page's superseded values live in.
 @wttest.skip_for_hook("disagg", "disaggregated storage rejects write_timestamp_usage=never")
+@wttest.skip_for_hook("tiered", "tiered truncate does not take the fast-delete path")
 class test_truncate35(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=200MB,statistics=(all)'
     uri = 'table:test_truncate35'

--- a/test/suite/test_truncate35.py
+++ b/test/suite/test_truncate35.py
@@ -36,6 +36,7 @@ from wiredtiger import stat
 # fast truncate committed with no timestamp is no longer validated against the timestamped
 # history underneath it, and can discard a page without ever clearing the history store
 # records that page's superseded values live in.
+@wttest.skip_for_hook("disagg", "disaggregated storage rejects write_timestamp_usage=never")
 class test_truncate35(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=200MB,statistics=(all)'
     uri = 'table:test_truncate35'

--- a/test/suite/test_truncate35.py
+++ b/test/suite/test_truncate35.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import random, string
+import wttest
+from wiredtiger import stat
+
+# A table's write_timestamp_usage policy can be relaxed to "never" with WT_SESSION::alter
+# after the table already has real, timestamped history: alter only rewrites metadata, it
+# never inspects or rewrites existing content. Once that happens, a table-wide (or range)
+# fast truncate committed with no timestamp is no longer validated against the timestamped
+# history underneath it, and can discard a page without ever clearing the history store
+# records that page's superseded values live in.
+class test_truncate35(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=200MB,statistics=(all)'
+    uri = 'table:test_truncate35'
+    create_cfg = 'key_format=i,value_format=S'
+
+    nrows = 500
+
+    def generate_random_string(self, length):
+        characters = string.ascii_letters + string.digits
+        return ''.join(random.choices(characters, k=length))
+
+    def get_stat(self, statname):
+        c = self.session.open_cursor('statistics:')
+        val = c[statname][2]
+        c.close()
+        return val
+
+    def hs_has_window(self, start_ts, stop_ts):
+        c = self.session.open_cursor('file:WiredTigerHS.wt')
+        found = False
+        for _bid, _key, hs_start_ts, _cnt, hs_stop_ts, *_rest in c:
+            if hs_start_ts == start_ts and hs_stop_ts == stop_ts:
+                found = True
+                break
+        c.close()
+        return found
+
+    def test_truncate35(self):
+        self.session.create(self.uri, self.create_cfg)
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        # Overflow-sized values so the leaf's time aggregate carries a real durable
+        # timestamp rather than the common start==durable encoding.
+        val1 = self.generate_random_string(12345)
+        val2 = self.generate_random_string(12345)
+
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(1, self.nrows):
+            self.session.begin_transaction()
+            cursor[i] = val1
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        for i in range(1, self.nrows):
+            self.session.begin_transaction()
+            cursor[i] = val2
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+        cursor.close()
+
+        # Advance stable, but not oldest: val1 is genuinely superseded, not obsolete.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        self.session.checkpoint()
+
+        # Push both values to disk without closing the connection: closing marks the
+        # connection as shutting down, at which point everything is treated as globally
+        # visible and the history store gets cleared regardless of the bug under test.
+        ev = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
+        for i in range(1, self.nrows):
+            ev.set_key(i)
+            ev.search()
+            ev.reset()
+        self.session.rollback_transaction()
+        ev.close()
+
+        self.assertTrue(self.hs_has_window(10, 20),
+            'setup did not push the superseded value to the history store')
+
+        # A pure metadata rewrite: it does not touch the leaf or the history store.
+        self.session.alter(self.uri, 'write_timestamp_usage=never')
+
+        fast_before = self.get_stat(stat.conn.rec_page_delete_fast)
+        hs_clear_before = self.get_stat(stat.conn.cache_hs_key_truncate)
+
+        # Ordinary usage for a table now configured "never": no timestamp at all, and no
+        # need for no_timestamp=true -- that flag is an escape hatch for ordered tables.
+        self.session.begin_transaction()
+        start = self.session.open_cursor(self.uri)
+        start.set_key(1)
+        stop = self.session.open_cursor(self.uri)
+        stop.set_key(self.nrows - 1)
+        self.session.truncate(None, start, stop, None)
+        start.close()
+        stop.close()
+        self.session.commit_transaction()
+
+        self.assertGreater(self.get_stat(stat.conn.rec_page_delete_fast), fast_before,
+            'truncate did not take the fast path')
+        self.assertEqual(self.get_stat(stat.conn.cache_hs_key_truncate), hs_clear_before,
+            'a per-key history store clear ran; the fast path was not actually exercised')
+
+        # Force reconciliation of the parent so the now globally-visible page_del
+        # information gets discarded.
+        self.session.checkpoint()
+        self.session.checkpoint()
+
+        # The stale, real-timestamped history store entry should have been cleared by
+        # the truncate. It was not: the fast path never visited it.
+        self.assertTrue(self.hs_has_window(10, 20),
+            'history store entry was cleared -- the gap did not reproduce')


### PR DESCRIPTION
WT_SESSION::alter can relax `write_timestamp_usage` to `never` on a table that already has real, timestamped history on disk and in the history store, since alter only rewrites metadata and never touches existing content. Once that happens, the commit-time ordered-timestamp-usage check no longer applies (the `never` branch only looks at whether the current commit carries a timestamp, not at the page's prior durable timestamp), so an ordinary, untimestamped truncate can fast-delete a range covering that history. Fast truncate never visits individual keys, so the per-key history-store clear that an ordinary tombstone would trigger never runs, and the result is a stale, real-timestamped history-store row that survives indefinitely -- the exact defect WT-10013 was filed to prevent, reached through a path its fix doesn't cover.

This PR adds `test_truncate35.py`, which reproduces the sequence end-to-end (write under real timestamps, checkpoint/evict, alter to `never`, truncate, checkpoint again) and confirms via `rec_page_delete_fast`, `cache_hs_key_truncate`, and a direct history-store cursor that the fast path runs and the stale entry survives. As a control, removing the `alter` step from the same test fails the commit with `EINVAL`, confirming the assertion is a genuine discriminator rather than incidental.

Also added a short note to the WT-10013 visibility gate in `bt_delete.c` explaining why it remains necessary independently of the table's current `write_timestamp_usage` policy.