### PR TITLE
WT-18503 Force block_manager=disagg on the create-time stable config

### DIFF
--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1228,8 +1228,12 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
     /* Build the stable constituent configuration for a later step-up. */
     stable_cfg[1] = disagg_config->data;
 
-    /* Disable logging on the stable table to ensure we have timestamps. */
-    stable_cfg[3] = "log=(enabled=false)";
+    /*
+     * Disable logging on the stable table to ensure we have timestamps. Force block_manager=disagg:
+     * a legacy step-up derives a missing stable constituent from the ingest metadata, cannot
+     * recover the user's value and forces disagg, so the create-time metadata must match.
+     */
+    stable_cfg[3] = "block_manager=disagg,log=(enabled=false)";
     WT_ERR(__wt_config_merge(session, stable_cfg, NULL, &constituent_cfg));
 
     /*

--- a/test/suite/test_layered_schema31.py
+++ b/test/suite/test_layered_schema31.py
@@ -45,7 +45,6 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         "allocation_size=512B,"
         "block_allocation=first,"
         "block_compressor=snappy,"
-        "block_manager=disagg,"
         "checksum=unencrypted,"
         "dictionary=100,"
         "disaggregated=(storage_tier=cold),"
@@ -81,18 +80,33 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         ),
     ]
 
+    block_manager_scenarios = [
+        ("block_manager_disagg", {"block_manager": "disagg"}),
+        ("block_manager_default", {"block_manager": "default"}),
+    ]
+
     disagg_storages = gen_disagg_storages(disagg_only=True)
-    scenarios = make_scenarios(disagg_storages, uri_scenarios)
+    scenarios = make_scenarios(
+        disagg_storages, uri_scenarios, block_manager_scenarios
+    )
+
+    # Marks the ingest metadata so a stable configuration derived from it is
+    # recognizable.
+    ingest_marker = "app_metadata=ingest_only"
 
     def conn_extensions(self, extlist):
         self.add_scenario_config()
         extlist.extension("compressors", "snappy")
         return self.disagg_conn_extensions(extlist)
 
-    def create_on_follower_then_step_up(self, config, use_schema_epochs=True):
+    def table_config(self):
+        """The table configuration for this scenario."""
+        return f"{self.config},block_manager={self.block_manager}"
+
+    def create_on_follower_then_step_up(self, use_schema_epochs=True):
         """
-        Create the table in the follower role, then step up to create the
-        missing stable table.
+        Create the table in the follower role, mark its ingest metadata, then
+        step up to create the missing stable table.
         """
         self.step_down()
 
@@ -100,10 +114,13 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
             self.set_stable_epoch(1)
 
         # A follower create leaves the stable table missing until step-up.
-        self.session.create(self.uri, config)
+        self.session.create(self.uri, self.table_config())
 
         if use_schema_epochs:
             self.publish(self.uri, epoch=5)
+
+        ingest_uri = "file:" + self.uri.split(":", 1)[1] + ".wt_ingest"
+        self.session.alter(ingest_uri, self.ingest_marker)
 
         self.step_up()
 
@@ -113,48 +130,39 @@ class test_layered_schema31(WiredTigerTestCase, DisaggSchemaEpochMixin):
         with open_cursor(self.session, "metadata:create") as cursor:
             return cursor[stable_uri]
 
-    def check_step_up_stable_config(self, config):
+    def check_step_up_stable_config(self, derived_from_ingest):
         """
-        Check that step-up creates the stable table with the expected
-        configuration.
+        Check that step-up creates the stable table with the leader's
+        configuration, carrying the ingest marker only when the configuration
+        was derived from ingest metadata.
         """
         # Get the config produced when the leader creates the stable table.
         leader_table_uri = self.uri + "_leader"
-        self.session.create(leader_table_uri, config)
+        self.session.create(leader_table_uri, self.table_config())
         expected_config = self.read_stable_config(leader_table_uri)
 
-        # Compare it with the config of the stable table created at step-up.
         step_up_config = self.read_stable_config(self.uri)
+        if derived_from_ingest:
+            self.assertIn(self.ingest_marker, step_up_config)
+            step_up_config = step_up_config.replace(
+                self.ingest_marker, "app_metadata="
+            )
+        else:
+            self.assertNotIn(self.ingest_marker, step_up_config)
         self.assertEqual(step_up_config, expected_config)
 
     def test_schema_epoch_step_up_matches_leader_config(self):
         """
-        Verify that schema epoch step-up matches the leader's stable
-        configuration.
+        Verify that schema epoch step-up replays the create-time stable
+        configuration rather than deriving it from ingest metadata.
         """
-        self.create_on_follower_then_step_up(self.config)
-        self.check_step_up_stable_config(self.config)
+        self.create_on_follower_then_step_up()
+        self.check_step_up_stable_config(derived_from_ingest=False)
 
     def test_legacy_step_up_derives_config_from_ingest(self):
         """
         Verify that legacy step-up derives the stable configuration from ingest
-        metadata.
+        metadata and still matches the leader's configuration.
         """
-        self.create_on_follower_then_step_up(
-            self.config, use_schema_epochs=False
-        )
-        self.check_step_up_stable_config(self.config)
-
-    def test_schema_epoch_step_up_does_not_derive_from_ingest(self):
-        """
-        Verify that schema epoch step-up does not derive the stable
-        configuration from ingest metadata.
-        """
-        # Deriving the configuration from ingest metadata forces
-        # block_manager=disagg. If block_manager=default is found after
-        # step-up, it proves the ingest-derived path was not used.
-        table_config = self.config.replace(
-            "block_manager=disagg", "block_manager=default"
-        )
-        self.create_on_follower_then_step_up(table_config)
-        self.check_step_up_stable_config(table_config)
+        self.create_on_follower_then_step_up(use_schema_epochs=False)
+        self.check_step_up_stable_config(derived_from_ingest=True)

--- a/test/suite/test_layered_tombstone_modify.py
+++ b/test/suite/test_layered_tombstone_modify.py
@@ -323,8 +323,6 @@ class test_layered_tombstone_modify(wttest.WiredTigerTestCase):
 
     def test_modify_namespace_transitions_survive_stepup_drain(self):
         """Step up after follower modifies; the drain moves every ingest version to stable."""
-        self.checkpoint_to_follower(1)
-
         for key, case in enumerate(self.modify_cases, 1):
             self.write_value(self.follow, key, case.base_value, commit_ts=2)
             self.apply_modify(self.follow, key, case.modifications, commit_ts=3)


### PR DESCRIPTION
- `__create_layered` now sets `block_manager=disagg` on the stable constituent's configuration. The legacy step-up path (`__layered_stable_config_from_ingest`) derives a missing stable constituent from ingest metadata which always records `block_manager=default`, so it cannot recover the user's value and forces `disagg`; the create-time metadata and the schema-epoch replay now produce the same value and the checkpoint pick-up metadata check no longer panics after a step-up rebuilt a table created since the last checkpoint.
- test_layered_tombstone_modify.py: drop the leading `checkpoint_to_follower(1)` from the step-up drain test so it exercises the legacy rebuild path directly.
- test_layered_schema31.py: make `block_manager` (disagg/default) a scenario dimension and mark the follower's ingest metadata before step-up, so the test distinguishes a replayed create-time configuration from one derived from ingest metadata while asserting both match the leader's.
- Compatibility: tables created before this change without a user-supplied `block_manager` record `default` in local and shared metadata; a legacy step-up rebuilding such a table still produces `disagg` and still trips the diagnostic pick-up check, as before. Not applicable to mongod tables which always pass `block_manager=disagg`.
