### PR TITLE
WT-18359 Document why the layered ENOENT guards are reachable

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1216,8 +1216,10 @@ __clayered_ignore_missing_stable(WT_SESSION_IMPL *session, WTI_CLAYERED_ROLE rol
      * the step-down window is marked at handle open and never attempts this open, so any other miss
      * is a genuinely missing constituent and must be reported.
      *
-     * FIXME-WT-18359: Investigate whether this guard is reachable now that step_down_created skips
-     * opening the stable constituent for tables created during the step-down window.
+     * The step-down mark does not close this window: step-down clears it before publishing the
+     * follower role, so a cursor that read the mark as clear can still resolve the leader role and
+     * attempt the open.
+
      */
     return (role == WTI_CLAYERED_ROLE_LEADER &&
       !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -484,10 +484,10 @@ retry:
 
     /*
      * A reader races the role change across a step-up or step-down, so a leader can still find the
-     * stable constituent missing here.
-     *
-     * FIXME-WT-18359: Investigate whether this guard is reachable now that step_down_created routes
-     * tables without a stable constituent through the follower path above.
+     * stable constituent missing here. The role and the step-down mark are read above without a
+     * lock: step-down clears the mark before it publishes the follower role, and step-up publishes
+     * the leader role before it creates the stable tables a follower era left missing.
+
      */
     if (ret == ENOENT) {
         ret = 0;


### PR DESCRIPTION
Document why the layered ENOENT guards are reachable.

- Reachable via two role-transition races: step-down clears `WT_LAYERED_TABLE_STEP_DOWN_CREATED` before publishing the follower role while the stat cursor reads role then flag without a lock and step-up publishes the leader role under the checkpoint lock before creating the stable tables a follower era left missing.
- Comment-only, no functional change.
- Follow-up: in the step-up window a layered cursor can still surface ENOENT, since `__clayered_ignore_missing_stable` does not tolerate it for a leader.