### PR TITLE
WT-17827 layered cursor after failed remove

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3799,10 +3799,6 @@ __clayered_modify_try_ingest(
      * A tombstone is a special value in the ingest table, so it cannot be used as a base value for
      * a modify operation. Similarly, a delete-encoded value alters the original value and also
      * cannot serve as the base value for a modify. In these cases, perform a full update instead.
-     *
-     * FIXME-WT-17827: a lookup returns WT_NOTFOUND for a deleted key, so the tombstone case is only
-     * reachable if the modify skips the lookup on an already-positioned cursor. Revisit whether
-     * that can happen.
      */
     if (__wt_clayered_deleted(&c_ingest->value) ||
       __clayered_value_in_tombstone_namespace(&c_ingest->value, false /* decode */)) {

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3402,18 +3402,31 @@ __clayered_remove(WT_CURSOR *cursor)
      * landed on.
      */
     WT_ERR(__cursor_needkey(cursor));
-    WT_ERR(__clayered_remove_int(&op, &cursor->key, positioned));
+    ret = __clayered_remove_int(&op, &cursor->key, positioned);
 
-    /*
-     * If the cursor was positioned, it stays positioned with a key but no value, otherwise, there's
-     * no position, key or value. This isn't just cosmetic, without a reset, iteration on this
-     * cursor won't start at the beginning/end of the table.
-     */
-    F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-    if (positioned)
-        F_SET(cursor, WT_CURSTD_KEY_INT);
-    else
+    if (ret == 0) {
+        /*
+         * If the cursor was positioned, it stays positioned with a key but no value, otherwise,
+         * there's no position, key or value. This isn't just cosmetic, without a reset, iteration
+         * on this cursor won't start at the beginning/end of the table.
+         */
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+        if (positioned)
+            F_SET(cursor, WT_CURSTD_KEY_INT);
+        else
+            WT_TRET(__clayered_reset_cursors(clayered, false));
+    } else {
+        /*
+         * A failed remove loses the position but keeps an application key, as a file cursor does,
+         * so a following traversal starts from the beginning/end of the table. A positioned
+         * cursor's key was localized above only for the remove and goes with the position.
+         */
+        if (positioned)
+            F_CLR(cursor, WT_CURSTD_KEY_SET);
+        F_CLR(cursor, WT_CURSTD_VALUE_SET);
         WT_TRET(__clayered_reset_cursors(clayered, false));
+    }
+    WT_ERR(ret);
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_remove);
 
 err:

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3402,34 +3402,30 @@ __clayered_remove(WT_CURSOR *cursor)
      * landed on.
      */
     WT_ERR(__cursor_needkey(cursor));
-    ret = __clayered_remove_int(&op, &cursor->key, positioned);
+    WT_ERR(__clayered_remove_int(&op, &cursor->key, positioned));
 
-    if (ret == 0) {
+    /*
+     * If the cursor was positioned, it stays positioned with a key but no value, otherwise, there's
+     * no position, key or value.
+     */
+    F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+    if (positioned)
+        F_SET(cursor, WT_CURSTD_KEY_INT);
+    else
+        WT_TRET(__clayered_reset_cursors(clayered, false));
+    WT_STAT_CONN_DSRC_INCR(session, layered_curs_remove);
+
+err:
+    if (ret != 0) {
         /*
-         * If the cursor was positioned, it stays positioned with a key but no value, otherwise,
-         * there's no position, key or value. This isn't just cosmetic, without a reset, iteration
-         * on this cursor won't start at the beginning/end of the table.
-         */
-        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-        if (positioned)
-            F_SET(cursor, WT_CURSTD_KEY_INT);
-        else
-            WT_TRET(__clayered_reset_cursors(clayered, false));
-    } else {
-        /*
-         * A failed remove loses the position but keeps an application key, as a file cursor does,
-         * so a following traversal starts from the beginning/end of the table. A positioned
-         * cursor's key was localized above only for the remove and goes with the position.
+         * A failed remove loses the position, as with a file cursor: a cursor that started
+         * positioned ends with no key, one that started unpositioned keeps its application key.
          */
         if (positioned)
             F_CLR(cursor, WT_CURSTD_KEY_SET);
         F_CLR(cursor, WT_CURSTD_VALUE_SET);
         WT_TRET(__clayered_reset_cursors(clayered, false));
     }
-    WT_ERR(ret);
-    WT_STAT_CONN_DSRC_INCR(session, layered_curs_remove);
-
-err:
     __clayered_leave(clayered);
     CURSOR_UPDATE_API_END(session, ret);
     return (ret);
@@ -3799,6 +3795,10 @@ __clayered_modify_try_ingest(
      * A tombstone is a special value in the ingest table, so it cannot be used as a base value for
      * a modify operation. Similarly, a delete-encoded value alters the original value and also
      * cannot serve as the base value for a modify. In these cases, perform a full update instead.
+     *
+     * FIXME-WT-18563: a lookup returns WT_NOTFOUND for a deleted key, so the tombstone case is only
+     * reachable if the modify skips the lookup on an already-positioned cursor. Revisit whether
+     * that can happen.
      */
     if (__wt_clayered_deleted(&c_ingest->value) ||
       __clayered_value_in_tombstone_namespace(&c_ingest->value, false /* decode */)) {

--- a/test/suite/test_layered_cursor28.py
+++ b/test/suite/test_layered_cursor28.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_layered_cursor28.py
+#
+# A cursor operating on a just-removed key must behave the same on a layered table as on a plain
+# table. The expected values in every check below are what the plain cursor reports.
+
+import re
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+KEYS = [10, 20, 30, 40, 50]
+K = 30
+MISSING = 25
+VAL = 'X'
+
+# The observed effect of one op from the deleted slot, plus a following next() or prev().
+class OpResult:
+    def __init__(self):
+        self.op_return_code = None      # the op's return code, or 'EINVAL'/'ENOTSUP'/'NOTFOUND'
+        self.op_key = None              # key the cursor is left on after the op, None if unpositioned
+        self.follow_return_code = None  # return code of the following next() or prev()
+        self.follow_key = None          # key the following next() or prev() lands on
+
+    def __repr__(self):
+        return ('OpResult(op_return_code=%r, op_key=%r, follow_return_code=%r, follow_key=%r)'
+                % (self.op_return_code, self.op_key, self.follow_return_code, self.follow_key))
+
+def _seed_layered(t, uri):
+    c = t.session.open_cursor(uri)
+    for i, k in enumerate(KEYS, 1):
+        t.session.begin_transaction()
+        c[k] = 'orig%d' % k
+        t.session.commit_transaction('commit_timestamp=' + t.timestamp_str(i))
+    c.close()
+
+# Open a transaction, position on K and remove it; return the cursor on the deleted slot.
+def _deleted_cursor(t, sess, uri):
+    sess.begin_transaction()
+    c = sess.open_cursor(uri)
+    c.set_key(K)
+    t.assertEqual(c.search(), 0)
+    t.assertEqual(c.remove(), 0)
+    return c
+
+# Each setup creates and populates the table once and returns the session to operate through.
+def setup_plain(t):
+    uri = 'table:test_layered_cursor28'
+    t.session.create(uri, 'key_format=i,value_format=S')
+    c = t.session.open_cursor(uri)
+    for k in KEYS:
+        c[k] = 'orig%d' % k
+    c.close()
+    return t.session, uri
+
+def setup_leader(t):
+    uri = 'layered:test_layered_cursor28'
+    t.session.create(uri, 'key_format=i,value_format=S')
+    _seed_layered(t, uri)
+    return t.session, uri
+
+def setup_follower(t):
+    uri = 'layered:test_layered_cursor28'
+    t.session.create(uri, 'key_format=i,value_format=S')
+    # Leader writes land in the stable table; the follower's remove writes an ingest tombstone.
+    _seed_layered(t, uri)
+    t.session.checkpoint()
+    t.conn_follow = t.wiredtiger_open('follower',
+        t.extensionsConfig() + t.conn_base_config + 'disaggregated=(role="follower")')
+    t.session_follow = t.conn_follow.open_session('')
+    t.ignoreStdoutPattern('Picking up the same checkpoint again')
+    t.disagg_advance_checkpoint(t.conn_follow)
+    return t.session_follow, uri
+
+_variants = [
+    ('plain',    dict(setup=setup_plain)),
+    ('leader',   dict(setup=setup_leader)),
+    ('follower', dict(setup=setup_follower)),
+]
+
+@disagg_test_class
+class test_layered_cursor28(wttest.WiredTigerTestCase):
+    conn_base_config = ',create,cache_size=1GB,statistics=(all),'
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, _variants)
+
+    conn_follow = None
+    active = None
+    uri = None
+
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def tearDown(self):
+        if self.conn_follow is not None:
+            self.conn_follow.close()
+            self.conn_follow = None
+        super().tearDown()
+
+    def return_code(self, fn):
+        try:
+            r = fn()
+        except wiredtiger.WiredTigerError as e:
+            m = str(e)
+            if wiredtiger.wiredtiger_strerror(wiredtiger.WT_NOTFOUND) in m:
+                return 'NOTFOUND'
+            if 'Invalid argument' in m:
+                return 'EINVAL'
+            if 'Operation not supported' in m:
+                return 'ENOTSUP'
+            return 'ERR:' + m.strip()
+        return 'NOTFOUND' if r == wiredtiger.WT_NOTFOUND else r
+
+    def get_key_safe(self, c):
+        try:
+            return c.get_key()
+        except wiredtiger.WiredTigerError:
+            return None
+
+    def run_op(self, op, follow='next', unpositioned=False):
+        # These ops legitimately log to stderr off a deleted or unpositioned slot.
+        self.captureerr.setIgnorePattern(re.compile(
+            'requires key be set|requires value be set'
+            '|only permitted in a running transaction|not supported in implicit transactions'))
+
+        # Every run works in a transaction that is rolled back, so one setup serves a whole test.
+        if self.active is None:
+            self.active, self.uri = self.setup(self)
+        c = _deleted_cursor(self, self.active, self.uri)
+        if unpositioned:
+            c.reset()
+
+        result = OpResult()
+        result.op_return_code = self.return_code(lambda: op(c))
+        result.op_key = self.get_key_safe(c)
+
+        # A following next() or prev() shows whether an op that failed on the deleted key left the
+        # cursor truly unpositioned.
+        result.follow_return_code = self.return_code(lambda: getattr(c, follow)())
+        result.follow_key = self.get_key_safe(c)
+
+        self.active.rollback_transaction()
+        c.close()
+        return result
+
+    # Assert every field separately, so a failure shows exactly which one diverged.
+    def check(self, result, op_return_code, op_key, follow_return_code, follow_key):
+        self.assertEqual(result.op_return_code, op_return_code, 'op_return_code')
+        self.assertEqual(result.op_key, op_key, 'op_key')
+        self.assertEqual(result.follow_return_code, follow_return_code, 'follow_return_code')
+        self.assertEqual(result.follow_key, follow_key, 'follow_key')
+
+    def test_get_key(self):
+        result = self.run_op(lambda c: c.get_key())
+        self.check(result, op_return_code=30, op_key=30, follow_return_code=0, follow_key=40)
+
+    def test_get_value(self):
+        result = self.run_op(lambda c: c.get_value())
+        self.check(result, op_return_code='EINVAL', op_key=30, follow_return_code=0, follow_key=40)
+
+    def test_next(self):
+        result = self.run_op(lambda c: c.next())
+        self.check(result, op_return_code=0, op_key=40, follow_return_code=0, follow_key=50)
+
+    def test_prev(self):
+        result = self.run_op(lambda c: c.prev())
+        self.check(result, op_return_code=0, op_key=20, follow_return_code=0, follow_key=40)
+
+    def test_search(self):
+        result = self.run_op(lambda c: c.set_key(K) or c.search())
+        self.check(result, op_return_code='NOTFOUND', op_key=30, follow_return_code=0, follow_key=10)
+
+    def test_search_near(self):
+        result = self.run_op(lambda c: c.set_key(K) or c.search_near())
+        self.check(result, op_return_code=1, op_key=40, follow_return_code=0, follow_key=50)
+
+    def test_reset(self):
+        result = self.run_op(lambda c: c.reset())
+        self.check(result, op_return_code=0, op_key=None, follow_return_code=0, follow_key=10)
+
+    def test_largest_key(self):
+        result = self.run_op(lambda c: c.largest_key())
+        self.check(result, op_return_code=0, op_key=50, follow_return_code=0, follow_key=10)
+
+    def test_update(self):
+        result = self.run_op(lambda c: c.set_value(VAL) or c.update())
+        self.check(result, op_return_code=0, op_key=30, follow_return_code=0, follow_key=40)
+
+    def test_insert(self):
+        result = self.run_op(lambda c: c.set_key(K) or c.set_value(VAL) or c.insert())
+        self.check(result, op_return_code=0, op_key=None, follow_return_code=0, follow_key=10)
+
+    def test_reserve(self):
+        result = self.run_op(lambda c: c.reserve())
+        self.check(result, op_return_code='NOTFOUND', op_key=30, follow_return_code=0, follow_key=10)
+
+    def test_remove(self):
+        result = self.run_op(lambda c: c.remove())
+        self.check(result, op_return_code='NOTFOUND', op_key=None, follow_return_code=0, follow_key=10)
+        result = self.run_op(lambda c: c.remove(), follow='prev')
+        self.check(result, op_return_code='NOTFOUND', op_key=None, follow_return_code=0, follow_key=50)
+
+    # Removing by key from an unpositioned cursor keeps the application key on failure.
+    def test_remove_by_key_missing(self):
+        op = lambda c: c.set_key(MISSING) or c.remove()
+        result = self.run_op(op, unpositioned=True)
+        self.check(result, op_return_code='NOTFOUND', op_key=MISSING, follow_return_code=0, follow_key=10)
+        result = self.run_op(op, follow='prev', unpositioned=True)
+        self.check(result, op_return_code='NOTFOUND', op_key=MISSING, follow_return_code=0, follow_key=50)
+
+    def test_remove_by_key_removed(self):
+        op = lambda c: c.set_key(K) or c.remove()
+        result = self.run_op(op, unpositioned=True)
+        self.check(result, op_return_code='NOTFOUND', op_key=K, follow_return_code=0, follow_key=10)
+        result = self.run_op(op, follow='prev', unpositioned=True)
+        self.check(result, op_return_code='NOTFOUND', op_key=K, follow_return_code=0, follow_key=50)
+
+    def test_modify(self):
+        result = self.run_op(lambda c: c.modify([wiredtiger.Modify(VAL, 0, 0)]))
+        self.check(result, op_return_code='NOTFOUND', op_key=30, follow_return_code=0, follow_key=10)

--- a/test/suite/test_layered_cursor28.py
+++ b/test/suite/test_layered_cursor28.py
@@ -53,76 +53,74 @@ class OpResult:
         return ('OpResult(op_return_code=%r, op_key=%r, follow_return_code=%r, follow_key=%r)'
                 % (self.op_return_code, self.op_key, self.follow_return_code, self.follow_key))
 
-def _seed_layered(t, uri):
-    c = t.session.open_cursor(uri)
-    for i, k in enumerate(KEYS, 1):
-        t.session.begin_transaction()
-        c[k] = 'orig%d' % k
-        t.session.commit_transaction('commit_timestamp=' + t.timestamp_str(i))
-    c.close()
-
-# Open a transaction, position on K and remove it; return the cursor on the deleted slot.
-def _deleted_cursor(t, sess, uri):
-    sess.begin_transaction()
-    c = sess.open_cursor(uri)
-    c.set_key(K)
-    t.assertEqual(c.search(), 0)
-    t.assertEqual(c.remove(), 0)
-    return c
-
-# Each setup creates and populates the table once and returns the session to operate through.
-def setup_plain(t):
-    uri = 'table:test_layered_cursor28'
-    t.session.create(uri, 'key_format=i,value_format=S')
-    c = t.session.open_cursor(uri)
-    for k in KEYS:
-        c[k] = 'orig%d' % k
-    c.close()
-    return t.session, uri
-
-def setup_leader(t):
-    uri = 'layered:test_layered_cursor28'
-    t.session.create(uri, 'key_format=i,value_format=S')
-    _seed_layered(t, uri)
-    return t.session, uri
-
-def setup_follower(t):
-    uri = 'layered:test_layered_cursor28'
-    t.session.create(uri, 'key_format=i,value_format=S')
-    # Leader writes land in the stable table; the follower's remove writes an ingest tombstone.
-    _seed_layered(t, uri)
-    t.session.checkpoint()
-    t.conn_follow = t.wiredtiger_open('follower',
-        t.extensionsConfig() + t.conn_base_config + 'disaggregated=(role="follower")')
-    t.session_follow = t.conn_follow.open_session('')
-    t.ignoreStdoutPattern('Picking up the same checkpoint again')
-    t.disagg_advance_checkpoint(t.conn_follow)
-    return t.session_follow, uri
-
-_variants = [
-    ('plain',    dict(setup=setup_plain)),
-    ('leader',   dict(setup=setup_leader)),
-    ('follower', dict(setup=setup_follower)),
-]
-
 @disagg_test_class
 class test_layered_cursor28(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    plain_uri = f'table:{test_name}'
+    layered_uri = f'layered:{test_name}'
+
     conn_base_config = ',create,cache_size=1GB,statistics=(all),'
     disagg_storages = gen_disagg_storages(disagg_only=True)
-    scenarios = make_scenarios(disagg_storages, _variants)
+    variants = [
+        ('plain', dict(variant='plain')),
+        ('leader', dict(variant='leader')),
+        ('follower', dict(variant='follower')),
+    ]
+    scenarios = make_scenarios(disagg_storages, variants)
 
     conn_follow = None
-    active = None
-    uri = None
 
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    # Create and populate the table, and pick the session the test operates through. Every op runs
+    # in a transaction that is rolled back, so the table stays as seeded here.
+    def setUp(self):
+        super().setUp()
+        if self.variant == 'plain':
+            self.uri = self.plain_uri
+            self.active = self.session
+            self.session.create(self.uri, 'key_format=i,value_format=S')
+            self.seed()
+        elif self.variant == 'leader':
+            self.uri = self.layered_uri
+            self.active = self.session
+            self.session.create(self.uri, 'key_format=i,value_format=S')
+            self.seed()
+        else:
+            # Leader writes land in the stable table; the follower's remove writes an ingest tombstone.
+            self.uri = self.layered_uri
+            self.session.create(self.uri, 'key_format=i,value_format=S')
+            self.seed()
+            self.session.checkpoint()
+            self.conn_follow = self.wiredtiger_open('follower',
+                self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+            self.active = self.conn_follow.open_session('')
+            self.ignoreStdoutPattern('Picking up the same checkpoint again')
+            self.disagg_advance_checkpoint(self.conn_follow)
 
     def tearDown(self):
         if self.conn_follow is not None:
             self.conn_follow.close()
             self.conn_follow = None
         super().tearDown()
+
+    def seed(self):
+        c = self.session.open_cursor(self.uri)
+        for i, k in enumerate(KEYS, 1):
+            self.session.begin_transaction()
+            c[k] = 'orig%d' % k
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(i))
+        c.close()
+
+    # Open a transaction, position on K and remove it; return the cursor on the deleted slot.
+    def deleted_cursor(self):
+        self.active.begin_transaction()
+        c = self.active.open_cursor(self.uri)
+        c.set_key(K)
+        self.assertEqual(c.search(), 0)
+        self.assertEqual(c.remove(), 0)
+        return c
 
     def return_code(self, fn):
         try:
@@ -145,15 +143,10 @@ class test_layered_cursor28(wttest.WiredTigerTestCase):
             return None
 
     def run_op(self, op, follow='next', unpositioned=False):
-        # These ops legitimately log to stderr off a deleted or unpositioned slot.
-        self.captureerr.setIgnorePattern(re.compile(
-            'requires key be set|requires value be set'
-            '|only permitted in a running transaction|not supported in implicit transactions'))
+        # get_value() and update() legitimately log to stderr off a deleted slot.
+        self.captureerr.setIgnorePattern(re.compile('requires key be set|requires value be set'))
 
-        # Every run works in a transaction that is rolled back, so one setup serves a whole test.
-        if self.active is None:
-            self.active, self.uri = self.setup(self)
-        c = _deleted_cursor(self, self.active, self.uri)
+        c = self.deleted_cursor()
         if unpositioned:
             c.reset()
 

--- a/test/suite/test_layered_cursor_stress.py
+++ b/test/suite/test_layered_cursor_stress.py
@@ -83,10 +83,7 @@ def write_allowed(txn):
 
 # The default Weights() below are a balanced starting point; the tuned per-theme mixes live in
 # WORKLOAD_PROFILES and are what the suite actually runs.
-# FIXME-WT-17827: the follower layered cursor mishandles operating on a just-removed cursor -- a repeat
-# remove of an already-deleted key leaves a stale position (a later iterate then diverges) and modify on
-# a deleted slot aborts. So op_pos_remove resets the dsc cursor in that case (see there) and there is no
-# modify op; revisit both once WT-17827 lands.
+# FIXME-WT-XXXX: there is no modify op; add one, including modify on a just-removed slot.
 # FIXME-WT-17825: add prepared transactions once fixed (prepare misbehaves on the follower layered cursor).
 
 @dataclass(frozen=True)

--- a/test/suite/test_layered_cursor_stress.py
+++ b/test/suite/test_layered_cursor_stress.py
@@ -83,7 +83,7 @@ def write_allowed(txn):
 
 # The default Weights() below are a balanced starting point; the tuned per-theme mixes live in
 # WORKLOAD_PROFILES and are what the suite actually runs.
-# FIXME-WT-XXXX: there is no modify op; add one, including modify on a just-removed slot.
+# FIXME-WT-18563: there is no modify op; add one, including modify on a just-removed slot.
 # FIXME-WT-17825: add prepared transactions once fixed (prepare misbehaves on the follower layered cursor).
 
 @dataclass(frozen=True)
@@ -114,7 +114,7 @@ class RemoveKeyWeights:
 @dataclass(frozen=True)
 class BulkRemoveWeights:
     # scen_bulk_remove deletes a contiguous 40/80/100% range either by per-key remove or range truncate.
-    # FIXME-WT-XXXX: truncate over-truncates on the follower layered table -- a key re-inserted inside a
+    # FIXME-WT-17841: truncate over-truncates on the follower layered table -- a key re-inserted inside a
     # prior truncate range is lost once it drains to stable. Disabled (weight 0) until fixed; raise it then.
     remove: float = 100
     truncate: float = 0

--- a/test/suite/test_layered_cursor_stress.py
+++ b/test/suite/test_layered_cursor_stress.py
@@ -588,16 +588,13 @@ class test_layered_cursor_stress(wttest.WiredTigerTestCase):
 
     def op_pos_remove(self, nodes, rnd, trace):
         # The long-lived position can be stale, so it cannot satisfy the blind-remove guarantee.
-        # Use the stable-aware remove cursors and reset the shared positioned cursors afterward.
+        # Use the stable-aware remove cursors; the shared cursors stay positioned on the removed key.
         key = self.state.cur_pos
         if key not in self.state.py_table:
             return
         trace.log('pos_remove %r' % key)
         self._remove_txn(nodes, lambda c: (c.set_key(key), c.remove())[-1], 'pos_remove')
         self.state.py_table.pop(key, None)
-        for n in nodes:
-            n.reset_all()
-        self.state.cur_pos = None
 
     def op_txn_begin(self, nodes, rnd, trace):
         # No txn open -> begin one (flavor by the txn_mode weights); a txn open -> end it.


### PR DESCRIPTION
- `__clayered_remove`: when the remove fails, drop the position and reset the constituent cursors so a following `next()`/`prev()` restarts from the table boundary instead of resuming past the removed key. An unpositioned cursor keeps its application key, as a file cursor does.
- Add `test/suite/test_layered_cursor28.py`: every cursor operation on a just-removed key, plus remove by key from an unpositioned cursor, compared across plain, leader and follower tables with the plain cursor's results as the expected values.