### PR TITLE
WT-18335 Skip the lazy stable open on a step-down-created leader table

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2417,13 +2417,22 @@ err:
 /*
  * __clayered_lookup_lazy_stable_open --
  *     Open the stable constituent an operation deferred at enter time, and hand it to the
- *     operation. The operation stays without a stable cursor if the follower has no checkpoint.
+ *     operation. The operation stays without a stable cursor if the follower has no checkpoint or
+ *     the table was created inside the step-down window.
  */
 static int
 __clayered_lookup_lazy_stable_open(WTI_CLAYERED_OP *op)
 {
     WTI_CURSOR_LAYERED *clayered = op->clayered;
     WT_SESSION_IMPL *session = CUR2S(clayered);
+
+    /*
+     * A leader's table created inside the step-down window deferred the open because it has no
+     * stable constituent at all, not because it is waiting on a checkpoint: opening as a follower
+     * would refuse the bind against the leader-era snapshot.
+     */
+    if (F_ISSET((WT_LAYERED_TABLE *)clayered->dhandle, WT_LAYERED_TABLE_STEP_DOWN_CREATED))
+        return (0);
 
     WT_RET(__clayered_open_stable_first(clayered, WTI_CLAYERED_ROLE_FOLLOWER,
       __wt_atomic_load_uint64_acquire(
@@ -3823,6 +3832,8 @@ __clayered_modify_try_ingest(
     if (ret == WT_NOTFOUND) {
         if (op->stable == NULL)
             WT_RET(__clayered_lookup_lazy_stable_open(op));
+        WT_ASSERT_ALWAYS(session, op->stable != NULL,
+          "ingest modify evicted the key, but there is no stable constituent to hold it");
         WT_RET_NOTFOUND_OK(ret = __clayered_lookup_constituent(op, op->stable, value));
         WT_ASSERT_ALWAYS(
           session, ret != WT_NOTFOUND, "ingest modify evicted the key, now it should be in stable");

--- a/test/suite/test_layered_async_stepdown13.py
+++ b/test/suite/test_layered_async_stepdown13.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_async_stepdown13.py
+#    A table created inside the step-down window has no stable constituent. Once the leader has
+#    completed a checkpoint, a lookup that misses in ingest must still report not found rather than
+#    attempt a follower-style stable open, which the leader-era snapshot would refuse.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from helper_layered_stepdown import LayeredStepdownMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_async_stepdown13(LayeredStepdownMixin, wttest.WiredTigerTestCase):
+    test_name = __qualname__
+
+    conn_config = 'precise_checkpoint=true,disaggregated=(role="leader")'
+    table_config = 'key_format=S,value_format=S'
+    uri = f'layered:{test_name}'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def create_window_table_after_checkpoint(self):
+        self.set_global_ts(1, 10)
+        self.session.checkpoint()
+        self.set_step_down_ts(20)
+        self.session.create(self.uri, self.table_config)
+        self.assertFalse(self.stable_constituent_exists(self.conn, self.uri))
+
+    def test_search_miss_is_not_found(self):
+        self.create_window_table_after_checkpoint()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.session.begin_transaction()
+        cursor.set_key('missing')
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+
+        # A present key is still found through the ingest constituent.
+        self.session.begin_transaction()
+        cursor['present'] = 'value'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        self.session.begin_transaction()
+        cursor.set_key('present')
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), 'value')
+        cursor.set_key('missing')
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+        cursor.close()
+
+    def test_modify_miss_is_not_found(self):
+        self.create_window_table_after_checkpoint()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.session.begin_transaction()
+        cursor.set_key('missing')
+        self.assertEqual(cursor.modify([wiredtiger.Modify('x', 0, 1)]), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+        cursor.close()


### PR DESCRIPTION
- `__clayered_lookup_lazy_stable_open`returns with no stable cursor when the table carries `WT_LAYERED_TABLE_STEP_DOWN_CREATED`: such a table has no stable constituent, so the follower-style deferred open must not run.
- Previously, once the leader had completed a checkpoint, that open hit the role-change bind check against the leader-era snapshot and a plain search or modify miss returned WT_ROLLBACK instead of WT_NOTFOUND.
- `__clayered_modify_try_ingest` asserts the stable cursor is present after the lazy open instead of dereferencing NULL; the path is not reachable for a table with no stable constituent.
- Add `test_layered_async_stepdown13`: search and modify misses on a table created while the step-down timestamp is set return WT_NOTFOUND.
- Merge order: the new flag read uses plain `F_ISSET`; if this lands after WT-18333 which moves the flag to `flags_atomic`, it must become `F_ISSET_ATOMIC_8`.