### PR TITLE
WT-14788 Triage test_util entries in the disagg hook fail list

### DIFF
--- a/test/suite/fail_lists/hook_disagg.fail
+++ b/test/suite/fail_lists/hook_disagg.fail
@@ -29,14 +29,7 @@ test_shared_cache01.py
 test_stat01.py
 test_stat_log02.py
 test_sweep05
-test_util01.py
-test_util02.py
-test_util04.py
-test_util07.py
-test_util09.py
-test_util11.py
-test_util12.py
-test_util13.py
-test_util14.py
-test_util15.py
-test_util17.py
+test_util01.py  # runWt rewrites table: URIs to layered: only for verify
+test_util07.py  # runWt rewrites table: URIs to layered: only for verify
+test_util11.py  # runWt rewrites table: URIs to layered: only for verify; wt list shows file:WiredTigerShared.wt_stable where the test expects empty output
+test_util17.py  # FIXME: WT-16918 hook_disagg tableExists() always returns False


### PR DESCRIPTION
- Remove the `test/suite/fail_lists/hook_disagg.fail` entries for test_util02/04/09/12/13/14/15: every class in those files already carries `@wttest.skip_for_hook("disagg", ...)`, so the lines were redundant.
- Annotate the remaining test_util01/07/11 entries: `wt dump`, `read` and `list` are supported in disagg mode but `runWt` in `test/suite/helpers/suite_subprocess.py` rewrites `table:` URIs to `layered:` only for `verify`; test_util11 also expects `wt list` to print nothing where the shared metadata file appears.
- Annotate test_util17 with FIXME WT-16918: the disagg hook's `tableExists()` always returns False.
- Caveat: test_util01/07/11 stay fail-listed pending a harness ticket for `runWt` URI rewriting; test_util17 is tracked by WT-16918.