### PR TITLE
WT-15584 Silence the addDuration RuntimeWarning in parallel test runs

### DIFF
--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -1224,6 +1224,10 @@ def runsuite(suite, parallel):
         warnings.filterwarnings(
             "ignore", category=RuntimeWarning,
             message="line buffering .* isn't supported in binary mode")
+        # Python 3.12+ reports test timing to the result; the one used in the forked children lacks that method.
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning,
+            message="TestResult has no addDuration method")
         suite_to_run = ConcurrentTestSuite(suite, fork_for_tests(parallel), wrap_result=wrap_result_for_tags)
     try:
         if WiredTigerTestCase._randomseed:


### PR DESCRIPTION
- Add a warnings filter in `runsuite()` for "TestResult has no addDuration method" next to the existing line-buffering filter so forked children inherit it.
- Python 3.12+ unittest calls `result.addDuration`. The vendored subunit result used by concurrencytest lacks it so every test emitted the warning under `run.py -j`. The durations are not used, no vendored code changes.