### PR TITLE
WT-18571 Allow test_checkpoint10 to retry on oldest-for-eviction rollback

### DIFF
--- a/test/suite/test_checkpoint10.py
+++ b/test/suite/test_checkpoint10.py
@@ -41,6 +41,9 @@ from wtscenario import make_scenarios
 @wttest.skip_for_hook("tiered", "Fails with tiered storage")
 class test_checkpoint(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
+    # checkpoint_slow can stall eviction long enough to roll back session2's held-open transaction
+    # as the oldest pinned transaction; test_checkpoint11 hits the same condition.
+    rollbacks_allowed = 10
 
     format_values = [
         ('column', dict(key_format='r', value_format='S', extraconfig='')),


### PR DESCRIPTION
timing_stress_for_test=checkpoint_slow deliberately delays the checkpoint's commit path to widen the race between the checkpoint and a concurrent long-running commit. Under that delay, session2's held-open bulk-insert transaction can legitimately become the globally oldest pinned transaction while eviction is stuck, and gets rolled back with WT_ROLLBACK/WT_OLDEST_FOR_EVICTION — correct engine behavior, not a bug.

test_checkpoint10 didn't tolerate this: the framework's built-in retry-on-rollback (rollbacks_allowed, default 2) was exhausted on the ASAN variant, so the test failed outright after cursor2's insert loop raised WiredTigerRollbackError.

test_checkpoint11 already hits the identical condition under the same stress config and sets rollbacks_allowed = 10; this applies the same fix to test_checkpoint10.