### PR TITLE
WT-18515 schema_disagg_abort: Avoid the shared metadata mismatch panic

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1761,6 +1761,7 @@ sanitizer
 sanitizers
 scalable
 scen
+scheckpoint
 schemas
 sclose
 scr

--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -16,8 +16,9 @@ the durable state against per-operation record files.
   publish event. Inserts are generated only after the create is complete.
 - A published drop parks the slot in REMOVED until the stable schema epoch passes the drop's epoch;
   recreating the name earlier is an API violation WiredTiger panics on.
-- Leaders write checkpoints to the shared page log; followers adopt them. Role changes are events in
-  the same stream, so all earlier work is drained before the connection is reconfigured.
+- Leaders write checkpoints to the shared metadata; followers pick them up.
+- Role changes are events in the event stream, so all earlier work is drained before the connection
+  is reconfigured.
 
 ## Directory layout
 
@@ -77,7 +78,7 @@ Threads are created for each leader or follower phase.
 | reader | 1 | Read the self-pipe or peer pipe, demultiplex events and drain work at transition markers. |
 | worker | `-T N` | Apply events, relay leader events, append records and report completed timestamps. |
 | timestamp | 1 | Advance oldest and stable timestamps, plus the stable schema epoch in epoch mode, to the completed frontier. |
-| checkpoint | 1 | Write leader checkpoints to PALite or adopt the latest checkpoint as follower. |
+| checkpoint | 1 | Take leader checkpoint, or pick up checkpoints as follower. |
 
 Shutdown is ordered generator, reader, workers, checkpoint, timestamp. The last two remain available
 while workers drain because a schema operation can be waiting for a checkpoint.

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -8,36 +8,32 @@
 
 /*
  * The checkpoint stage: the node's checkpoint duty, paced independently of the workload - produced
- * while leading, adopted from the page log while following.
+ * while leading, adopted one at a time while following.
  */
 
 #include "schema_disagg_abort.h"
 
 /*
- * ckpt_latest --
- *     Read the latest complete checkpoint. False when none found; the caller frees the metadata
- *     buffer.
+ * ckpt_get --
+ *     Read one complete checkpoint: the one at the given LSN or the next one above it, or the
+ *     latest when the LSN is zero. False when none found; the caller frees the metadata buffer.
  */
 bool
-ckpt_latest(WORKLOAD_STATE *state, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args)
+ckpt_get(WORKLOAD_STATE *state, WT_SESSION *session, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args)
 {
-    WT_CONNECTION *conn = state->conn;
     WT_PAGE_LOG *page_log = state->page_log;
 
-    WT_SESSION *session;
-    testutil_check(conn->open_session(conn, NULL, NULL, &session));
     const int ret = page_log->pl_get_complete_checkpoint(page_log, session, args);
     testutil_check_error_ok(ret, WT_NOTFOUND);
-    testutil_check(session->close(session, NULL));
 
     return (ret != WT_NOTFOUND);
 }
 /*
- * ckpt_lsn_stat --
- *     Return one of the connection's checkpoint metadata LSN statistics.
+ * ckpt_stat --
+ *     Return one of the connection's statistics.
  */
 static uint64_t
-ckpt_lsn_stat(WT_SESSION *session, int stat_key)
+ckpt_stat(WT_SESSION *session, int stat_key)
 {
     WT_CURSOR *stat_cursor;
     testutil_check(session->open_cursor(session, "statistics:", NULL, NULL, &stat_cursor));
@@ -54,41 +50,23 @@ ckpt_lsn_stat(WT_SESSION *session, int stat_key)
 
 /*
  * ckpt_pick_up --
- *     Pick up and adopt the latest complete checkpoint onto this connection. Returns true once a
- *     new checkpoint is adopted, false if the page log has no new checkpoint.
+ *     Pick up one checkpoint's metadata onto this connection and wait for the pick-up to land.
  */
-static bool
-ckpt_pick_up(WORKLOAD_STATE *state, WT_SESSION *session)
+static void
+ckpt_pick_up(WORKLOAD_STATE *state, WT_SESSION *session, const char *meta, size_t meta_size)
 {
-    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
-
-    if (!ckpt_latest(state, &ckpt_args))
-        return (false);
-
-    if (ckpt_args.checkpoint_lsn == state->adopted_ckpt_lsn) {
-        free(ckpt_args.checkpoint_metadata.mem);
-        return (false);
-    }
-
-    /* Never adopt a checkpoint the node has not caught up with. */
-    if (__wt_atomic_load_uint64(&state->current_ts) < ckpt_args.checkpoint_timestamp) {
-        free(ckpt_args.checkpoint_metadata.mem);
-        return (false);
-    }
-
     struct timespec start;
     __wt_epoch(NULL, &start);
 
     WT_CONNECTION *conn = session->connection;
     char meta_config[4096];
     testutil_snprintf(meta_config, sizeof(meta_config), "disaggregated=(checkpoint_meta=\"%.*s\")",
-      (int)ckpt_args.checkpoint_metadata.size, (const char *)ckpt_args.checkpoint_metadata.data);
+      (int)meta_size, meta);
     testutil_check(conn->reconfigure(conn, meta_config));
-    free(ckpt_args.checkpoint_metadata.mem);
 
-    const uint64_t delivered = ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN);
+    const uint64_t delivered = ckpt_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN);
     for (;;) {
-        const uint64_t adopted = ckpt_lsn_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN);
+        const uint64_t adopted = ckpt_stat(session, WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN);
         if (adopted >= delivered)
             break;
 
@@ -101,9 +79,6 @@ ckpt_pick_up(WORKLOAD_STATE *state, WT_SESSION *session)
               state->cfg->node_id, delivered, MAX_OP_WAIT, adopted);
         __wt_sleep(0, 10 * WT_THOUSAND);
     }
-
-    state->adopted_ckpt_lsn = ckpt_args.checkpoint_lsn;
-    return (true);
 }
 
 /*
@@ -115,17 +90,31 @@ ckpt_adopt_latest(WORKLOAD_STATE *state)
 {
     WT_SESSION *session;
     testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
-    const bool adopted = ckpt_pick_up(state, session);
-    testutil_check(session->close(session, NULL));
-    if (adopted)
+
+    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
+    if (!ckpt_get(state, session, &ckpt_args)) {
+        testutil_check(session->close(session, NULL));
+        return; /* no checkpoint to adopt */
+    }
+
+    const bool adopt = ckpt_args.checkpoint_lsn != state->adopted_ckpt_lsn &&
+      __wt_atomic_load_uint64(&state->frontier_ts) >= ckpt_args.checkpoint_timestamp;
+    if (adopt) {
+        ckpt_pick_up(state, session, (const char *)ckpt_args.checkpoint_metadata.data,
+          ckpt_args.checkpoint_metadata.size);
+
+        state->adopted_ckpt_lsn = ckpt_args.checkpoint_lsn;
         println(
           "Node %" PRIu32 ": adopted the latest checkpoint before step-up", state->cfg->node_id);
+    }
+
+    testutil_check(session->close(session, NULL));
+    free(ckpt_args.checkpoint_metadata.mem);
 }
 
 /*
  * thread_ckpt_run --
- *     Take one checkpoint per random interval for as long as the phase runs. The interval runs from
- *     the previous checkpoint's completion, so slow checkpoints do not chain back to back.
+ *     Run the role's checkpoint duty for as long as the phase runs.
  */
 WT_THREAD_RET
 thread_ckpt_run(void *arg)
@@ -135,27 +124,16 @@ thread_ckpt_run(void *arg)
     WT_SESSION *session;
     testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
 
-    /* The role's checkpoint bookkeeping for this phase; only a follower adopts checkpoints. */
-    CKPT_CTX ckpt = {0};
+    CKPT_CTX ckpt;
+    WT_CLEAR(ckpt);
     __wt_epoch(NULL, &ckpt.phase_start);
-
-    /* The cadence draws from the stream one past the generator's per-worker streams. */
-    WT_RAND_STATE *rnd = &state->gen_rnd[state->worker_count];
-    struct timespec last = ckpt.phase_start;
-    uint64_t wait = 1 + __wt_random(rnd) % MAX_CKPT_INVL;
+    ckpt.last = ckpt.phase_start;
+    ckpt.rnd = &state->ext_rnd;
+    ckpt.wait = 1 + __wt_random(ckpt.rnd) % MAX_CKPT_INVL;
 
     while (workload_active(state, STAGE_CKPT)) {
-        struct timespec now;
-        __wt_epoch(NULL, &now);
-        if ((uint64_t)WT_TIMEDIFF_SEC(now, last) < wait) {
-            __wt_sleep(0, 100 * WT_THOUSAND);
-            continue;
-        }
-
         node_role(state->leads)->checkpoint(state, session, &ckpt);
-
-        __wt_epoch(NULL, &last);
-        wait = 1 + __wt_random(rnd) % MAX_CKPT_INVL;
+        __wt_sleep(0, 100 * WT_THOUSAND);
     }
 
     testutil_check(session->close(session, NULL));
@@ -217,57 +195,126 @@ thread_ts_run(void *arg)
 }
 
 /*
- * leader_checkpoint --
- *     Produce one checkpoint. The first one reports leader readiness. Nothing is checkpointed while
- *     no stable timestamp exists yet.
+ * leader_checkpoint_take --
+ *     Take one checkpoint at the given stable timestamp and report it, returning its LSN.
  */
-void
-leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
+static uint64_t
+leader_checkpoint_take(
+  WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt, uint64_t stable_ts, const char *kind)
 {
-    /* Skip the checkpoint if the step-down is in progress. */
-    if (__wt_atomic_load_uint64(&state->stepdown_ts) != 0)
+    /* The timestamp thread owns the frontier; just checkpoint. */
+    testutil_check(session->checkpoint(session, "use_timestamp=true"));
+
+    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
+    testutil_assert(ckpt_get(state, session, &ckpt_args));
+    free(ckpt_args.checkpoint_metadata.mem);
+    testutil_assert(ckpt_args.checkpoint_lsn != 0);
+
+    println("Node %" PRIu32 ": %scheckpoint %" PRIu32 " at %" PRIu64 " (lsn %" PRIu64 ")",
+      state->cfg->node_id, kind, ++ckpt->produced, stable_ts, ckpt_args.checkpoint_lsn);
+
+    return (ckpt_args.checkpoint_lsn);
+}
+
+/*
+ * leader_checkpoint_normal --
+ *     Produce one checkpoint on the phase's own cadence.
+ */
+static void
+leader_checkpoint_normal(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
+{
+    struct timespec now;
+    __wt_epoch(NULL, &now);
+    if ((uint64_t)WT_TIMEDIFF_SEC(now, ckpt->last) < ckpt->wait)
         return;
 
-    /* Skip the checkpoint if there is no stable timestamp yet. */
     const uint64_t stable_ts = query_ts(state->conn, TS_STABLE);
     if (stable_ts == 0) {
-        struct timespec now;
-        __wt_epoch(NULL, &now);
         if (WT_TIMEDIFF_SEC(now, ckpt->phase_start) > MAX_OP_WAIT)
             testutil_die(ETIMEDOUT, "stable timestamp not set after %d seconds", MAX_OP_WAIT);
         return;
     }
 
-    /* The timestamp thread owns the frontier; just checkpoint. */
-    testutil_check(session->checkpoint(session, "use_timestamp=true"));
+    (void)leader_checkpoint_take(state, session, ckpt, stable_ts, "");
 
-    println("Node %" PRIu32 ": checkpoint %" PRIu32 " complete; stable timestamp = %" PRIu64,
-      state->cfg->node_id, ++ckpt->produced, stable_ts);
-
-    /* A stable frontier implies every worker completed an operation this phase. */
+    /* A stable frontier implies every worker completed an operation by now. */
     if (ckpt->produced == 1u)
         testutil_sentinel(NULL, LEADER_READY_FILE);
+
+    /* The interval runs from the completion, so slow checkpoints do not chain back to back. */
+    __wt_epoch(NULL, &ckpt->last);
+    ckpt->wait = 1 + __wt_random(ckpt->rnd) % MAX_CKPT_INVL;
+}
+
+/*
+ * leader_checkpoint_stepdown --
+ *     Produce the single step-down checkpoint. The next leader waits on its LSN.
+ */
+static void
+leader_checkpoint_stepdown(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
+{
+    if (!__wt_atomic_load_bool(&state->stepdown_ckpt_due) ||
+      __wt_atomic_load_uint64(&state->stepdown_ckpt_lsn) != 0)
+        return;
+
+    /* The reader pinned stable at the step-down timestamp before releasing this thread. */
+    const uint64_t stepdown_ts = __wt_atomic_load_uint64(&state->stepdown_ts);
+    const uint64_t lsn = leader_checkpoint_take(state, session, ckpt, stepdown_ts, "step-down ");
+
+    /* Zero would read as "not taken yet" to the generator waiting on it. */
+    __wt_atomic_store_uint64(&state->stepdown_ckpt_lsn, lsn);
+}
+
+/*
+ * leader_checkpoint --
+ *     The leader's checkpoint duty: a step-down replaces the cadence with one final checkpoint, and
+ *     nothing else is checkpointed until the transition completes.
+ */
+void
+leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
+{
+    if (__wt_atomic_load_uint64(&state->stepdown_ts) != 0)
+        leader_checkpoint_stepdown(state, session, ckpt);
+    else
+        leader_checkpoint_normal(state, session, ckpt);
 }
 
 /*
  * follower_checkpoint --
- *     Adopt the latest checkpoint from the leader. The workers keep running through it.
+ *     Pick up the next checkpoint once this node has caught up with it; a worker blocked on a drop
+ *     is waiting for it.
  */
 void
 follower_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 {
     WT_UNUSED(ckpt);
 
-    /* Adopted LSN is 0 until a checkpoint is picked up, so read it before the pick-up. */
-    const bool first_ckpt = state->adopted_ckpt_lsn == 0;
-
-    if (!ckpt_pick_up(state, session))
+    /* The next checkpoint this node has not picked up. */
+    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
+    ckpt_args.lsn = state->adopted_ckpt_lsn + 1;
+    if (!ckpt_get(state, session, &ckpt_args))
         return;
 
-    /* Each adoption is reported for a stepping-down peer. */
-    adopted_lsn_publish(state->cfg->node_id, state->adopted_ckpt_lsn);
+    /* Never pick up a checkpoint the node has not caught up with; leave it for a later tick. */
+    const uint64_t frontier_ts = __wt_atomic_load_uint64(&state->frontier_ts);
+    if (frontier_ts >= ckpt_args.checkpoint_timestamp) {
+        /* Adopted LSN is 0 until a checkpoint is picked up, so read it before the pick-up. */
+        const bool first_ckpt = state->adopted_ckpt_lsn == 0;
 
-    /* The first picked up checkpoint: follower is ready. */
-    if (first_ckpt)
-        testutil_sentinel(NULL, FOLLOWER_READY_FILE);
+        ckpt_pick_up(state, session, (const char *)ckpt_args.checkpoint_metadata.data,
+          ckpt_args.checkpoint_metadata.size);
+        state->adopted_ckpt_lsn = ckpt_args.checkpoint_lsn;
+
+        println("Node %" PRIu32 ": pick-up at %" PRIu64 " (lsn %" PRIu64 "); frontier %" PRIu64,
+          state->cfg->node_id, ckpt_args.checkpoint_timestamp, ckpt_args.checkpoint_lsn,
+          frontier_ts);
+
+        /* Each pick-up is reported for a stepping-down peer. */
+        adopted_lsn_publish(state->cfg->node_id, state->adopted_ckpt_lsn);
+
+        /* The first picked up checkpoint: follower is ready. */
+        if (first_ckpt)
+            testutil_sentinel(NULL, FOLLOWER_READY_FILE);
+    }
+    free(ckpt_args.checkpoint_metadata.mem);
 }

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -195,11 +195,11 @@ thread_ts_run(void *arg)
 }
 
 /*
- * leader_checkpoint_take --
+ * ckpt_take --
  *     Take one checkpoint at the given stable timestamp and report it, returning its LSN.
  */
 static uint64_t
-leader_checkpoint_take(
+ckpt_take(
   WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt, uint64_t stable_ts, const char *kind)
 {
     /* The timestamp thread owns the frontier; just checkpoint. */
@@ -217,11 +217,11 @@ leader_checkpoint_take(
 }
 
 /*
- * leader_checkpoint_normal --
+ * ckpt_take_periodic --
  *     Produce one checkpoint on the phase's own cadence.
  */
 static void
-leader_checkpoint_normal(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
+ckpt_take_periodic(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 {
     struct timespec now;
     __wt_epoch(NULL, &now);
@@ -235,7 +235,7 @@ leader_checkpoint_normal(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *c
         return;
     }
 
-    (void)leader_checkpoint_take(state, session, ckpt, stable_ts, "");
+    (void)ckpt_take(state, session, ckpt, stable_ts, "");
 
     /* A stable frontier implies every worker completed an operation by now. */
     if (ckpt->produced == 1u)
@@ -247,11 +247,11 @@ leader_checkpoint_normal(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *c
 }
 
 /*
- * leader_checkpoint_stepdown --
+ * ckpt_take_stepdown --
  *     Produce the single step-down checkpoint. The next leader waits on its LSN.
  */
 static void
-leader_checkpoint_stepdown(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
+ckpt_take_stepdown(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 {
     if (!__wt_atomic_load_bool(&state->stepdown_ckpt_due) ||
       __wt_atomic_load_uint64(&state->stepdown_ckpt_lsn) != 0)
@@ -259,7 +259,7 @@ leader_checkpoint_stepdown(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX 
 
     /* The reader pinned stable at the step-down timestamp before releasing this thread. */
     const uint64_t stepdown_ts = __wt_atomic_load_uint64(&state->stepdown_ts);
-    const uint64_t lsn = leader_checkpoint_take(state, session, ckpt, stepdown_ts, "step-down ");
+    const uint64_t lsn = ckpt_take(state, session, ckpt, stepdown_ts, "step-down ");
 
     /* Zero would read as "not taken yet" to the generator waiting on it. */
     __wt_atomic_store_uint64(&state->stepdown_ckpt_lsn, lsn);
@@ -274,9 +274,9 @@ void
 leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 {
     if (__wt_atomic_load_uint64(&state->stepdown_ts) != 0)
-        leader_checkpoint_stepdown(state, session, ckpt);
+        ckpt_take_stepdown(state, session, ckpt);
     else
-        leader_checkpoint_normal(state, session, ckpt);
+        ckpt_take_periodic(state, session, ckpt);
 }
 
 /*

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -17,7 +17,7 @@
 /* The generator's state machine. */
 typedef enum {
     GEN_NORMAL,          /* the term's workload */
-    GEN_FLUSH_PUBLISHES, /* one-shot: emit the publishes a term must not end holding */
+    GEN_PUBLISH_PENDING, /* publish what the preceding workload left unpublished */
     GEN_BEGIN_STEPDOWN,  /* one-shot: emit the step-down timestamp */
     GEN_STEPDOWN,        /* the step-down: limited workload */
     GEN_SWITCH,          /* one-shot: emit the switch event that ends the stream */
@@ -48,14 +48,14 @@ generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
 static bool
 generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
 {
-    const bool stepping_down = phase == GEN_STEPDOWN;
-    WT_RAND_STATE *rnd = &state->gen_rnd[t];
+    WT_RAND_STATE *rnd = &state->workers[t].rnd;
     const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
     TABLE_STATE *slot_state = &state->workers[t].table[slot].state;
     uint64_t *drop_epoch = &state->workers[t].table[slot].drop_epoch;
     /* Set when no checkpoint of this phase can cover the insert; such a slot is not droppable. */
     bool *uncovered_insert = &state->workers[t].table[slot].uncovered_insert;
 
+    const bool stepping_down = phase == GEN_STEPDOWN;
     SCHEMA_EVENT ev = {0}; /* EVENT_NONE until a move is taken */
     switch (*slot_state) {
     case TABLE_NONE:
@@ -192,13 +192,14 @@ generator_switch_requested(GENERATOR_PACING *pacing)
 }
 
 /*
- * generator_flush_publishes --
- *     Emit the pending publish for every slot in an unpublished state, before the role transition.
- *     FIXME-WT-18272 FIXME-WT-18284: Remove this function once these tickets are resolved.
- *     Corresponding generator state GEN_FLUSH_PUBLISHES won't be needed anymore, as well.
+ * generator_publish_pending --
+ *     Emit the pending publish for every slot in an unpublished state.
+ *
+ * FIXME-WT-18272 FIXME-WT-18284: Consider removing this function and GEN_PUBLISH_PENDING once these
+ *     are fixed.
  */
 static void
-generator_flush_publishes(WORKLOAD_STATE *state)
+generator_publish_pending(WORKLOAD_STATE *state)
 {
     if (state->cfg->epoch_less)
         return;
@@ -252,20 +253,20 @@ generator_stepdown_ended(WORKLOAD_STATE *state, GENERATOR_PACING *pacing)
         return (true);
 
     /* Report which part of the step-down stalled. */
-    if (WT_TIMEDIFF_SEC(now, pacing->stepdown_start) > MAX_OP_WAIT) {
+    if (WT_TIMEDIFF_SEC(now, pacing->stepdown_start) > MAX_STEPDOWN_WAIT) {
         if (ckpt_lsn == 0)
             testutil_die(ETIMEDOUT,
               "Node %" PRIu32 ": the step-down checkpoint did not complete in %d seconds",
-              state->cfg->node_id, MAX_OP_WAIT);
+              state->cfg->node_id, MAX_STEPDOWN_WAIT);
         else if (lone)
             testutil_die(ETIMEDOUT,
               "Node %" PRIu32 ": the step-down emitted %" PRIu64 " of %d events in %d seconds",
-              state->cfg->node_id, stepdown_events, GEN_STEPDOWN_MIN_EVENTS, MAX_OP_WAIT);
+              state->cfg->node_id, stepdown_events, GEN_STEPDOWN_MIN_EVENTS, MAX_STEPDOWN_WAIT);
         else
             testutil_die(ETIMEDOUT,
               "Node %" PRIu32 ": peer did not adopt the step-down checkpoint (lsn %" PRIu64
               ") in %d seconds",
-              state->cfg->node_id, ckpt_lsn, MAX_OP_WAIT);
+              state->cfg->node_id, ckpt_lsn, MAX_STEPDOWN_WAIT);
     }
 
     return (false);
@@ -307,11 +308,18 @@ thread_generator_run(void *arg)
         switch (phase) {
         case GEN_NORMAL:
             progressed = generator_round(state, pacing.lead_max, GEN_NORMAL);
-            phase = generator_switch_requested(&pacing) ? GEN_FLUSH_PUBLISHES : GEN_NORMAL;
+            phase = generator_switch_requested(&pacing) ? GEN_PUBLISH_PENDING : GEN_NORMAL;
             break;
-        case GEN_FLUSH_PUBLISHES:
-            generator_flush_publishes(state);
-            phase = state->leads ? GEN_BEGIN_STEPDOWN : GEN_SWITCH;
+        case GEN_PUBLISH_PENDING:
+            /*
+             * Generator enters this state twice: before the step-down begins and after the
+             * step-down ends.
+             */
+            generator_publish_pending(state);
+            if (state->leads && __wt_atomic_load_uint64(&state->stepdown_ts) == 0)
+                phase = GEN_BEGIN_STEPDOWN;
+            else
+                phase = GEN_SWITCH;
             break;
         case GEN_BEGIN_STEPDOWN:
             /*
@@ -327,9 +335,13 @@ thread_generator_run(void *arg)
             progressed = (node_is_lone(state->cfg) || state->cfg->peer_alive) &&
               generator_round(state, pacing.lead_max, GEN_STEPDOWN);
             if (generator_stepdown_ended(state, &pacing)) {
-                println("Node %" PRIu32 ": step-down emitted %" PRIu64 " events",
-                  state->cfg->node_id, state->emitted - pacing.stepdown_emitted);
-                phase = GEN_SWITCH;
+                struct timespec now;
+                __wt_epoch(NULL, &now);
+                println("Node %" PRIu32 ": step-down emitted %" PRIu64 " events in %" PRIu64
+                        " ms (budget %d s)",
+                  state->cfg->node_id, state->emitted - pacing.stepdown_emitted,
+                  (uint64_t)WT_TIMEDIFF_MS(now, pacing.stepdown_start), MAX_STEPDOWN_WAIT);
+                phase = GEN_PUBLISH_PENDING;
             }
             break;
         case GEN_SWITCH:

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -266,6 +266,7 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
     state->handover_received = false;
     state->emitted = state->applied = 0;
     state->stepdown_ts = state->stepdown_ckpt_lsn = 0;
+    state->stepdown_ckpt_due = false;
 
     /* The frontier continues from the previous phase; nothing above it is completed yet. */
     state->frontier_ts = state->current_ts;
@@ -275,6 +276,7 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
     for (uint32_t i = 0; i < cfg->thread_count; i++) {
         state->workers[i].busy = false;
         state->workers[i].evq.head = state->workers[i].evq.tail = 0;
+        testutil_random_from_random(&state->workers[i].rnd, &cfg->opts->data_rnd);
         /*
          * A leading phase checkpoints every slot, including inherited ingest data; a follower phase
          * covers nothing, so the slots it inherits stay blocked.
@@ -285,10 +287,8 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
         /* State and slot generation survive role transitioning. */
     }
 
-    /* Re-seed the phase's worker and auxiliary streams. */
-    for (uint32_t i = 0; i <= cfg->thread_count; i++)
-        testutil_random_from_random(
-          &state->gen_rnd[i], i < cfg->thread_count ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
+    /* Re-seed the auxiliary stream. */
+    testutil_random_from_random(&state->ext_rnd, &cfg->opts->extra_rnd);
 
     node_aux_start(state, STAGE_TS, thread_ts_run);
     node_workers_start(state);
@@ -339,10 +339,15 @@ node_step_down(WORKLOAD_STATE *state, uint64_t final_ts)
         println("Node %" PRIu32 ": no peer to hand over to; continuing alone", state->cfg->node_id);
     }
 
-    /* Reset adopted checkpoint and transition tracking. */
-    state->adopted_ckpt_lsn = 0;
+    /* The pick-up resumes from the step-down checkpoint. */
+    const uint64_t stepdown_lsn = __wt_atomic_load_uint64(&state->stepdown_ckpt_lsn);
+    if (state->adopted_ckpt_lsn < stepdown_lsn)
+        state->adopted_ckpt_lsn = stepdown_lsn;
+
+    /* Reset transition tracking. */
     __wt_atomic_store_uint64(&state->stepdown_ts, 0);
     __wt_atomic_store_uint64(&state->stepdown_ckpt_lsn, 0);
+    __wt_atomic_store_bool(&state->stepdown_ckpt_due, false);
 }
 
 /*

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -35,7 +35,8 @@ frontier_assert(WORKLOAD_STATE *state, uint64_t timestamp)
 static void
 reader_step_down(WORKLOAD_STATE *state, uint64_t ts)
 {
-    WT_CONNECTION *conn = state->conn;
+    testutil_assert(__wt_atomic_load_uint64(&state->stepdown_ts) == 0);
+    testutil_assert(__wt_atomic_load_bool(&state->stepdown_ckpt_due) == false);
 
     /* Signal the timestamp and checkpoint threads to pause. */
     __wt_atomic_store_uint64(&state->stepdown_ts, ts);
@@ -43,25 +44,13 @@ reader_step_down(WORKLOAD_STATE *state, uint64_t ts)
         __wt_sleep(0, WT_THOUSAND);
 
     /*
-     * FIXME-WT-18314: Reject step down timestamp without the epoch. The `-e` mode with role
-     * switches becomes illegal.
+     * FIXME-WT-18314: Once the ticket is fixed, the `-e` mode with role switches becomes illegal.
      */
-    set_ts(state->cfg, conn, TS_STEPDOWN, ts);
+    set_ts(state->cfg, state->conn, TS_STEPDOWN, ts);
     workload_set_frontier(state, ts);
 
-    WT_SESSION *session;
-    testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    testutil_check(session->checkpoint(session, "use_timestamp=true"));
-    testutil_check(session->close(session, NULL));
-
-    /* Keep the step-down checkpoint's LSN; the next leader should adopt it. */
-    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
-    testutil_assert(ckpt_latest(state, &ckpt_args));
-    free(ckpt_args.checkpoint_metadata.mem);
-
-    __wt_atomic_store_uint64(&state->stepdown_ckpt_lsn, ckpt_args.checkpoint_lsn);
-    println("Node %" PRIu32 ": step-down checkpoint at %" PRIu64 " (lsn %" PRIu64 ")",
-      state->cfg->node_id, ts, ckpt_args.checkpoint_lsn);
+    /* Signal the checkpoint thread to resume and run the step-down checkpoint. */
+    __wt_atomic_store_bool(&state->stepdown_ckpt_due, true);
 }
 
 /*

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -45,15 +45,12 @@
 #define MAX_CKPT_INVL 4 /* checkpoint thread: upper bound on the interval, in seconds */
 #define TS_BOOTSTRAP 1  /* the timestamp sequence starts here, on either mode */
 #define MAX_NODES 2
-/*
- * In-node: a retried op gives up, before the parent stops waiting. A blocked drop waits for the
- * checkpoint thread's next checkpoint, so this has to stay well above MAX_CKPT_INVL.
- */
-#define MAX_OP_WAIT 30
+#define MAX_OP_WAIT 30 /* maximum time to wait for an in-node operation */
 #define MAX_POOL_SIZE 64
 #define MAX_TIME 40
 #define MIN_TIME 10
 #define MAX_WAIT 60 /* parent: a child starting, stopping, or posting a sentinel */
+#define MAX_STEPDOWN_WAIT (2 * MAX_WAIT) /* maximum time to wait for a step-down to complete */
 #define MIN_POOL_SIZE 2
 #define MAX_TH 12
 #define MIN_TH 2
@@ -234,6 +231,7 @@ typedef struct {
 
     /* Step-down state, zero outside a transition; atomic access. */
     uint64_t stepdown_ts;       /* while set, the timestamp and checkpoint threads hold */
+    bool stepdown_ckpt_due;     /* the timestamps are set: the checkpoint thread may take it */
     uint64_t stepdown_ckpt_lsn; /* the step-down checkpoint, once taken */
     bool ts_busy;               /* the timestamp thread is mid-advance; atomic access */
 
@@ -249,9 +247,10 @@ typedef struct {
 
     /* Per-worker-thread state; the reader fills the queue, the slot model is the generator's. */
     struct {
-        wt_thread_t thr; /* this worker's handle */
-        EVENT_QUEUE evq; /* this worker's inbound events */
-        bool busy;       /* the worker is mid-apply; atomic access */
+        wt_thread_t thr;   /* this worker's handle */
+        EVENT_QUEUE evq;   /* this worker's inbound events */
+        bool busy;         /* the worker is mid-apply; atomic access */
+        WT_RAND_STATE rnd; /* this worker's random stream */
         struct {
             /* Table state is carried across leader-follower transitions. */
             TABLE_STATE state;
@@ -267,16 +266,22 @@ typedef struct {
     /* The single-threaded stages, indexed by stage: generator, reader, checkpoint, timestamp. */
     wt_thread_t aux_thr[AUX_THR_COUNT];
 
-    /* Random streams: one per worker, plus one for the checkpoint thread's cadence. */
-    WT_RAND_STATE gen_rnd[MAX_TH + 1];
+    /* Auxiliary random stream */
+    WT_RAND_STATE ext_rnd;
+
 } WORKLOAD_STATE;
 
 /*
  * The checkpoint thread's bookkeeping for one phase.
  */
 typedef struct {
-    uint32_t produced;           /* checkpoints produced so far */
     struct timespec phase_start; /* when the phase began, used for checkpoint timeouts */
+
+    /* Leading only: the cadence. */
+    uint32_t produced;    /* checkpoints produced so far */
+    struct timespec last; /* when the previous checkpoint completed */
+    uint64_t wait;        /* seconds to the next one, redrawn after each */
+    WT_RAND_STATE *rnd;   /* the cadence's random stream */
 } CKPT_CTX;
 
 /*
@@ -337,7 +342,8 @@ WT_THREAD_RET thread_reader_run(void *arg);
 WT_THREAD_RET thread_ckpt_run(void *arg);
 WT_THREAD_RET thread_ts_run(void *arg);
 void ckpt_adopt_latest(WORKLOAD_STATE *state);
-bool ckpt_latest(WORKLOAD_STATE *state, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args);
+bool ckpt_get(
+  WORKLOAD_STATE *state, WT_SESSION *session, WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS *args);
 void leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt);
 void follower_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt);
 

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -140,21 +140,20 @@ schema_op_execute(WORKLOAD_STATE *state, WT_SESSION *session, const SCHEMA_EVENT
         if (ret != EBUSY)
             break;
 
-        struct timespec now;
-        __wt_epoch(NULL, &now);
-        const bool timed_out = WT_TIMEDIFF_SEC(now, start) > MAX_OP_WAIT;
-        /* Leader is gone, so no one produces checkpoints to unblock this operation. */
-        const bool abandoned = !state->generates && (!state->cfg->peer_alive || timed_out);
         int err, sub_err;
         const char *err_msg;
-        if (abandoned) {
+
+        /* Leader is gone, so no one produces checkpoints to unblock this operation. */
+        if (!state->generates && !state->cfg->peer_alive) {
             session->get_last_error(session, &err, &sub_err, &err_msg);
-            println("Node %" PRIu32 ": abandoning follower %s %s (%s): %s", state->cfg->node_id,
-              is_create ? "CREATE" : "DROP", ev->uri,
-              timed_out ? "no checkpoint arrived" : "peer left", err_msg);
+            println("Node %" PRIu32 ": abandoning follower %s %s (peer left): %s",
+              state->cfg->node_id, is_create ? "CREATE" : "DROP", ev->uri, err_msg);
             return (ECANCELED);
         }
-        if (timed_out) {
+
+        struct timespec now;
+        __wt_epoch(NULL, &now);
+        if (WT_TIMEDIFF_SEC(now, start) > MAX_OP_WAIT) {
             session->get_last_error(session, &err, &sub_err, &err_msg);
             schema_op_stall_report(state);
             testutil_die(ETIMEDOUT, "node%" PRIu32 " %s %s %s: EBUSY for %d seconds: %s",


### PR DESCRIPTION
- A follower adopts chekpoints in the same order as leader produced them.