### PR TITLE
WT-18560 Increase sweep-close wait timeout in test_layered_checkpoint08

### DIFF
--- a/test/suite/test_layered_checkpoint08.py
+++ b/test/suite/test_layered_checkpoint08.py
@@ -73,7 +73,7 @@ class test_layered_checkpoint08(checkpoint_util):
         # wait to fail fast with a clear error rather than spin until the task timeout if the sweep
         # never makes progress.
         self.assertStatGreaterSoon(wiredtiger.stat.conn.dh_sweep_expired_close, sweep_closes_before,
-            timeout=60, msg='sweep server did not close the idle table handle within 60 seconds')
+            timeout=120, msg='sweep server did not close the idle table handle within 120 seconds')
         self.pr(f"Dhandles closed by sweep: "
             f"{self.get_stat(wiredtiger.stat.conn.dh_sweep_expired_close) - sweep_closes_before}")
 


### PR DESCRIPTION
test_layered_checkpoint08 failed on unit-test-xsan-bucket18/ubuntu2004-asan waiting for the sweep server to close an idle table handle within 60 seconds. The test already had one flakiness fix (WT-17851) for polling the wrong stat; this time the counter itself just didn't move in time, consistent with sweep-server scheduling delays under ASAN rather than a logic bug in the sweep path.

test_layered_follower14 hit the same kind of wait on a sweep stat and was already bumped from 60 to 120 seconds. Apply the same margin to test_layered_checkpoint08's dh_sweep_expired_close wait.