### PR TITLE
WT-18558 Disable key-level checkpoint cleanup for disaggregated storage

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -56,14 +56,6 @@ __sync_obsolete_tw_check(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE ta)
     if (WT_TIME_AGGREGATE_HAS_STOP(&ta))
         return (false);
 
-    /*
-     * Disaggregated storage reconciliation can write a delta rather than a full page, so dirtying a
-     * page to strip its obsolete time window information can grow disk usage instead of shrinking
-     * it. Leave that content in place; page-level cleanup still reclaims whole pages.
-     */
-    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
-        return (false);
-
     /* Limit the activity to reduce the load. */
     if (__sync_obsolete_limit_reached(session))
         return (false);
@@ -174,11 +166,14 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
         /* Mark the obsolete page to evict soon. */
         __wt_evict_page_soon(session, ref);
         WT_STAT_CONN_DSRC_INCR(session, checkpoint_cleanup_pages_evict);
-    } else if (__sync_obsolete_tw_check(session, newest_ta)) {
+    } else if (!WT_DELTA_LEAF_ENABLED(session) && __sync_obsolete_tw_check(session, newest_ta)) {
 
         /*
          * Dirty the page with an obsolete time window to let the page reconciliation remove all the
-         * obsolete time window information.
+         * obsolete time window information. Skip this when the page reconciles to a delta rather
+         * than a full page: rewriting it to drop the obsolete time window can grow disk usage
+         * instead of shrinking it, since the delta still has to record the change. Page-level
+         * cleanup still reclaims whole pages regardless.
          */
         __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p in-memory page %s obsolete time window: time aggregate %s", (void *)ref, tag,
@@ -474,9 +469,14 @@ __checkpoint_cleanup_page_skip(
 
     /*
      * While we may have decided to skip the page, check if there is obsolete content that can be
-     * cleaned up.
+     * cleaned up. Always read an internal page for this: skipping it could also hide fully obsolete
+     * leaves further down that page-level cleanup would otherwise reach. A leaf page is only worth
+     * reading for its own obsolete time window when reconciliation would actually benefit from
+     * removing it: if the leaf reconciles to a delta rather than a full page, the rewrite can grow
+     * disk usage instead of shrinking it.
      */
-    if (*skipp && __sync_obsolete_tw_check(session, addr.ta)) {
+    if (*skipp && (F_ISSET(ref, WT_REF_FLAG_INTERNAL) || !WT_DELTA_LEAF_ENABLED(session)) &&
+      __sync_obsolete_tw_check(session, addr.ta)) {
         WT_STAT_CONN_DSRC_INCR(session, checkpoint_cleanup_pages_read_obsolete_tw);
         *skipp = false;
     }

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -56,6 +56,14 @@ __sync_obsolete_tw_check(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE ta)
     if (WT_TIME_AGGREGATE_HAS_STOP(&ta))
         return (false);
 
+    /*
+     * Disaggregated storage reconciliation can write a delta rather than a full page, so dirtying a
+     * page to strip its obsolete time window information can grow disk usage instead of shrinking
+     * it. Leave that content in place; page-level cleanup still reclaims whole pages.
+     */
+    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
+        return (false);
+
     /* Limit the activity to reduce the load. */
     if (__sync_obsolete_limit_reached(session))
         return (false);

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -166,14 +166,16 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
         /* Mark the obsolete page to evict soon. */
         __wt_evict_page_soon(session, ref);
         WT_STAT_CONN_DSRC_INCR(session, checkpoint_cleanup_pages_evict);
-    } else if (!WT_DELTA_LEAF_ENABLED(session) && __sync_obsolete_tw_check(session, newest_ta)) {
+    } else if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
+      __sync_obsolete_tw_check(session, newest_ta)) {
 
         /*
          * Dirty the page with an obsolete time window to let the page reconciliation remove all the
-         * obsolete time window information. Skip this when the page reconciles to a delta rather
-         * than a full page: rewriting it to drop the obsolete time window can grow disk usage
-         * instead of shrinking it, since the delta still has to record the change. Page-level
-         * cleanup still reclaims whole pages regardless.
+         * obsolete time window information. Skip this for disaggregated btrees: dirtying the page
+         * doesn't add any new update, so reconciliation's skip-write check in __rec_split_write
+         * (the !newer_updates_than_last_rec_used case) finds nothing newer than what's already
+         * durable and skips writing the page, leaving the obsolete time window on disk regardless.
+         * Page-level cleanup still reclaims whole pages.
          */
         __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p in-memory page %s obsolete time window: time aggregate %s", (void *)ref, tag,
@@ -472,11 +474,12 @@ __checkpoint_cleanup_page_skip(
      * cleaned up. This only ever matters for reaching a leaf with an obsolete time window that
      * isn't otherwise fully deleted: a ref only reaches this point with *skipp set for an internal
      * page when its own aggregate has no stop time point anywhere below it, so there is no
-     * page-level reclaim being missed here. Skip forcing the read when reconciliation wouldn't
-     * benefit from removing that time window: if the leaf reconciles to a delta rather than a full
-     * page, the rewrite can grow disk usage instead of shrinking it.
+     * page-level reclaim being missed here. Don't force the read for a disaggregated btree: there
+     * is no new update for reconciliation to write, so it skips the write entirely and the obsolete
+     * time window stays on disk regardless.
      */
-    if (*skipp && !WT_DELTA_LEAF_ENABLED(session) && __sync_obsolete_tw_check(session, addr.ta)) {
+    if (*skipp && !F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+      __sync_obsolete_tw_check(session, addr.ta)) {
         WT_STAT_CONN_DSRC_INCR(session, checkpoint_cleanup_pages_read_obsolete_tw);
         *skipp = false;
     }

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -469,14 +469,14 @@ __checkpoint_cleanup_page_skip(
 
     /*
      * While we may have decided to skip the page, check if there is obsolete content that can be
-     * cleaned up. Always read an internal page for this: skipping it could also hide fully obsolete
-     * leaves further down that page-level cleanup would otherwise reach. A leaf page is only worth
-     * reading for its own obsolete time window when reconciliation would actually benefit from
-     * removing it: if the leaf reconciles to a delta rather than a full page, the rewrite can grow
-     * disk usage instead of shrinking it.
+     * cleaned up. This only ever matters for reaching a leaf with an obsolete time window that
+     * isn't otherwise fully deleted: a ref only reaches this point with *skipp set for an internal
+     * page when its own aggregate has no stop time point anywhere below it, so there is no
+     * page-level reclaim being missed here. Skip forcing the read when reconciliation wouldn't
+     * benefit from removing that time window: if the leaf reconciles to a delta rather than a full
+     * page, the rewrite can grow disk usage instead of shrinking it.
      */
-    if (*skipp && (F_ISSET(ref, WT_REF_FLAG_INTERNAL) || !WT_DELTA_LEAF_ENABLED(session)) &&
-      __sync_obsolete_tw_check(session, addr.ta)) {
+    if (*skipp && !WT_DELTA_LEAF_ENABLED(session) && __sync_obsolete_tw_check(session, addr.ta)) {
         WT_STAT_CONN_DSRC_INCR(session, checkpoint_cleanup_pages_read_obsolete_tw);
         *skipp = false;
     }

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -172,8 +172,7 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
         /*
          * Dirty the page with an obsolete time window to let the page reconciliation remove all the
          * obsolete time window information. Skip this for disaggregated btrees: dirtying the page
-         * doesn't add any new update, so reconciliation's skip-write check in __rec_split_write
-         * (the !newer_updates_than_last_rec_used case) finds nothing newer than what's already
+         * doesn't add any new update, so reconciliation finds nothing newer than what's already
          * durable and skips writing the page, leaving the obsolete time window on disk regardless.
          * Page-level cleanup still reclaims whole pages.
          */

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1018,11 +1018,13 @@ __evict_review_obsolete_time_window(WT_SESSION_IMPL *session, WT_REF *ref)
         return (0);
 
     /*
-     * Disaggregated storage reconciliation can write a delta rather than a full page, so dirtying a
-     * page to strip its obsolete time window information can grow disk usage instead of shrinking
-     * it. Leave that content in place; page-level cleanup still reclaims whole pages.
+     * Dirtying a disaggregated leaf just to strip its obsolete time window doesn't add any new
+     * update, so reconciliation's skip-write check in __rec_split_write (the
+     * !newer_updates_than_last_rec_used case) finds nothing newer than what's already durable and
+     * skips writing the page, leaving the obsolete time window on disk regardless. Leave that
+     * content in place; page-level cleanup still reclaims whole pages.
      */
-    if (WT_DELTA_LEAF_ENABLED(session))
+    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
         return (0);
 
     /* We are only interested in clean pages. */

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1017,6 +1017,14 @@ __evict_review_obsolete_time_window(WT_SESSION_IMPL *session, WT_REF *ref)
     if (WT_PAGE_IS_INTERNAL(ref->page))
         return (0);
 
+    /*
+     * Disaggregated storage reconciliation can write a delta rather than a full page, so dirtying a
+     * page to strip its obsolete time window information can grow disk usage instead of shrinking
+     * it. Leave that content in place; page-level cleanup still reclaims whole pages.
+     */
+    if (WT_DELTA_LEAF_ENABLED(session))
+        return (0);
+
     /* We are only interested in clean pages. */
     if (__wt_page_is_modified(ref->page))
         return (0);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1019,10 +1019,9 @@ __evict_review_obsolete_time_window(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /*
      * Dirtying a disaggregated leaf just to strip its obsolete time window doesn't add any new
-     * update, so reconciliation's skip-write check in __rec_split_write (the
-     * !newer_updates_than_last_rec_used case) finds nothing newer than what's already durable and
-     * skips writing the page, leaving the obsolete time window on disk regardless. Leave that
-     * content in place; page-level cleanup still reclaims whole pages.
+     * update, so reconciliation finds nothing newer than what's already durable and skips writing
+     * the page, leaving the obsolete time window on disk regardless. Leave that content in place;
+     * page-level cleanup still reclaims whole pages.
      */
     if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
         return (0);

--- a/test/suite/test_cc07.py
+++ b/test/suite/test_cc07.py
@@ -26,11 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import wttest
 from test_cc01 import test_cc_base
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
 # Verify checkpoint cleanup removes the obsolete time window from the pages.
+@wttest.skip_for_hook("disagg", "checkpoint cleanup does not remove obsolete time windows for disaggregated tables")
 class test_cc07(test_cc_base):
     conn_config_common = 'cache_size=1GB,statistics=(all),statistics_log=(json,wait=1,on_close=true)'
 

--- a/test/suite/test_cc09.py
+++ b/test/suite/test_cc09.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 # Verify checkpoint cleanup reads pages from the disk to remove any obsolete time window information
 # present on the page.
 @wttest.skip_for_hook("tiered", "Checkpoint cleanup does not support tiered tables")
+@wttest.skip_for_hook("disagg", "checkpoint cleanup does not remove obsolete time windows for disaggregated tables")
 class test_cc09(test_cc_base):
     conn_config_common = 'statistics=(all),statistics_log=(json,wait=1,on_close=true),verbose=(checkpoint_cleanup:0)'
 

--- a/test/suite/test_eviction02.py
+++ b/test/suite/test_eviction02.py
@@ -26,11 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import wttest
 from eviction_util import eviction_util
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
 # Verify evicting a clean page removes any obsolete time window information present on the page.
+@wttest.skip_for_hook("disagg", "eviction does not remove obsolete time windows for disaggregated tables")
 class test_eviction02(eviction_util):
     conn_config_common = 'cache_size=10MB,statistics=(all),statistics_log=(json,wait=1,on_close=true)'
 

--- a/test/suite/test_eviction03.py
+++ b/test/suite/test_eviction03.py
@@ -31,8 +31,10 @@ from eviction_util import eviction_util
 from statistics import mean
 from suite_subprocess import suite_subprocess
 import wiredtiger
+import wttest
 
 # Verify the disk footprint is reduced after eviction has removed obsolete time window information.
+@wttest.skip_for_hook("disagg", "eviction does not remove obsolete time windows for disaggregated tables")
 class test_eviction03(eviction_util, suite_subprocess):
 
     def verify_dump_pages(self, uri):

--- a/test/suite/test_layered_checkpoint_cleanup02.py
+++ b/test/suite/test_layered_checkpoint_cleanup02.py
@@ -32,8 +32,9 @@ from wiredtiger import stat
 from wtscenario import make_scenarios
 
 # Checkpoint cleanup dirties a page with obsolete time window information so reconciliation can
-# strip it out. On disaggregated btrees reconciliation may write a delta instead of a full page,
-# so that rewrite can grow disk usage instead of shrinking it. Verify checkpoint cleanup no longer
+# strip it out. On a disaggregated btree, that dirty adds no new update, so reconciliation's
+# skip-write optimization finds nothing newer than what's already durable and writes nothing at
+# all -- the obsolete time window stays on disk regardless. Verify checkpoint cleanup no longer
 # reads or dirties pages for that reason on disaggregated btrees, while page-level cleanup
 # (fast-deleting a fully obsolete page) keeps working.
 @disagg_test_class

--- a/test/suite/test_layered_checkpoint_cleanup02.py
+++ b/test/suite/test_layered_checkpoint_cleanup02.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# Checkpoint cleanup dirties a page with obsolete time window information so reconciliation can
+# strip it out. On disaggregated btrees reconciliation may write a delta instead of a full page,
+# so that rewrite can grow disk usage instead of shrinking it. Verify checkpoint cleanup no longer
+# reads or dirties pages for that reason on disaggregated btrees, while page-level cleanup
+# (fast-deleting a fully obsolete page) keeps working.
+@disagg_test_class
+class test_layered_checkpoint_cleanup02(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all),disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    uri = 'table:test_layered_checkpoint_cleanup02'
+    # Small pages so a key range spans several whole pages, and so the tree has internal pages
+    # for checkpoint cleanup to walk through.
+    create_params = ('key_format=i,value_format=S,block_manager=disagg,log=(enabled=false),'
+      'allocation_size=512,leaf_page_max=512,internal_page_max=512,memory_page_max=4096')
+    nrows = 1000
+    value = 'a' * 50
+
+    def force_checkpoint_cleanup(self):
+        prev_success = self.get_stat(stat.conn.checkpoint_cleanup_success)
+        self.session.checkpoint('debug=(checkpoint_cleanup=true)')
+        self.assertStatGreaterSoon(stat.conn.checkpoint_cleanup_success, prev_success, timeout=30)
+
+    def evict_all(self):
+        # Evict every page to disk, a requirement for both fast-delete and checkpoint cleanup's
+        # obsolete time window checks on on-disk pages.
+        with wttest.open_cursor(
+          self.session, self.uri, config='debug=(release_evict)') as evict_cursor, \
+          self.transaction(rollback=True):
+            for k in range(1, self.nrows + 1):
+                evict_cursor.set_key(k)
+                evict_cursor.search()
+                evict_cursor.reset()
+
+    def test_obsolete_time_window_not_dirtied(self):
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.session.create(self.uri, self.create_params)
+        with wttest.open_cursor(self.session, self.uri) as cursor, \
+          self.transaction(commit_timestamp=10):
+            for k in range(1, self.nrows + 1):
+                cursor[k] = self.value
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.evict_all()
+
+        # Move the oldest timestamp forward so every start time point becomes globally visible:
+        # exactly the condition key-level cleanup would otherwise dirty pages for.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+
+        self.force_checkpoint_cleanup()
+
+        self.assertGreater(self.get_stat(stat.dsrc.checkpoint_cleanup_pages_visited, self.uri), 0)
+        self.assertEqual(
+          self.get_stat(stat.dsrc.checkpoint_cleanup_pages_read_obsolete_tw, self.uri), 0)
+        self.assertEqual(self.get_stat(stat.dsrc.checkpoint_cleanup_pages_obsolete_tw, self.uri), 0)
+
+    def test_fast_deleted_page_still_removed(self):
+        trunc_start, trunc_stop = 100, 300
+
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.session.create(self.uri, self.create_params)
+        with wttest.open_cursor(self.session, self.uri) as cursor, \
+          self.transaction(commit_timestamp=10):
+            for k in range(1, self.nrows + 1):
+                cursor[k] = self.value
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.evict_all()
+
+        with wttest.open_cursor(self.session, self.uri) as start_cursor, \
+          wttest.open_cursor(self.session, self.uri) as stop_cursor, \
+          self.transaction(commit_timestamp=20):
+            start_cursor.set_key(trunc_start)
+            stop_cursor.set_key(trunc_stop)
+            self.session.truncate(None, start_cursor, stop_cursor, None)
+        fast_deleted = self.get_stat(stat.dsrc.rec_page_delete_fast, self.uri)
+        self.assertGreater(fast_deleted, 0, "truncate did not fast-delete any pages")
+
+        removed_before = self.get_stat(stat.dsrc.checkpoint_cleanup_pages_removed, self.uri)
+
+        # Make the truncation globally visible and run checkpoint cleanup: page-level cleanup
+        # is unaffected by the disagg guard on key-level cleanup, so the fast-deleted pages are
+        # still reclaimed.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20) +
+          ',oldest_timestamp=' + self.timestamp_str(20))
+        self.force_checkpoint_cleanup()
+
+        self.assertGreaterEqual(
+          self.get_stat(stat.dsrc.checkpoint_cleanup_pages_removed, self.uri) - removed_before,
+          fast_deleted)


### PR DESCRIPTION
Checkpoint cleanup dirties a page with obsolete time window information so reconciliation can rewrite it without that content. On disaggregated btrees reconciliation may write a delta instead of a full page, so that rewrite writes new tombstones or start-time-point content into the delta rather than reclaiming space, and can grow disk usage instead of shrinking it. It also adds unnecessary write amplification against the underlying storage.

This adds a check in `__sync_obsolete_tw_check` that skips the obsolete-time-window path for disaggregated btrees. Page-level cleanup (fast-deleting a fully obsolete page) is unaffected, since it does not go through this check.

Added `test_layered_checkpoint_cleanup02.py`: one test populates a disaggregated table, advances the oldest timestamp so every key's start time point is globally visible, and confirms checkpoint cleanup neither reads nor dirties pages for that reason. A second test truncates a range to fast-delete several leaf pages and confirms checkpoint cleanup still reclaims them once the truncation is globally visible, showing page-level cleanup keeps working.