### PR TITLE
WT-18570 Reopen the connection before corrupting checkpoint size in fix_btree_size tests

### DIFF
--- a/test/suite/test_verify_btree_size.py
+++ b/test/suite/test_verify_btree_size.py
@@ -95,6 +95,11 @@ class test_verify_btree_size(wttest.WiredTigerTestCase):
         real_size = self.get_ckpt_size()
         self.assertGreater(real_size, 0)
 
+        # Reopen so the stable file's dhandle is closed before it gets corrupted below: otherwise
+        # verify would keep consulting the dhandle's cached, pre-corruption checkpoint list and
+        # never see a mismatch to fix.
+        self.reopen_conn()
+
         # Corrupt the checkpoint size in the metadata.
         self.set_ckpt_size(1)
 
@@ -139,6 +144,11 @@ class test_verify_btree_size(wttest.WiredTigerTestCase):
         self.populate()
 
         real_size = self.get_ckpt_size()
+
+        # Reopen so the stable file's dhandle is closed before it gets corrupted below: otherwise
+        # verify would keep consulting the dhandle's cached, pre-corruption checkpoint list and
+        # never see a mismatch to fix.
+        self.reopen_conn()
         self.set_ckpt_size(1)
 
         with self.customStdoutPattern(
@@ -164,6 +174,11 @@ class test_verify_btree_size(wttest.WiredTigerTestCase):
             self.session.create(uri, 'key_format=S,value_format=S')
             self.populate(uri)
             real_sizes.append(self.get_ckpt_size(stable_uri))
+
+        # Reopen so every stable file's dhandle is closed before corruption below: otherwise
+        # verify would keep consulting a dhandle's cached, pre-corruption checkpoint list and
+        # never see a mismatch to fix.
+        self.reopen_conn()
 
         # Corrupt each table with a distinct bogus size.
         for i, stable_uri in enumerate(stable_uris):


### PR DESCRIPTION
The stable file's dhandle stays open (and its checkpoint list cached) across populate() and the later metadata corruption, since the tests patch the on-disk metadata string directly through a raw cursor rather than through a real checkpoint. verify(fix_btree_size=true) then keeps consulting the dhandle's cached, still-correct checkpoint list instead of rereading the corrupted metadata, so it detects no mismatch and never applies the fix.

Reopening the connection right before the corruption (instead of right after) closes the dhandle, forcing a fresh metadata read the next time verify opens it. Placing the reopen after the corruption instead doesn't work: it just moves the same stale-cache mismatch to connection-close time, where a diagnostic-build assertion aborts instead.