### PR TITLE
WT-16838 Add a software cache-warming pipeline to B-tree row search and cursor reopen

### DIFF
--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -104,19 +104,19 @@ __row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, u
 {
     if (limit > WT_ROW_SEARCH_WARM_MIN_2_AHEAD) {
         uint32_t indx_left_far, indx_left_near, indx_right_far, indx_right_near;
-        uint32_t quarter, right_base, right_limit;
+        uint32_t half, quarter, right_base, right_limit;
 
         /*
          * Two iterations ahead, the search will have narrowed to the left half of the current range
          * or the right half; refine each half the same way this iteration narrowed the whole range,
-         * to get two candidate slots on each side. indx_left_near is an approximation (off by at
-         * most one slot); the other three are exact.
+         * to get two exact candidate slots on each side.
          */
+        half = limit >> 1;
         quarter = limit >> 2;
         right_base = indx + 1;
         right_limit = (limit - 1) >> 1;
         indx_left_far = base + (quarter >> 1);
-        indx_left_near = base + quarter + 1 + ((quarter - 1) >> 1);
+        indx_left_near = base + quarter + 1 + ((half - 1) >> 2);
         indx_right_near = right_base + (right_limit >> 2);
         indx_right_far = right_base + (right_limit >> 1) + 1 + ((right_limit - 1) >> 2);
 

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -8,6 +8,109 @@
 
 #include "wt_internal.h"
 
+/*
+ * Depth of the leaf-page binary-search cache-warming pipeline. Level 1 warms a candidate's key
+ * data one iteration ahead; level 2 also warms pg_row entries two iterations ahead, so the level-1
+ * warm has time to land before it's needed.
+ */
+#define WT_ROW_SEARCH_WARM_DEPTH 2
+
+/*
+ * __row_search_warm_ref --
+ *     Warm the cache line for a WT_REF entry on an internal page.
+ */
+static WT_INLINE void
+__row_search_warm_ref(WT_PAGE_INDEX *pindex, uint32_t slot)
+{
+    if (slot < pindex->entries)
+        __builtin_prefetch(pindex->index[slot], 0, 3);
+}
+
+/*
+ * __row_search_warm_row_entry --
+ *     Warm the cache line for a pg_row struct entry on a leaf page.
+ */
+static WT_INLINE void
+__row_search_warm_row_entry(WT_PAGE *page, uint32_t slot)
+{
+    if (slot < page->entries)
+        __builtin_prefetch(&page->pg_row[slot], 0, 3);
+}
+
+/*
+ * __row_search_warm_key --
+ *     Warm the cache line for an encoded key's data for a leaf page's pg_row entry.
+ */
+static WT_INLINE void
+__row_search_warm_key(WT_PAGE *page, uint32_t slot)
+{
+    WT_ROW *rip;
+    uintptr_t v;
+
+    if (slot >= page->entries)
+        return;
+
+    rip = page->pg_row + slot;
+    v = (uintptr_t)WT_ROW_KEY_COPY(rip);
+    switch (v & WT_KEY_FLAG_BITS) {
+    case WT_K_FLAG:
+        __builtin_prefetch(
+          WT_PAGE_REF_OFFSET(page, WT_K_DECODE_KEY_CELL_OFFSET(v) + WT_K_DECODE_KEY_OFFSET(v)), 0,
+          3);
+        break;
+    case WT_KV_FLAG:
+        __builtin_prefetch(
+          WT_PAGE_REF_OFFSET(page, WT_KV_DECODE_KEY_CELL_OFFSET(v) + WT_KV_DECODE_KEY_OFFSET(v)), 0,
+          3);
+        break;
+    default:
+        /* On-page cells and instantiated keys need unpacking; not worth warming. */
+        break;
+    }
+}
+
+/*
+ * __row_search_warm_int_candidates --
+ *     Warm the WT_REF entries a binary search on an internal page is likely to visit one
+ *     iteration ahead.
+ */
+static WT_INLINE void
+__row_search_warm_int_candidates(
+  WT_PAGE_INDEX *pindex, uint32_t base, uint32_t indx, uint32_t limit)
+{
+    if (limit > 2) {
+        __row_search_warm_ref(pindex, base + (limit >> 2));
+        __row_search_warm_ref(pindex, indx + 1 + ((limit - 1) >> 2));
+    }
+}
+
+/*
+ * __row_search_warm_leaf_candidates --
+ *     Warm the pg_row entries and key data a binary search on a leaf page is likely to visit one
+ *     and two iterations ahead.
+ */
+static WT_INLINE void
+__row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, uint32_t limit)
+{
+#if WT_ROW_SEARCH_WARM_DEPTH >= 2
+    if (limit > 6) {
+        uint32_t pf_lq, pf_rb, pf_rh;
+
+        pf_lq = limit >> 2;
+        pf_rb = indx + 1;
+        pf_rh = (limit - 1) >> 1;
+        __row_search_warm_row_entry(page, base + (pf_lq >> 1));
+        __row_search_warm_row_entry(page, base + pf_lq + 1 + ((pf_lq - 1) >> 1));
+        __row_search_warm_row_entry(page, pf_rb + (pf_rh >> 2));
+        __row_search_warm_row_entry(page, pf_rb + (pf_rh >> 1) + 1 + ((pf_rh - 1) >> 2));
+    }
+#endif
+    if (limit > 2) {
+        __row_search_warm_key(page, base + (limit >> 2));
+        __row_search_warm_key(page, indx + 1 + ((limit - 1) >> 2));
+    }
+}
+
 static WT_INLINE int __validate_next_stack(
   WT_SESSION_IMPL *session, WT_INSERT *next_stack[WT_SKIP_MAXDEPTH], WT_ITEM *srch_key);
 
@@ -475,6 +578,9 @@ restart:
         if (collator == NULL && srch_key->size <= WT_COMPARE_SHORT_MAXLEN)
             for (; limit != 0; limit >>= 1) {
                 indx = base + (limit >> 1);
+
+                __row_search_warm_int_candidates(pindex, base, indx, limit);
+
                 descent = pindex->index[indx];
                 __wt_ref_key(page, descent, &item->data, &item->size);
 
@@ -506,6 +612,9 @@ restart:
 
             for (; limit != 0; limit >>= 1) {
                 indx = base + (limit >> 1);
+
+                __row_search_warm_int_candidates(pindex, base, indx, limit);
+
                 descent = pindex->index[indx];
                 __wt_ref_key(page, descent, &item->data, &item->size);
 
@@ -523,6 +632,9 @@ restart:
         } else
             for (; limit != 0; limit >>= 1) {
                 indx = base + (limit >> 1);
+
+                __row_search_warm_int_candidates(pindex, base, indx, limit);
+
                 descent = pindex->index[indx];
                 __wt_ref_key(page, descent, &item->data, &item->size);
 
@@ -638,6 +750,9 @@ leaf_only:
         for (; limit != 0; limit >>= 1) {
             indx = base + (limit >> 1);
             rip = page->pg_row + indx;
+
+            __row_search_warm_leaf_candidates(page, base, indx, limit);
+
             WT_ERR(__wt_row_leaf_key(session, page, rip, item, true));
 
             cmp = __wt_lex_compare_short(srch_key, item);
@@ -669,6 +784,9 @@ leaf_only:
         for (; limit != 0; limit >>= 1) {
             indx = base + (limit >> 1);
             rip = page->pg_row + indx;
+
+            __row_search_warm_leaf_candidates(page, base, indx, limit);
+
             WT_ERR(__wt_row_leaf_key(session, page, rip, item, true));
 
             match = WT_MIN(skiplow, skiphigh);
@@ -686,6 +804,9 @@ leaf_only:
         for (; limit != 0; limit >>= 1) {
             indx = base + (limit >> 1);
             rip = page->pg_row + indx;
+
+            __row_search_warm_leaf_candidates(page, base, indx, limit);
+
             WT_ERR(__wt_row_leaf_key(session, page, rip, item, true));
 
             WT_ERR(__wt_compare(session, collator, srch_key, item, &cmp));

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -9,6 +9,21 @@
 #include "wt_internal.h"
 
 /*
+ * The binary-search cache-warming pipeline below is built on __builtin_prefetch, which GCC and
+ * Clang support and other compilers, notably MSVC, do not. The two functions the search loops
+ * further down this file call compile to a no-op on an unsupported compiler instead.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+
+/*
+ * Minimum remaining candidates (the binary search loops' "limit") below which warming ahead isn't
+ * worth it: with this few candidates left, the "ahead" slots are too close to the one the loop is
+ * about to examine to matter.
+ */
+#define WT_ROW_SEARCH_WARM_MIN_1_AHEAD 2
+#define WT_ROW_SEARCH_WARM_MIN_2_AHEAD 6
+
+/*
  * __row_search_warm_ref --
  *     Warm the cache line for a WT_REF entry on an internal page.
  */
@@ -71,7 +86,7 @@ static WT_INLINE void
 __row_search_warm_int_candidates(
   WT_PAGE_INDEX *pindex, uint32_t base, uint32_t indx, uint32_t limit)
 {
-    if (limit > 2) {
+    if (limit > WT_ROW_SEARCH_WARM_MIN_1_AHEAD) {
         __row_search_warm_ref(pindex, base + (limit >> 2));
         __row_search_warm_ref(pindex, indx + 1 + ((limit - 1) >> 2));
     }
@@ -86,22 +101,67 @@ __row_search_warm_int_candidates(
 static WT_INLINE void
 __row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, uint32_t limit)
 {
-    if (limit > 6) {
-        uint32_t pf_lq, pf_rb, pf_rh;
+    if (limit > WT_ROW_SEARCH_WARM_MIN_2_AHEAD) {
+        uint32_t indx_left_far, indx_left_near, indx_right_far, indx_right_near;
+        uint32_t quarter, right_base, right_limit;
 
-        pf_lq = limit >> 2;
-        pf_rb = indx + 1;
-        pf_rh = (limit - 1) >> 1;
-        __row_search_warm_row_entry(page, base + (pf_lq >> 1));
-        __row_search_warm_row_entry(page, base + pf_lq + 1 + ((pf_lq - 1) >> 1));
-        __row_search_warm_row_entry(page, pf_rb + (pf_rh >> 2));
-        __row_search_warm_row_entry(page, pf_rb + (pf_rh >> 1) + 1 + ((pf_rh - 1) >> 2));
+        /*
+         * Two iterations ahead, the search will have narrowed to the left half of the current
+         * range or the right half; refine each half the same way this iteration narrowed the
+         * whole range, to get two candidate slots on each side. indx_left_near is an
+         * approximation (off by at most one slot); the other three are exact.
+         */
+        quarter = limit >> 2;
+        right_base = indx + 1;
+        right_limit = (limit - 1) >> 1;
+        indx_left_far = base + (quarter >> 1);
+        indx_left_near = base + quarter + 1 + ((quarter - 1) >> 1);
+        indx_right_near = right_base + (right_limit >> 2);
+        indx_right_far = right_base + (right_limit >> 1) + 1 + ((right_limit - 1) >> 2);
+
+        __row_search_warm_row_entry(page, indx_left_far);
+        __row_search_warm_row_entry(page, indx_left_near);
+        __row_search_warm_row_entry(page, indx_right_near);
+        __row_search_warm_row_entry(page, indx_right_far);
     }
-    if (limit > 2) {
+    if (limit > WT_ROW_SEARCH_WARM_MIN_1_AHEAD) {
         __row_search_warm_key(page, base + (limit >> 2));
         __row_search_warm_key(page, indx + 1 + ((limit - 1) >> 2));
     }
 }
+
+#else /* !(defined(__GNUC__) || defined(__clang__)) */
+
+/*
+ * __row_search_warm_int_candidates --
+ *     No cache-prefetch intrinsic on this compiler; the warm is purely advisory, so skipping it
+ *     costs a few avoidable cache misses, never correctness.
+ */
+static WT_INLINE void
+__row_search_warm_int_candidates(
+  WT_PAGE_INDEX *pindex, uint32_t base, uint32_t indx, uint32_t limit)
+{
+    WT_UNUSED(pindex);
+    WT_UNUSED(base);
+    WT_UNUSED(indx);
+    WT_UNUSED(limit);
+}
+
+/*
+ * __row_search_warm_leaf_candidates --
+ *     No cache-prefetch intrinsic on this compiler; the warm is purely advisory, so skipping it
+ *     costs a few avoidable cache misses, never correctness.
+ */
+static WT_INLINE void
+__row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, uint32_t limit)
+{
+    WT_UNUSED(page);
+    WT_UNUSED(base);
+    WT_UNUSED(indx);
+    WT_UNUSED(limit);
+}
+
+#endif
 
 static WT_INLINE int __validate_next_stack(
   WT_SESSION_IMPL *session, WT_INSERT *next_stack[WT_SKIP_MAXDEPTH], WT_ITEM *srch_key);

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -10,10 +10,11 @@
 
 /*
  * The binary-search cache-warming pipeline below is built on __builtin_prefetch, which GCC and
- * Clang support and other compilers, notably MSVC, do not. The two functions the search loops
- * further down this file call compile to a no-op on an unsupported compiler instead.
+ * Clang support (Clang defines the same GNU compatibility macro this file checks for) and other
+ * compilers, notably MSVC, do not. The two functions the search loops further down this file call
+ * are only defined here, and only called there, on a supported compiler.
  */
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
 
 /*
  * Minimum remaining candidates (the binary search loops' "limit") below which warming ahead isn't
@@ -106,10 +107,10 @@ __row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, u
         uint32_t quarter, right_base, right_limit;
 
         /*
-         * Two iterations ahead, the search will have narrowed to the left half of the current
-         * range or the right half; refine each half the same way this iteration narrowed the
-         * whole range, to get two candidate slots on each side. indx_left_near is an
-         * approximation (off by at most one slot); the other three are exact.
+         * Two iterations ahead, the search will have narrowed to the left half of the current range
+         * or the right half; refine each half the same way this iteration narrowed the whole range,
+         * to get two candidate slots on each side. indx_left_near is an approximation (off by at
+         * most one slot); the other three are exact.
          */
         quarter = limit >> 2;
         right_base = indx + 1;
@@ -128,37 +129,6 @@ __row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, u
         __row_search_warm_key(page, base + (limit >> 2));
         __row_search_warm_key(page, indx + 1 + ((limit - 1) >> 2));
     }
-}
-
-#else /* !(defined(__GNUC__) || defined(__clang__)) */
-
-/*
- * __row_search_warm_int_candidates --
- *     No cache-prefetch intrinsic on this compiler; the warm is purely advisory, so skipping it
- *     costs a few avoidable cache misses, never correctness.
- */
-static WT_INLINE void
-__row_search_warm_int_candidates(
-  WT_PAGE_INDEX *pindex, uint32_t base, uint32_t indx, uint32_t limit)
-{
-    WT_UNUSED(pindex);
-    WT_UNUSED(base);
-    WT_UNUSED(indx);
-    WT_UNUSED(limit);
-}
-
-/*
- * __row_search_warm_leaf_candidates --
- *     No cache-prefetch intrinsic on this compiler; the warm is purely advisory, so skipping it
- *     costs a few avoidable cache misses, never correctness.
- */
-static WT_INLINE void
-__row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, uint32_t limit)
-{
-    WT_UNUSED(page);
-    WT_UNUSED(base);
-    WT_UNUSED(indx);
-    WT_UNUSED(limit);
 }
 
 #endif
@@ -631,7 +601,9 @@ restart:
             for (; limit != 0; limit >>= 1) {
                 indx = base + (limit >> 1);
 
+#if defined(__GNUC__)
                 __row_search_warm_int_candidates(pindex, base, indx, limit);
+#endif
 
                 descent = pindex->index[indx];
                 __wt_ref_key(page, descent, &item->data, &item->size);
@@ -665,7 +637,9 @@ restart:
             for (; limit != 0; limit >>= 1) {
                 indx = base + (limit >> 1);
 
+#if defined(__GNUC__)
                 __row_search_warm_int_candidates(pindex, base, indx, limit);
+#endif
 
                 descent = pindex->index[indx];
                 __wt_ref_key(page, descent, &item->data, &item->size);
@@ -685,7 +659,9 @@ restart:
             for (; limit != 0; limit >>= 1) {
                 indx = base + (limit >> 1);
 
+#if defined(__GNUC__)
                 __row_search_warm_int_candidates(pindex, base, indx, limit);
+#endif
 
                 descent = pindex->index[indx];
                 __wt_ref_key(page, descent, &item->data, &item->size);
@@ -803,7 +779,9 @@ leaf_only:
             indx = base + (limit >> 1);
             rip = page->pg_row + indx;
 
+#if defined(__GNUC__)
             __row_search_warm_leaf_candidates(page, base, indx, limit);
+#endif
 
             WT_ERR(__wt_row_leaf_key(session, page, rip, item, true));
 
@@ -837,7 +815,9 @@ leaf_only:
             indx = base + (limit >> 1);
             rip = page->pg_row + indx;
 
+#if defined(__GNUC__)
             __row_search_warm_leaf_candidates(page, base, indx, limit);
+#endif
 
             WT_ERR(__wt_row_leaf_key(session, page, rip, item, true));
 
@@ -857,7 +837,9 @@ leaf_only:
             indx = base + (limit >> 1);
             rip = page->pg_row + indx;
 
+#if defined(__GNUC__)
             __row_search_warm_leaf_candidates(page, base, indx, limit);
+#endif
 
             WT_ERR(__wt_row_leaf_key(session, page, rip, item, true));
 

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -9,13 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * Depth of the leaf-page binary-search cache-warming pipeline. Level 1 warms a candidate's key
- * data one iteration ahead; level 2 also warms pg_row entries two iterations ahead, so the level-1
- * warm has time to land before it's needed.
- */
-#define WT_ROW_SEARCH_WARM_DEPTH 2
-
-/*
  * __row_search_warm_ref --
  *     Warm the cache line for a WT_REF entry on an internal page.
  */
@@ -23,7 +16,7 @@ static WT_INLINE void
 __row_search_warm_ref(WT_PAGE_INDEX *pindex, uint32_t slot)
 {
     if (slot < pindex->entries)
-        __builtin_prefetch(pindex->index[slot], 0, 3);
+        __builtin_prefetch(pindex->index[slot], WT_WARM_READ, WT_WARM_LOCALITY_HIGH);
 }
 
 /*
@@ -34,7 +27,7 @@ static WT_INLINE void
 __row_search_warm_row_entry(WT_PAGE *page, uint32_t slot)
 {
     if (slot < page->entries)
-        __builtin_prefetch(&page->pg_row[slot], 0, 3);
+        __builtin_prefetch(&page->pg_row[slot], WT_WARM_READ, WT_WARM_LOCALITY_HIGH);
 }
 
 /*
@@ -55,13 +48,13 @@ __row_search_warm_key(WT_PAGE *page, uint32_t slot)
     switch (v & WT_KEY_FLAG_BITS) {
     case WT_K_FLAG:
         __builtin_prefetch(
-          WT_PAGE_REF_OFFSET(page, WT_K_DECODE_KEY_CELL_OFFSET(v) + WT_K_DECODE_KEY_OFFSET(v)), 0,
-          3);
+          WT_PAGE_REF_OFFSET(page, WT_K_DECODE_KEY_CELL_OFFSET(v) + WT_K_DECODE_KEY_OFFSET(v)),
+          WT_WARM_READ, WT_WARM_LOCALITY_HIGH);
         break;
     case WT_KV_FLAG:
         __builtin_prefetch(
-          WT_PAGE_REF_OFFSET(page, WT_KV_DECODE_KEY_CELL_OFFSET(v) + WT_KV_DECODE_KEY_OFFSET(v)), 0,
-          3);
+          WT_PAGE_REF_OFFSET(page, WT_KV_DECODE_KEY_CELL_OFFSET(v) + WT_KV_DECODE_KEY_OFFSET(v)),
+          WT_WARM_READ, WT_WARM_LOCALITY_HIGH);
         break;
     default:
         /* On-page cells and instantiated keys need unpacking; not worth warming. */
@@ -71,8 +64,8 @@ __row_search_warm_key(WT_PAGE *page, uint32_t slot)
 
 /*
  * __row_search_warm_int_candidates --
- *     Warm the WT_REF entries a binary search on an internal page is likely to visit one
- *     iteration ahead.
+ *     Warm the WT_REF entries a binary search on an internal page is likely to visit one iteration
+ *     ahead.
  */
 static WT_INLINE void
 __row_search_warm_int_candidates(
@@ -87,12 +80,12 @@ __row_search_warm_int_candidates(
 /*
  * __row_search_warm_leaf_candidates --
  *     Warm the pg_row entries and key data a binary search on a leaf page is likely to visit one
- *     and two iterations ahead.
+ *     and two iterations ahead: warming the pg_row entries two iterations ahead gives the key-data
+ *     warm below, one iteration ahead, time to land before it's needed.
  */
 static WT_INLINE void
 __row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, uint32_t limit)
 {
-#if WT_ROW_SEARCH_WARM_DEPTH >= 2
     if (limit > 6) {
         uint32_t pf_lq, pf_rb, pf_rh;
 
@@ -104,7 +97,6 @@ __row_search_warm_leaf_candidates(WT_PAGE *page, uint32_t base, uint32_t indx, u
         __row_search_warm_row_entry(page, pf_rb + (pf_rh >> 2));
         __row_search_warm_row_entry(page, pf_rb + (pf_rh >> 1) + 1 + ((pf_rh - 1) >> 2));
     }
-#endif
     if (limit > 2) {
         __row_search_warm_key(page, base + (limit >> 2));
         __row_search_warm_key(page, indx + 1 + ((limit - 1) >> 2));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -812,12 +812,16 @@ __curfile_reopen(WT_CURSOR *cursor, bool sweep_check_only)
         return (can_sweep ? WT_NOTFOUND : 0);
     }
 
+#if defined(__GNUC__) || defined(__clang__)
     /*
      * Warm the dhandle's rwlock and btree handle: the reopen below is about to lock the former and
-     * dereference the latter, and both are commonly cold after a cursor has sat in the cache.
+     * dereference the latter, and both are commonly cold after a cursor has sat in the cache. No
+     * cache-prefetch intrinsic is available outside GCC/Clang, so this is skipped elsewhere; the
+     * warm is purely advisory.
      */
     __builtin_prefetch(&dhandle->rwlock, WT_WARM_WRITE, WT_WARM_LOCALITY_HIGH);
     __builtin_prefetch(dhandle->handle, WT_WARM_READ, WT_WARM_LOCALITY_HIGH);
+#endif
 
     /*
      * Temporarily set the session's data handle to the data handle in the cursor. Reopen may be

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -816,8 +816,8 @@ __curfile_reopen(WT_CURSOR *cursor, bool sweep_check_only)
      * Warm the dhandle's rwlock and btree handle: the reopen below is about to lock the former and
      * dereference the latter, and both are commonly cold after a cursor has sat in the cache.
      */
-    __builtin_prefetch(&dhandle->rwlock, 1, 3);
-    __builtin_prefetch(dhandle->handle, 0, 3);
+    __builtin_prefetch(&dhandle->rwlock, WT_WARM_WRITE, WT_WARM_LOCALITY_HIGH);
+    __builtin_prefetch(dhandle->handle, WT_WARM_READ, WT_WARM_LOCALITY_HIGH);
 
     /*
      * Temporarily set the session's data handle to the data handle in the cursor. Reopen may be

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -812,7 +812,7 @@ __curfile_reopen(WT_CURSOR *cursor, bool sweep_check_only)
         return (can_sweep ? WT_NOTFOUND : 0);
     }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
     /*
      * Warm the dhandle's rwlock and btree handle: the reopen below is about to lock the former and
      * dereference the latter, and both are commonly cold after a cursor has sat in the cache. No

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -813,6 +813,13 @@ __curfile_reopen(WT_CURSOR *cursor, bool sweep_check_only)
     }
 
     /*
+     * Warm the dhandle's rwlock and btree handle: the reopen below is about to lock the former and
+     * dereference the latter, and both are commonly cold after a cursor has sat in the cache.
+     */
+    __builtin_prefetch(&dhandle->rwlock, 1, 3);
+    __builtin_prefetch(dhandle->handle, 0, 3);
+
+    /*
      * Temporarily set the session's data handle to the data handle in the cursor. Reopen may be
      * called either as part of an open API call, or during cursor sweep as part of a different API
      * call, so we need to restore the original data handle that was in our session after the reopen

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -29,18 +29,21 @@
 #endif /* CODE_COVERAGE_MEASUREMENT */
 
 /*
+ * Explicitly suppress compiler warnings about unused variables, and function parameters.
+ */
+#define WT_UNUSED(var) (void)(var)
+
+/*
  * __builtin_prefetch(addr, rw, locality) hint parameters: rw distinguishes a read-only touch from
  * one anticipating a write; locality selects how strongly to keep the line cached afterward (0 =
- * no temporal locality, 3 = highest).
+ * no temporal locality, 3 = highest). Only meaningful where __builtin_prefetch itself is available
+ * (see the callers' own compiler guards); the values are plain integers, so defining them here
+ * unconditionally is safe on every platform.
  */
 #define WT_WARM_READ 0
 #define WT_WARM_WRITE 1
 #define WT_WARM_LOCALITY_HIGH 3
 
-/*
- * Explicitly suppress compiler warnings about unused variables, and function parameters.
- */
-#define WT_UNUSED(var) (void)(var)
 #define WT_NOT_READ(v, val) \
     do {                    \
         (v) = (val);        \

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -29,6 +29,15 @@
 #endif /* CODE_COVERAGE_MEASUREMENT */
 
 /*
+ * __builtin_prefetch(addr, rw, locality) hint parameters: rw distinguishes a read-only touch from
+ * one anticipating a write; locality selects how strongly to keep the line cached afterward (0 =
+ * no temporal locality, 3 = highest).
+ */
+#define WT_WARM_READ 0
+#define WT_WARM_WRITE 1
+#define WT_WARM_LOCALITY_HIGH 3
+
+/*
  * Explicitly suppress compiler warnings about unused variables, and function parameters.
  */
 #define WT_UNUSED(var) (void)(var)

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -217,6 +217,20 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_dea
     }
 
     /*
+     * Fast path: try a single non-blocking read lock when shared access is enough. This skips the
+     * loop below entirely for the common case of an already-open, uncontended handle; if the
+     * trylock fails or the handle isn't reopenable, fall through to the general loop.
+     */
+    if (!want_exclusive && WT_DHANDLE_CAN_REOPEN(dhandle) &&
+      (btree == NULL || !F_ISSET(btree, WT_BTREE_SPECIAL_FLAGS)) &&
+      __wt_try_readlock(session, &dhandle->rwlock) == 0) {
+        if (WT_DHANDLE_CAN_REOPEN(dhandle))
+            return (0);
+        /* Lost the race with a state change under the lock; fall back to the general path. */
+        __wt_readunlock(session, &dhandle->rwlock);
+    }
+
+    /*
      * Check that the handle is open. We've already incremented the reference count, so once the
      * handle is open it won't be closed by another thread.
      *

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -219,7 +219,7 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_dea
     /*
      * Fast path: try a single non-blocking read lock when shared access is enough. This skips the
      * loop below entirely for the common case of an already-open, uncontended handle; if the
-     * trylock fails or the handle isn't reopenable, fall through to the general loop.
+     * trylock fails or the handle can no longer be reopened, fall through to the general loop.
      */
     if (!want_exclusive && WT_DHANDLE_CAN_REOPEN(dhandle) &&
       (btree == NULL || !F_ISSET(btree, WT_BTREE_SPECIAL_FLAGS)) &&


### PR DESCRIPTION
Leaf-page binary search in `__wt_row_search` does two dependent loads per iteration -- the `WT_ROW` entry, then the key bytes its encoded pointer points to -- each a potential cache miss that stalls the pipeline since the next candidate isn't known until the comparison completes. Since binary search is deterministic, the array index 1-2 iterations ahead is computable before the comparison, so `__wt_row_search` now warms those candidate cache lines (`WT_REF` entries during internal-page descent, `WT_ROW` entries and key data on leaf pages) ahead of when the loop will actually need them. The dhandle rwlock and btree handle a cached cursor's reopen touches are warmed the same way, since both are commonly cold after a cursor has sat in the session cursor cache.

Also adds a fast, non-blocking trylock path to `__wt_session_lock_dhandle` for the common case of shared access to an already-open, healthy handle, skipping the general loop's other checks entirely on success.

The cache-warming is built on `__builtin_prefetch`, a GCC/Clang-only intrinsic; it's named `__wt_row_search`'s own "warm" helpers rather than "prefetch" to avoid confusion with WiredTiger's existing, unrelated page-readahead prefetch subsystem (`bt_prefetch.c`/`conn_prefetch.c`/`session_prefetch.c`). The two entry points the search loops call, and the dhandle warm block in `__curfile_reopen`, are guarded so they compile to a no-op on any other compiler, including MSVC.

None of this changes behavior: every warm is a hint, guarded against out-of-range slots either by the loop's own `base + limit <= entries` invariant or by an explicit bounds check, and the lock fast path falls through to the existing loop unchanged whenever the trylock fails or the handle's state changed underneath it.

See WT-16838 for the profiling data motivating this change.