### PR TITLE
WT-15917 Remove redundant code related to increasing scrub eviction frequency for Disagg

### DIFF
--- a/src/evict/evict_thread.c
+++ b/src/evict/evict_thread.c
@@ -569,17 +569,13 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
     /*
      * Configure scrub - which reinstates clean equivalents of reconciled dirty pages. This is
      * useful because an evicted dirty page isn't necessarily a good proxy for knowing if the page
-     * will be accessed again soon. Be more aggressive about scrubbing in disaggregated storage
-     * because the cost of retrieving a recently reconciled page is higher in that configuration. In
-     * the local storage case scrub dirty pages and keep them in cache if we are less than half way
-     * to the clean, dirty and updates triggers.
+     * will be accessed again soon. Scrub dirty pages and keep them in cache if we are less than
+     * half way to the clean, dirty and updates triggers.
      *
      * There's an experimental flag WT_CACHE_PREFER_SCRUB_EVICTION that can be turned on to enable
      * scrub eviction as long as cache usage overall is under half way to the trigger limit.
      */
-    if (__wt_conn_is_disagg(session) && bytes_inuse < (uint64_t)(trigger * bytes_max) / 100)
-        LF_SET(WT_EVICT_CACHE_SCRUB);
-    else if (bytes_inuse < (uint64_t)((target + trigger) * bytes_max) / 200) {
+    if (bytes_inuse < (uint64_t)((target + trigger) * bytes_max) / 200) {
         if (F_ISSET_ATOMIC_32(
               &(conn->cache->cache_eviction_controls), WT_CACHE_PREFER_SCRUB_EVICTION)) {
             LF_SET(WT_EVICT_CACHE_SCRUB);


### PR DESCRIPTION
All dirty evictions in disagg are already forced to be scrub evictions, a page can't be evicted until it's materialized, so the disagg branch in __evict_update_work that widens the scrub window to the full trigger range is redundant.

This landed once in #12695 and was reverted in #12749 for a sys-perf regression, BF-40388: __wt_conn_is_disagg is connection-level, so the wider scrub window also applied to the local tables MongoDB disagg still kept on disk, where it wasn't wanted. Those are test-only now.

The removal is mechanical and the non-disagg path is unchanged, it previously fell through to the same condition, but this is a pure perf change that has regressed once before. Disagg perf patch: https://spruce.corp.mongodb.com/version/6a98f95ae6ea090007c74dcb, which doesn't
cover the original sys-perf task.
