### PR TITLE
WT-18397 Use atomic accesses for the last checkpoint schema epoch

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1399,7 +1399,8 @@ __checkpoint_can_skip(WT_SESSION_IMPL *session, WT_CHECKPOINT_DB_CONFIG *ckpt_cf
     if (!conn->modified && ckpt_cfg->use_timestamp && last_ckpt_ts != WT_TS_NONE &&
       last_ckpt_ts == __wt_get_stable_timestamp(session) &&
       (stable_disagg_epoch == WT_SCHEMA_EPOCH_NONE ||
-        txn_global->last_ckpt_disaggregated_schema_epoch == stable_disagg_epoch)) {
+        __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_disaggregated_schema_epoch) ==
+          stable_disagg_epoch)) {
         ckpt_cfg->can_skip = true;
         return (0);
     }
@@ -2150,7 +2151,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * WT_CONNECTION.rollback_to_stable is an allowed operation.
      */
     if (ckpt_cfg.use_timestamp) {
-        conn->txn_global.last_ckpt_disaggregated_schema_epoch = ckpt_disagg_write_epoch;
+        __wt_atomic_store_uint64_release(
+          &conn->txn_global.last_ckpt_disaggregated_schema_epoch, ckpt_disagg_write_epoch);
         /*
          * MongoDB assumes the checkpoint timestamp will be initialized with WT_TS_NONE. In such
          * cases it queries the recovery timestamp to determine the last stable recovery timestamp.
@@ -2165,7 +2167,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
             ckpt_tmp_ts = conn->txn_global.recovery_timestamp;
         __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, ckpt_tmp_ts);
     } else {
-        conn->txn_global.last_ckpt_disaggregated_schema_epoch = WT_TS_NONE;
+        __wt_atomic_store_uint64_release(
+          &conn->txn_global.last_ckpt_disaggregated_schema_epoch, WT_SCHEMA_EPOCH_NONE);
         __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, WT_TS_NONE);
     }
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1394,6 +1394,7 @@ __checkpoint_can_skip(WT_SESSION_IMPL *session, WT_CHECKPOINT_DB_CONFIG *ckpt_cf
      * even without new committed data. A node with no live stable epoch carries the last written
      * epoch forward, so the epoch cannot have changed.
      */
+    /* Relaxed loads: the checkpoint lock held here also serializes every store. */
     last_ckpt_ts = __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_timestamp);
     stable_disagg_epoch = __wt_get_stable_disaggregated_schema_epoch(session);
     if (!conn->modified && ckpt_cfg->use_timestamp && last_ckpt_ts != WT_TS_NONE &&
@@ -2149,6 +2150,9 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * schema epoch, otherwise clear them. We clear the timestamp for a couple of reasons:
      * applications can query it and we don't want to lie, and we use it to decide if
      * WT_CONNECTION.rollback_to_stable is an allowed operation.
+     *
+     * The stores are release to pair with the acquire loads in sweep and query_timestamp; nothing
+     * in this process depends on the ordering, it keeps the two fields published consistently.
      */
     if (ckpt_cfg.use_timestamp) {
         __wt_atomic_store_uint64_release(
@@ -2160,8 +2164,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
          * timestamp. This should never be a problem, as checkpoint timestamp should never be less
          * than recovery timestamp. This could potentially avoid MongoDB making two calls to
          * determine last stable recovery timestamp.
-         *
-         * The store is release to pair with the acquire load in sweep.
          */
         if (ckpt_tmp_ts == WT_TS_NONE)
             ckpt_tmp_ts = conn->txn_global.recovery_timestamp;

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2150,12 +2150,9 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * schema epoch, otherwise clear them. We clear the timestamp for a couple of reasons:
      * applications can query it and we don't want to lie, and we use it to decide if
      * WT_CONNECTION.rollback_to_stable is an allowed operation.
-     *
-     * The stores are release to pair with the acquire loads in sweep and query_timestamp; nothing
-     * in this process depends on the ordering, it keeps the two fields published consistently.
      */
     if (ckpt_cfg.use_timestamp) {
-        __wt_atomic_store_uint64_release(
+        __wt_atomic_store_uint64_relaxed(
           &conn->txn_global.last_ckpt_disaggregated_schema_epoch, ckpt_disagg_write_epoch);
         /*
          * MongoDB assumes the checkpoint timestamp will be initialized with WT_TS_NONE. In such
@@ -2164,12 +2161,14 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
          * timestamp. This should never be a problem, as checkpoint timestamp should never be less
          * than recovery timestamp. This could potentially avoid MongoDB making two calls to
          * determine last stable recovery timestamp.
+         *
+         * The store is release to pair with the acquire load in sweep.
          */
         if (ckpt_tmp_ts == WT_TS_NONE)
             ckpt_tmp_ts = conn->txn_global.recovery_timestamp;
         __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, ckpt_tmp_ts);
     } else {
-        __wt_atomic_store_uint64_release(
+        __wt_atomic_store_uint64_relaxed(
           &conn->txn_global.last_ckpt_disaggregated_schema_epoch, WT_SCHEMA_EPOCH_NONE);
         __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, WT_TS_NONE);
     }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -283,7 +283,7 @@ __layered_create_missing_stable_tables_helper(WT_SESSION_IMPL *session)
         return (__layered_create_missing_stable_tables_legacy(session));
 
     last_ckpt_epoch =
-      __wt_atomic_load_uint64_acquire(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
+      __wt_atomic_load_uint64_relaxed(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
     WT_UNUSED(last_ckpt_epoch); /* Only read by the assertion below. */
 
     __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1648,7 +1648,8 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
       &conn->disaggregated_storage.last_checkpoint_timestamp, metadata->checkpoint_timestamp);
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
-    conn->txn_global.last_ckpt_disaggregated_schema_epoch = metadata->schema_epoch;
+    __wt_atomic_store_uint64_release(
+      &conn->txn_global.last_ckpt_disaggregated_schema_epoch, metadata->schema_epoch);
     /* Release store to pair with the acquire load in sweep. */
     __wt_atomic_store_uint64_release(
       &conn->txn_global.last_ckpt_timestamp, metadata->checkpoint_timestamp);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1648,9 +1648,9 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
       &conn->disaggregated_storage.last_checkpoint_timestamp, metadata->checkpoint_timestamp);
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
-    /* Release stores to pair with the acquire loads in sweep and query_timestamp. */
-    __wt_atomic_store_uint64_release(
+    __wt_atomic_store_uint64_relaxed(
       &conn->txn_global.last_ckpt_disaggregated_schema_epoch, metadata->schema_epoch);
+    /* Release store to pair with the acquire load in sweep. */
     __wt_atomic_store_uint64_release(
       &conn->txn_global.last_ckpt_timestamp, metadata->checkpoint_timestamp);
 

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1648,9 +1648,9 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
       &conn->disaggregated_storage.last_checkpoint_timestamp, metadata->checkpoint_timestamp);
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
+    /* Release stores to pair with the acquire loads in sweep and query_timestamp. */
     __wt_atomic_store_uint64_release(
       &conn->txn_global.last_ckpt_disaggregated_schema_epoch, metadata->schema_epoch);
-    /* Release store to pair with the acquire load in sweep. */
     __wt_atomic_store_uint64_release(
       &conn->txn_global.last_ckpt_timestamp, metadata->checkpoint_timestamp);
 

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -194,6 +194,10 @@ struct __wt_txn_global {
     wt_shared volatile uint64_t oldest_id;
 
     wt_shared wt_timestamp_t durable_timestamp;
+    /*
+     * All accesses are relaxed: the value never orders other memory. Writers and the in-engine
+     * readers hold the checkpoint lock, and query_timestamp only returns it.
+     */
     wt_shared wt_timestamp_t last_ckpt_disaggregated_schema_epoch;
     /*
      * Release-stored by checkpoint once its durable state is established, acquire-loaded by sweep

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -207,7 +207,7 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
     } else if (WT_CONFIG_LIT_MATCH("last_checkpoint", cval))
         ts = __wt_atomic_load_uint64_acquire(&txn_global->last_ckpt_timestamp);
     else if (WT_CONFIG_LIT_MATCH("last_disaggregated_schema_epoch", cval))
-        ts = __wt_atomic_load_uint64_acquire(&txn_global->last_ckpt_disaggregated_schema_epoch);
+        ts = __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_disaggregated_schema_epoch);
     else if (WT_CONFIG_LIT_MATCH("oldest_timestamp", cval) || WT_CONFIG_LIT_MATCH("oldest", cval))
         ts = __wt_get_oldest_timestamp(session);
     else if (WT_CONFIG_LIT_MATCH("oldest_reader", cval))


### PR DESCRIPTION
- Store `txn_global->last_ckpt_disaggregated_schema_epoch` with relaxed atomic ops.
- Relaxed is sufficient: the value never orders other memory, writers and the in-engine readers hold the checkpoint lock and `query_timestamp` only returns it. Documented at the field in `txn.h`.
- Fixes the TSan data race between the plain stores and the lock-free read in `query_timestamp`. `last_ckpt_timestamp` is unchanged.