### PR TITLE
WT-18572 allow ignore_cache_size to be reconfigured while a transaction is running

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1399,11 +1399,10 @@ session_config = [
         min=0),
     Config('ignore_cache_size', 'false', r'''
         when set, operations performed by this session ignore the cache size and are not blocked
-        when the cache is full. WT_SESSION::reconfigure returns \c EINVAL if this setting is
-        specified while a transaction is running; use the \c ignore_cache_size setting of
-        WT_SESSION::begin_transaction to configure a single transaction. Note that use of this
-        option for operations that create cache pressure can starve ordinary sessions that obey
-        the cache size.''',
+        when the cache is full. This setting may be reconfigured while a transaction is running,
+        in which case it takes precedence over the \c ignore_cache_size setting of
+        WT_SESSION::begin_transaction. Note that use of this option for operations that create
+        cache pressure can starve ordinary sessions that obey the cache size.''',
         type='boolean'),
     Config('isolation', 'snapshot', r'''
         the default isolation level for operations in this session''',
@@ -2041,10 +2040,12 @@ methods = {
 'WT_SESSION.begin_transaction' : Method([
     Config('ignore_cache_size', 'false', r'''
         when set, operations performed by this transaction ignore the cache size and are not
-        blocked when the cache is full. The setting applies until the transaction is resolved.
-        Setting it to \c false has no effect: it does not override a session configured with
-        \c ignore_cache_size. Note that use of this option for operations that create cache
-        pressure can starve ordinary transactions that obey the cache size.''',
+        blocked when the cache is full. The setting applies until the transaction is resolved,
+        unless WT_SESSION::reconfigure sets \c ignore_cache_size while the transaction is
+        running, which makes it session-wide. Setting it to \c false has no effect: it does not
+        override a session configured with \c ignore_cache_size. Note that use of this option
+        for operations that create cache pressure can starve ordinary transactions that obey the
+        cache size.''',
         type='boolean'),
     Config('ignore_prepare', 'false', r'''
         whether to ignore updates by other prepared transactions when doing of read operations

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2729,6 +2729,7 @@ static WT_INLINE void __wt_timing_stress(
   WT_SESSION_IMPL *session, uint64_t flag, struct timespec *tsp);
 static WT_INLINE void __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_tree_modify_set(WT_SESSION_IMPL *session);
+static WT_INLINE void __wt_txn_config_clear(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);
 static WT_INLINE void __wt_txn_op_delete_apply_prepare_state(

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2069,6 +2069,26 @@ __wt_txn_stepdown_straddler_check(WT_SESSION_IMPL *session, bool is_writer)
 }
 
 /*
+ * __wt_txn_config_clear --
+ *     Discard a transaction's configuration. The cache-size exemption is the only setting stored
+ *     outside the transaction, so it is dropped here, and only when the transaction claimed it
+ *     rather than the session. Clearing twice is harmless, so error paths may nest.
+ */
+static WT_INLINE void
+__wt_txn_config_clear(WT_SESSION_IMPL *session)
+{
+    WT_TXN *txn;
+
+    txn = session->txn;
+
+    if (F_ISSET(txn, WT_TXN_IGNORE_CACHE_SIZE))
+        F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
+    txn->flags = 0;
+    txn->time_point.flags = 0;
+    txn->operation_timeout_us = 0;
+}
+
+/*
  * __wt_txn_begin --
  *     Begin a transaction.
  */
@@ -2090,6 +2110,9 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
     txn->modify_block_count = 0;
 
     WT_ASSERT(session, !F_ISSET(txn, WT_TXN_RUNNING));
+
+    /* A stale exemption means an earlier transaction was abandoned without clearing its config. */
+    WT_ASSERT(session, !F_ISSET(txn, WT_TXN_IGNORE_CACHE_SIZE));
 
     WT_ERR(__wt_txn_config(session, conf));
 
@@ -2161,11 +2184,7 @@ err:
      * WT_TXN_HAS_SNAPSHOT to know it must give the snapshot back.
      */
     WT_ASSERT(session, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT));
-    if (F_ISSET(txn, WT_TXN_IGNORE_CACHE_SIZE))
-        F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
-    txn->flags = 0;
-    txn->time_point.flags = 0;
-    txn->operation_timeout_us = 0;
+    __wt_txn_config_clear(session);
     return (ret);
 }
 

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -888,11 +888,11 @@ struct __wt_session {
      * when it is released and no longer needed., a boolean flag; default \c false.}
      * @config{ ),,}
      * @config{ignore_cache_size, when set\, operations performed by this session ignore the cache
-     * size and are not blocked when the cache is full.  WT_SESSION::reconfigure returns \c EINVAL
-     * if this setting is specified while a transaction is running; use the \c ignore_cache_size
-     * setting of WT_SESSION::begin_transaction to configure a single transaction.  Note that use of
-     * this option for operations that create cache pressure can starve ordinary sessions that obey
-     * the cache size., a boolean flag; default \c false.}
+     * size and are not blocked when the cache is full.  This setting may be reconfigured while a
+     * transaction is running\, in which case it takes precedence over the \c ignore_cache_size
+     * setting of WT_SESSION::begin_transaction.  Note that use of this option for operations that
+     * create cache pressure can starve ordinary sessions that obey the cache size., a boolean flag;
+     * default \c false.}
      * @config{isolation, the default isolation level for operations in this session., a string\,
      * chosen from the following options: \c "read-uncommitted"\, \c "read-committed"\, \c
      * "snapshot"; default \c snapshot.}
@@ -1659,10 +1659,11 @@ struct __wt_session {
      * id doesn't exist., a string; default empty.}
      * @config{ignore_cache_size, when set\, operations performed by this transaction ignore the
      * cache size and are not blocked when the cache is full.  The setting applies until the
-     * transaction is resolved.  Setting it to \c false has no effect: it does not override a
-     * session configured with \c ignore_cache_size.  Note that use of this option for operations
-     * that create cache pressure can starve ordinary transactions that obey the cache size., a
-     * boolean flag; default \c false.}
+     * transaction is resolved\, unless WT_SESSION::reconfigure sets \c ignore_cache_size while the
+     * transaction is running\, which makes it session-wide.  Setting it to \c false has no effect:
+     * it does not override a session configured with \c ignore_cache_size.  Note that use of this
+     * option for operations that create cache pressure can starve ordinary transactions that obey
+     * the cache size., a boolean flag; default \c false.}
      * @config{ignore_prepare, whether to ignore updates by other prepared transactions when doing
      * of read operations of this transaction.  When \c true\, forces the transaction to be
      * read-only.  Use \c force to ignore prepared updates and permit writes (see @ref
@@ -2700,11 +2701,11 @@ struct __wt_connection {
      * when it is released and no longer needed., a boolean flag; default \c false.}
      * @config{ ),,}
      * @config{ignore_cache_size, when set\, operations performed by this session ignore the cache
-     * size and are not blocked when the cache is full.  WT_SESSION::reconfigure returns \c EINVAL
-     * if this setting is specified while a transaction is running; use the \c ignore_cache_size
-     * setting of WT_SESSION::begin_transaction to configure a single transaction.  Note that use of
-     * this option for operations that create cache pressure can starve ordinary sessions that obey
-     * the cache size., a boolean flag; default \c false.}
+     * size and are not blocked when the cache is full.  This setting may be reconfigured while a
+     * transaction is running\, in which case it takes precedence over the \c ignore_cache_size
+     * setting of WT_SESSION::begin_transaction.  Note that use of this option for operations that
+     * create cache pressure can starve ordinary sessions that obey the cache size., a boolean flag;
+     * default \c false.}
      * @config{isolation, the default isolation level for operations in this session., a string\,
      * chosen from the following options: \c "read-uncommitted"\, \c "read-committed"\, \c
      * "snapshot"; default \c snapshot.}

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -511,6 +511,19 @@ __session_config_int(WT_SESSION_IMPL *session, WT_CONF *conf)
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
 
+    if ((ret = __wt_conf_getones(session, conf, ignore_cache_size, &cval)) == 0) {
+        if (cval.val)
+            F_SET(session, WT_SESSION_IGNORE_CACHE_SIZE);
+        else
+            F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
+        /*
+         * The session now owns this flag, so a running transaction that had claimed it must no
+         * longer undo it on release.
+         */
+        F_CLR(session->txn, WT_TXN_IGNORE_CACHE_SIZE);
+    }
+    WT_RET_NOTFOUND_OK(ret);
+
     if ((ret = __wt_conf_getones(session, conf, cache_cursors, &cval)) == 0) {
         if (cval.val)
             F_SET(session, WT_SESSION_CACHE_CURSORS);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -517,8 +517,8 @@ __session_config_int(WT_SESSION_IMPL *session, WT_CONF *conf)
         else
             F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
         /*
-         * The session now owns this flag, so a running transaction that had claimed it must no
-         * longer undo it on release.
+         * The session now owns this flag, so drop any ownership a running transaction recorded in
+         * txn config; it must no longer undo the setting when it is released.
          */
         F_CLR(session->txn, WT_TXN_IGNORE_CACHE_SIZE);
     }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -861,9 +861,9 @@ __wt_txn_config(WT_SESSION_IMPL *session, WT_CONF *conf)
         txn->txn_log.txn_logsync = 0;
 
     /*
-     * Exempt this transaction from the cache size. Track that we set the session flag so it is
-     * cleared on release, unless the session was already configured to ignore the cache size. A
-     * false setting is not an override of the session-level setting.
+     * Exempt this transaction from the cache size, recording ownership of the session flag so that
+     * __wt_txn_config_clear drops it again, unless the session was already configured to ignore the
+     * cache size. A false setting is not an override of the session-level setting.
      */
     WT_ERR(__wt_conf_gets_def(session, conf, ignore_cache_size, 0, &cval));
     if (cval.val && !F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE)) {
@@ -908,6 +908,12 @@ __wt_txn_config(WT_SESSION_IMPL *session, WT_CONF *conf)
     }
 
 err:
+    /*
+     * A rejected configuration must leave nothing behind for the next transaction, including the
+     * session flag this function may have set.
+     */
+    if (ret != 0)
+        __wt_txn_config_clear(session);
     return (ret);
 }
 
@@ -1003,14 +1009,8 @@ __txn_release(WT_SESSION_IMPL *session)
      * Purposely do NOT clear the commit and durable timestamps on release. Other readers may still
      * find these transactions in the durable queue and will need to see those timestamps.
      */
-    if (F_ISSET(txn, WT_TXN_IGNORE_CACHE_SIZE))
-        F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
-    txn->flags = 0;
-    txn->time_point.flags = 0;
+    __wt_txn_config_clear(session);
     txn->time_point.prepare_timestamp = WT_TS_NONE;
-
-    /* Clear operation timer. */
-    txn->operation_timeout_us = 0;
 
     /* Reset the dirty footprint tracking */
     __txn_clear_bytes_dirty(session);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -937,22 +937,6 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, WT_CONF *conf)
     }
     WT_RET_NOTFOUND_OK(ret);
 
-    ret = __wt_conf_getones(session, conf, ignore_cache_size, &cval);
-    if (ret == 0)
-        /*
-         * Can only reconfigure this if a transaction is not active: it would otherwise race with a
-         * transaction that has claimed the flag for itself.
-         */
-        WT_RET(__wt_txn_context_check(session, false));
-
-    if (ret == 0) {
-        if (cval.val)
-            F_SET(session, WT_SESSION_IGNORE_CACHE_SIZE);
-        else
-            F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
-    }
-    WT_RET_NOTFOUND_OK(ret);
-
     return (0);
 }
 

--- a/test/catch2/misc_tests/test_txn_config.cpp
+++ b/test/catch2/misc_tests/test_txn_config.cpp
@@ -97,12 +97,33 @@ TEST_CASE("ignore_cache_size is scoped to the transaction that set it", "[txn_co
         REQUIRE(F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
     }
 
-    SECTION("a session-level reconfigure is rejected while a transaction is active")
+    SECTION("a session-level setting made during the transaction outlives it")
     {
         REQUIRE(session->iface.begin_transaction(&session->iface, "ignore_cache_size=true") == 0);
-        REQUIRE(session->iface.reconfigure(&session->iface, "ignore_cache_size=true") == EINVAL);
-        REQUIRE(session->iface.reconfigure(&session->iface, "ignore_cache_size=false") == EINVAL);
+        REQUIRE(session->iface.reconfigure(&session->iface, "ignore_cache_size=true") == 0);
+        REQUIRE(session->iface.commit_transaction(&session->iface, NULL) == 0);
         REQUIRE(F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
+    }
+
+    SECTION("a transaction can acquire the setting after it has begun")
+    {
+        /*
+         * A transaction that starts obeying the cache size can be exempted part way through, and
+         * the exemption is the session's from then on.
+         */
+        REQUIRE(session->iface.begin_transaction(&session->iface, NULL) == 0);
+        REQUIRE(!F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
+        REQUIRE(session->iface.reconfigure(&session->iface, "ignore_cache_size=true") == 0);
+        REQUIRE(F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
+        REQUIRE(session->iface.commit_transaction(&session->iface, NULL) == 0);
+        REQUIRE(F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
+    }
+
+    SECTION("a session-level clear during the transaction takes effect")
+    {
+        REQUIRE(session->iface.begin_transaction(&session->iface, "ignore_cache_size=true") == 0);
+        REQUIRE(session->iface.reconfigure(&session->iface, "ignore_cache_size=false") == 0);
+        REQUIRE(!F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
         REQUIRE(session->iface.commit_transaction(&session->iface, NULL) == 0);
         REQUIRE(!F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE));
     }


### PR DESCRIPTION
In the recent change to ignore_cache_size to make it both a session and a transaction level setting modified the code to not allow it to be reconfigured while a transaction is ongoing. Server has a _noEvictionAfterCommitOrRollback which we apply to certain transactions dynamically. They participate in eviction normally for like read/write, but not when they commit/abort. Previously they were able to reconfigure cache_max_wait_ms for a WT_SESSION, but the change prevented the reconfigure at the session level.

This change makes it so that the reconfigure can happen with running transactions. Notably, adding the transaction level granularity made this a little more complex. If a transaction level ignore_cache_size is not needed, it would simplify the setting without needing to track whether the flag was set by the session or a transaction. The original [WT-18006](https://jira.mongodb.org/browse/WT-18006) ticket mentioned different granularity could be useful, but I don't believe any caller currently needs the transaction level opt out, so it added some complexity that is currently unused.