### PR TITLE
WT-18228 Run format random cursor reads in snapshot transactions

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1822,7 +1822,6 @@ variables:
           format_args: disagg.mode=switch runs.timer=3
           times: 1
 
-  # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests
   # Switch-mode variants with asynchronous step-down.
   - &format-stress-test-disagg-switch-stepdown-async
     depends_on: *s-all-dep
@@ -1831,15 +1830,14 @@ variables:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          format_test_script_args: -t 120 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 runs.timer=5:10
+          format_test_script_args: -t 120 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch disagg.stepdown_async=1 runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 runs.timer=5:10
+          format_args: disagg.mode=switch disagg.stepdown_async=1 runs.timer=5:10
           times: 5
 
   # FIXME-WT-16113: Consolidate this logic in test/format itself.
-  # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests
   - &format-stress-test-disagg-switch-data-validation-stepdown-async
     depends_on: *s-all-dep
     commands:
@@ -1847,15 +1845,14 @@ variables:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          format_test_script_args: -t 120 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_test_script_args: -t 120 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch disagg.stepdown_async=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          format_args: disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_args: disagg.mode=switch disagg.stepdown_async=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           times: 5
 
-  # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests
   - &format-stress-test-disagg-switch-pull-request-stepdown-async
     depends_on: *s-all-dep
     commands:
@@ -1864,10 +1861,10 @@ variables:
       - func: "format test script"
         vars:
           # run for 10 minutes.
-          format_test_script_args: -c ../../../test/format/CONFIG.disagg -t 10 -- disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 runs.rows=10000 runs.timer=1
+          format_test_script_args: -c ../../../test/format/CONFIG.disagg -t 10 -- disagg.mode=switch disagg.stepdown_async=1 runs.rows=10000 runs.timer=1
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 runs.timer=3
+          format_args: disagg.mode=switch disagg.stepdown_async=1 runs.timer=3
           times: 1
 
   - &format-stress-test-disagg-multi
@@ -5477,7 +5474,6 @@ tasks:
           additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           times: 2
 
-  # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests
   - name: format-stress-test-disagg-switch-tsan-stepdown-async
     tags: ["pull_request"]
     depends_on: *s-all-dep
@@ -5486,11 +5482,11 @@ tasks:
       - func: "compile wiredtiger"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 runs.rows=1000:3000 runs.tables=1:3 runs.timer=1
+          format_args: disagg.mode=switch disagg.stepdown_async=1 runs.rows=1000:3000 runs.tables=1:3 runs.timer=1
           times: 2
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=0 runs.rows=100000:300000 runs.tables=1:3 runs.timer=1
+          format_args: disagg.mode=switch disagg.stepdown_async=1 runs.rows=100000:300000 runs.tables=1:3 runs.timer=1
           additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           times: 2
 

--- a/test/format/random.c
+++ b/test/format/random.c
@@ -74,10 +74,7 @@ random_kv(void *arg)
         /* Select a table. */
         table = table_select_type(ROW, false);
 
-        /*
-         * Read inside a snapshot transaction so the reads observe a single consistent state, even
-         * when racing a disaggregated leader step-down.
-         */
+        /* Read inside a snapshot transaction so the reads observe a single consistent state. */
         wt_wrap_begin_transaction(session, "isolation=snapshot");
         wt_wrap_open_cursor(session, table->uri, config, &cursor);
 

--- a/test/format/random.c
+++ b/test/format/random.c
@@ -71,8 +71,14 @@ random_kv(void *arg)
         config = simple ? "next_random=true" : "next_random=true,next_random_sample_size=37";
         simple = !simple;
 
-        /* Select a table and open a cursor. */
+        /* Select a table. */
         table = table_select_type(ROW, false);
+
+        /*
+         * Read inside a snapshot transaction so the reads observe a single consistent state, even
+         * when racing a disaggregated leader step-down.
+         */
+        wt_wrap_begin_transaction(session, "isolation=snapshot");
         wt_wrap_open_cursor(session, table->uri, config, &cursor);
 
         /* This is just a smoke-test, get some key/value pairs. */
@@ -81,9 +87,12 @@ random_kv(void *arg)
             case 0:
                 break;
             case WT_NOTFOUND:
-            case WT_ROLLBACK:
             case WT_CACHE_FULL:
             case WT_PREPARE_CONFLICT:
+                continue;
+            case WT_ROLLBACK:
+                /* A rollback ends the transaction; abandon this round and start a new one. */
+                i = 1;
                 continue;
             default:
                 testutil_check(ret);
@@ -93,6 +102,9 @@ random_kv(void *arg)
         }
 
         testutil_check(cursor->close(cursor));
+
+        /* Release the snapshot; a no-op if the round ended in a rollback. */
+        testutil_check(session->rollback_transaction(session, NULL));
 
         /* Sleep for some number of seconds. */
         period = mmrand(&g.extra_rnd, 1, 10);

--- a/test/format/random.c
+++ b/test/format/random.c
@@ -45,7 +45,7 @@ random_kv(void *arg)
     uint32_t i;
     u_int period;
     const char *config;
-    bool simple;
+    bool rollback, simple;
 
     (void)(arg); /* Unused parameter */
 
@@ -82,7 +82,9 @@ random_kv(void *arg)
         wt_wrap_open_cursor(session, table->uri, config, &cursor);
 
         /* This is just a smoke-test, get some key/value pairs. */
-        for (i = mmrand(&g.extra_rnd, 0, WT_THOUSAND); i > 0 && !g.workers_finished; --i) {
+        rollback = false;
+        for (i = mmrand(&g.extra_rnd, 0, WT_THOUSAND); i > 0 && !rollback && !g.workers_finished;
+          --i) {
             switch (ret = cursor->next(cursor)) {
             case 0:
                 break;
@@ -91,8 +93,8 @@ random_kv(void *arg)
             case WT_PREPARE_CONFLICT:
                 continue;
             case WT_ROLLBACK:
-                /* A rollback ends the transaction; abandon this round and start a new one. */
-                i = 1;
+                /* The snapshot can no longer be used; abandon this round and start a new one. */
+                rollback = true;
                 continue;
             default:
                 testutil_check(ret);
@@ -103,7 +105,10 @@ random_kv(void *arg)
 
         testutil_check(cursor->close(cursor));
 
-        /* Release the snapshot; a no-op if the round ended in a rollback. */
+        /*
+         * End the transaction; required even after WT_ROLLBACK, which only marks the error and
+         * leaves it running.
+         */
         testutil_check(session->rollback_transaction(session, NULL));
 
         /* Sleep for some number of seconds. */


### PR DESCRIPTION
## Summary

The disaggregated asynchronous step-down format tests run with `ops.random_cursor=0` because random cursor reads in test/format ran outside any transaction, so a read racing the leader transition wasn't attributable to a consistent snapshot and could trip the test's validation.

This change wraps each `random_kv` read round in an explicit snapshot transaction (`isolation=snapshot`):

- begin transaction → open the `next_random` cursor → read up to 1000 key/value pairs → close cursor → roll back (read-only, nothing pinned across the inter-round sleep).
- `WT_NOTFOUND` / `WT_CACHE_FULL` / `WT_PREPARE_CONFLICT` retry within the same snapshot as before.
- `WT_ROLLBACK` ends the transaction, so the round is abandoned and a new one begins; the final `rollback_transaction` is a no-op in that case.

This is safe for the async step-down: the drain only tracks worker write commits (`timestamp_minimum_committed()`), and read-only snapshots don't allocate timestamps or block checkpoints. It matches the pattern already used by the follower snapshot readers (`follower_read_no_ts`).

Also removes `ops.random_cursor=0` and the FIXME-WT-18228 comments from the four async step-down task definitions in `test/evergreen.yml`.

## Testing

- `dist/s_fast` clean.
- Regular format run with `ops.random_cursor=1`: passed.
- `CONFIG.disagg disagg.mode=switch disagg.stepdown_async=1 ops.random_cursor=1 runs.timer=1`: passed repeatedly, including through step-downs/checkpoint pickups.