### PR TITLE
WT-16737 Run disagg timestamp_abort stress tasks in mainline variants

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1167,6 +1167,20 @@ functions:
         ${PREPARE_TEST_ENV}
 
         ../../../../test/evergreen/schema_abort_predictable.sh ${times} ${truncated_log_args|}
+  "timestamp abort disagg":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/cmake_build/test/csuite/timestamp_abort"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        ${additional_san_vars}
+        for i in $(seq ${times|1}); do
+          echo Iteration $i/${times}
+          ./test_timestamp_abort -G -s
+        done
   "upload artifact":
     - command: archive.targz_pack
       type: setup
@@ -1877,6 +1891,15 @@ variables:
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=20000 runs.ops=100000 ops.truncate=0
           times: 10
+
+  - &timestamp-abort-test-disagg
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "timestamp abort disagg"
+        vars:
+          times: 50
 
 #######################################
 #               Tasks                 #
@@ -5399,6 +5422,13 @@ tasks:
   - <<: *format-stress-test-disagg-multi-pull-request
     name: format-stress-test-disagg-multi-pull-request
     tags: ["pull_request"]
+
+  - <<: *timestamp-abort-test-disagg
+    name: timestamp-abort-test-disagg-1
+    tags: ["stress-test-disagg"]
+  - <<: *timestamp-abort-test-disagg
+    name: timestamp-abort-test-disagg-2
+    tags: ["stress-test-disagg"]
 
   - name: format-stress-test-disagg-follower-pull-request
     tags: ["pull_request"]

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -564,21 +564,6 @@ functions:
           ./test_schema_disagg_abort -b "$build_dir" ${schema_args} -T 12 -u 64 -t 300
         done
 
-  "timestamp abort disagg":
-    command: shell.exec
-    params:
-      working_dir: "wiredtiger/cmake_build/test/csuite/timestamp_abort"
-      shell: bash
-      script: |
-        set -o errexit
-        set -o verbose
-        ${PREPARE_TEST_ENV}
-        ${additional_san_vars}
-        for i in $(seq ${times|1}); do
-          echo Iteration $i/${times}
-          ./test_timestamp_abort -G -s
-        done
-
 #######################################
 #               Variables             #
 #######################################
@@ -664,15 +649,6 @@ variables:
             runs.predictable_replay=1 runs.rows=50000:200000 runs.ops=500000:2000000
           times: 10
 
-  - &timestamp-abort-test-disagg
-    depends_on:
-        - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "timestamp abort disagg"
-        vars:
-          times: 50
-
   - &schema-disagg-abort-smoke-test-disagg
     depends_on:
         - name: compile
@@ -754,13 +730,6 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-snapshot
     name: format-stress-test-disagg-snapshot-2
-    tags: ["stress-test-disagg-fail"]
-
-  - <<: *timestamp-abort-test-disagg
-    name: timestamp-abort-test-disagg-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *timestamp-abort-test-disagg
-    name: timestamp-abort-test-disagg-2
     tags: ["stress-test-disagg-fail"]
 
   # The schema-disagg-abort matrix. The kill variants cover their graceful counterparts, since a


### PR DESCRIPTION
- Add the `timestamp abort disagg` function, the `timestamp-abort-test-disagg` task template and the `timestamp-abort-test-disagg-1/2` tasks to `test/evergreen.yml`, tagged `stress-test-disagg`.
- Remove the same function, template and tasks from `test/evergreen_disagg.yml`, so they no longer run in the failure-expected wiredtiger-disagg project.
- Caveat: the shared tag also schedules the tasks on the ubuntu2004-asan and amazon2023-arm64-asan variants, where they have not run before.