### PR TITLE
WT-18540 Return end of log after salvaging a leftover log tail

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2451,6 +2451,12 @@ err:
         /* Don't alter the file when the logging system is not set up. */
         if (log != NULL)
             WT_TRET(__log_truncate(session, &rd_lsn, false, true));
+        /* Salvage truncated at this LSN, so this is the end of the log. */
+        __wt_verbose_notice(session, WT_VERB_LOG,
+          "salvage: log scan truncated at %" PRIu32 "/%" PRIu32
+          ", returning end of log (flags 0x%" PRIx32 ", first record %d)",
+          rd_lsn.l.file, __wt_lsn_offset(&rd_lsn), flags, firstrecord);
+        eol = true;
         ret = 0;
     }
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2449,13 +2449,14 @@ err:
         WT_TRET(__wt_close(session, &log_fh));
         log_fh = NULL;
         /* Don't alter the file when the logging system is not set up. */
-        if (log != NULL)
+        if (log != NULL) {
             WT_TRET(__log_truncate(session, &rd_lsn, false, true));
+            __wt_verbose_notice(session, WT_VERB_LOG,
+              "salvage: log scan truncated at %" PRIu32 "/%" PRIu32
+              ", returning end of log (flags 0x%" PRIx32 ", first record %d)",
+              rd_lsn.l.file, __wt_lsn_offset(&rd_lsn), flags, firstrecord);
+        }
         /* Salvage truncated at this LSN, so this is the end of the log. */
-        __wt_verbose_notice(session, WT_VERB_LOG,
-          "salvage: log scan truncated at %" PRIu32 "/%" PRIu32
-          ", returning end of log (flags 0x%" PRIx32 ", first record %d)",
-          rd_lsn.l.file, __wt_lsn_offset(&rd_lsn), flags, firstrecord);
         eol = true;
         ret = 0;
     }

--- a/test/suite/test_log08.py
+++ b/test/suite/test_log08.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+
+# test_log08.py
+#   A log cursor that salvages a corrupt record at the end of the log must end
+#   with WT_NOTFOUND, not an error. Recovery walks the log with this cursor at
+#   open, so an error fails the whole open. Without zero_fill, preallocation on
+#   macOS can leave such a record after the last real one.
+class test_log08(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled,file_max=100K,zero_fill=false)'
+    uri = 'table:test_log08'
+
+    def test_log_cursor_after_salvage(self):
+        # One committed transaction, flushed so the log is complete on disk.
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 51):
+            cursor[i] = 'value'
+        self.session.commit_transaction()
+        cursor.close()
+        self.session.log_flush('sync=on')
+
+        # A stray byte in the record length of the slot right after the last
+        # record. Records are 128 byte aligned, so the scan reads it as a header
+        # whose checksum does not match and salvages it.
+        with open('WiredTigerLog.0000000001', 'r+b') as f:
+            used = len(f.read().rstrip(b'\x00'))
+            f.seek((used + 127) // 128 * 128)
+            f.write(b'\x08')
+
+        # Walk off the end of the log. The salvage truncates the file and the
+        # cursor must then report end of log rather than fail.
+        log_cursor = self.session.open_cursor('log:')
+        with self.expectedStdoutPattern('record len corruption 0x8'):
+            while log_cursor.next() == 0:
+                pass
+        log_cursor.close()

--- a/test/suite/test_log08.py
+++ b/test/suite/test_log08.py
@@ -26,40 +26,49 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import struct
 import wttest
 
 # test_log08.py
 #   A log cursor that salvages a corrupt record at the end of the log must end
 #   with WT_NOTFOUND, not an error. Recovery walks the log with this cursor at
-#   open, so an error fails the whole open. Without zero_fill, preallocation on
-#   macOS can leave such a record after the last real one.
+#   open, so an error fails the whole open.
 class test_log08(wttest.WiredTigerTestCase):
     conn_config = 'log=(enabled,file_max=100K,zero_fill=false)'
     uri = 'table:test_log08'
 
     def test_log_cursor_after_salvage(self):
-        # One committed transaction, flushed so the log is complete on disk.
         self.session.create(self.uri, 'key_format=i,value_format=S')
         cursor = self.session.open_cursor(self.uri)
-        self.session.begin_transaction()
-        for i in range(1, 51):
-            cursor[i] = 'value'
-        self.session.commit_transaction()
+        cursor[1] = 'value'
         cursor.close()
         self.session.log_flush('sync=on')
 
-        # A stray byte in the record length of the slot right after the last
-        # record. Records are 128 byte aligned, so the scan reads it as a header
-        # whose checksum does not match and salvages it.
+        # Records are 128-byte slots whose first 4 bytes are the length.
+        # Walk until that length is 0 (unused preallocated tail) and write
+        # 0x08, which is too small to be a real header. The log cursor must
+        # salvage that leftover and stop, not return an error.
         with open('WiredTigerLog.0000000001', 'r+b') as f:
-            used = len(f.read().rstrip(b'\x00'))
-            f.seek((used + 127) // 128 * 128)
+            offset = 0
+            while True:
+                f.seek(offset)
+                header = f.read(4)
+                if len(header) < 4:
+                    break
+                rec_len = struct.unpack('<I', header)[0]
+                if rec_len == 0:
+                    break
+                offset += (rec_len + 127) // 128 * 128
+            f.seek(offset)
             f.write(b'\x08')
 
-        # Walk off the end of the log. The salvage truncates the file and the
-        # cursor must then report end of log rather than fail.
         log_cursor = self.session.open_cursor('log:')
         with self.expectedStdoutPattern('record len corruption 0x8'):
             while log_cursor.next() == 0:
                 pass
         log_cursor.close()
+
+        self.reopen_conn()
+        cursor = self.session.open_cursor(self.uri)
+        self.assertEqual(cursor[1], 'value')
+        cursor.close()

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -318,6 +318,7 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
             #   salvage: log file x truncated at beginning
             #   salvage: log file x truncated
             #   salvage: log file x removed
+            #   salvage: log scan truncated at ...
             #
             # The removal case may not give an informational error because
             # the log file is already missing, so salvage itself is not
@@ -325,7 +326,7 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
             # much as it can.
             #
             if self.kind == 'removal':
-                outpat = '^$'
+                outpat = 'salvage: log scan truncated'
             else:
                 outpat = 'salvage: log file'
         else:


### PR DESCRIPTION
## Summary
After salvaging a corrupt leftover in a preallocated log tail, a WT_LOGSCAN_ONE scan could return 0 without a record. The log cursor then unpacked nothing and failed with EINVAL, which made wiredtiger_open fail in recovery.

Set eol after that truncate so the scan returns WT_NOTFOUND, and log the truncate LSN.
## Tests

- test_log08 plants a too-small length in the first unused 128-byte slot, walks a log: cursor through salvage, then reopens and checks the data is still there.