### PR TITLE
WT-18333 Make the layered step-down-created mark an atomic bool

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1680,9 +1680,15 @@ __disagg_mark_btrees_readonly_and_outdated_then_step_down(WT_SESSION_IMPL *sessi
         if (WT_IS_HS(dhandle))
             continue;
 
-        /* Clear the mark on tables created during the step-down window. */
+        /*
+         * Tables created during the step-down window get a stable constituent on step-up, so clear
+         * the mark that makes cursors skip the stable open. Must stay ahead of the release store of
+         * the follower role below: readers resolve the role first, so observing the follower role
+         * guarantees they observe this store.
+         */
         if (dhandle->type == WT_DHANDLE_TYPE_LAYERED) {
-            F_CLR((WT_LAYERED_TABLE *)dhandle, WT_LAYERED_TABLE_STEP_DOWN_CREATED);
+            __wt_atomic_store_bool_relaxed(
+              &((WT_LAYERED_TABLE *)dhandle)->step_down_created, false);
             continue;
         }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -428,7 +428,7 @@ __clayered_enter_flags(
      * by contract.
      */
     if (role == WTI_CLAYERED_ROLE_FOLLOWER || session->txn->stepdown_ts_set ||
-      F_ISSET((WT_LAYERED_TABLE *)clayered->dhandle, WT_LAYERED_TABLE_STEP_DOWN_CREATED) ||
+      __wt_atomic_load_bool_relaxed(&((WT_LAYERED_TABLE *)clayered->dhandle)->step_down_created) ||
       mode == WTI_CLAYERED_MODE_LARGEST_KEY)
         LF_SET(CLAYERED_ENTER_OPEN_INGEST);
 
@@ -1216,9 +1216,8 @@ __clayered_ignore_missing_stable(WT_SESSION_IMPL *session, WTI_CLAYERED_ROLE rol
      * the step-down window is marked at handle open and never attempts this open, so any other miss
      * is a genuinely missing constituent and must be reported.
      *
-     * FIXME-WT-18359: Investigate whether this guard is reachable now that
-     * WT_LAYERED_TABLE_STEP_DOWN_CREATED skips opening the stable constituent for tables created
-     * during the step-down window.
+     * FIXME-WT-18359: Investigate whether this guard is reachable now that step_down_created skips
+     * opening the stable constituent for tables created during the step-down window.
      */
     return (role == WTI_CLAYERED_ROLE_LEADER &&
       !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
@@ -1273,7 +1272,8 @@ __clayered_update_stable(WTI_CURSOR_LAYERED *clayered, uint32_t flags, WTI_CLAYE
 
     if (clayered->stable_cursor == NULL) {
         /* Open stable the first time if needed, unless the constituent does not exist yet. */
-        if (!F_ISSET((WT_LAYERED_TABLE *)clayered->dhandle, WT_LAYERED_TABLE_STEP_DOWN_CREATED) &&
+        if (!__wt_atomic_load_bool_relaxed(
+              &((WT_LAYERED_TABLE *)clayered->dhandle)->step_down_created) &&
           (role == WTI_CLAYERED_ROLE_LEADER || !LF_ISSET(CLAYERED_ENTER_SKIP_STABLE)))
             WT_RET(__clayered_open_stable_first(clayered, role, conn_lsn));
     } else if (LF_ISSET(CLAYERED_ENTER_ROLE_CHANGE) ||
@@ -2457,7 +2457,7 @@ __clayered_lookup_lazy_stable_open(WTI_CLAYERED_OP *op)
      * stable constituent at all, not because it is waiting on a checkpoint: opening as a follower
      * would refuse the bind against the leader-era snapshot.
      */
-    if (F_ISSET((WT_LAYERED_TABLE *)clayered->dhandle, WT_LAYERED_TABLE_STEP_DOWN_CREATED))
+    if (__wt_atomic_load_bool_relaxed(&((WT_LAYERED_TABLE *)clayered->dhandle)->step_down_created))
         return (0);
 
     WT_RET(__clayered_open_stable_first(clayered, WTI_CLAYERED_ROLE_FOLLOWER,

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -437,7 +437,7 @@ retry:
      * constituent until a later step-up creates one, so it reports the same way a follower does.
      */
     if (!__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader) ||
-      F_ISSET(layered, WT_LAYERED_TABLE_STEP_DOWN_CREATED)) {
+      __wt_atomic_load_bool_relaxed(&layered->step_down_created)) {
         /*
          * Neither case has the stable's pages resident in the local cache, so its non-walk stats
          * are ~0 - except the block size, which we read from the checkpoint metadata directly since
@@ -486,9 +486,8 @@ retry:
      * A reader races the role change across a step-up or step-down, so a leader can still find the
      * stable constituent missing here.
      *
-     * FIXME-WT-18359: Investigate whether this guard is reachable now that
-     * WT_LAYERED_TABLE_STEP_DOWN_CREATED routes tables without a stable constituent through the
-     * follower path above.
+     * FIXME-WT-18359: Investigate whether this guard is reachable now that step_down_created routes
+     * tables without a stable constituent through the follower path above.
      */
     if (ret == ENOENT) {
         ret = 0;

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -129,9 +129,19 @@ struct __wt_layered_table {
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_LAYERED_TABLE_OPEN 0x1u
-#define WT_LAYERED_TABLE_STEP_DOWN_CREATED 0x2u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
+    /* These flags are only modified while the handle is held exclusively, at open or close. */
     uint8_t flags;
+
+    /*
+     * Created while the step-down timestamp was set, so there is no stable constituent. Relaxed
+     * order suffices: the set happens before the handle is published, and the clear precedes
+     * step-down's release store of the follower role, so a cursor that resolved its role with the
+     * acquire load has already seen the clear. A cursor that still holds the leader role may see
+     * the clear early; its stable open then fails under the schema lock and
+     * __clayered_ignore_missing_stable tolerates the miss.
+     */
+    wt_shared bool step_down_created;
 };
 
 /* Holds metadata entry name and the associated config string. */

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -753,7 +753,7 @@ __wt_schema_open_layered(WT_SESSION_IMPL *session)
       __wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_timestamp) != WT_TS_NONE) {
         WT_RET_NOTFOUND_OK(ret = __wt_metadata_search(session, layered->stable_uri, &stable_value));
         if (ret == WT_NOTFOUND)
-            F_SET(layered, WT_LAYERED_TABLE_STEP_DOWN_CREATED);
+            __wt_atomic_store_bool_relaxed(&layered->step_down_created, true);
         __wt_free(session, stable_value);
     }
 


### PR DESCRIPTION
- Replace `WT_LAYERED_TABLE_STEP_DOWN_CREATED` in the plain `flags` word of `WT_LAYERED_TABLE` with `wt_shared bool step_down_created`, accessed with relaxed atomic load/store at the set, clear, read sites.
- Relaxed order suffices: the set precedes handle publication, the clear precedes the release store of the follower role and a stale-leader reader's failed stable open is tolerated under the schema lock.
- Fixes a formal data race reported by TSan. No behaviour change.