### PR TITLE
WT-18511 Reconcile model's connection logging belief with WiredTiger at open time

### DIFF
--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -355,19 +355,6 @@ kv_workload_runner_wt::do_operation(const operation::checkpoint_crash_trigger &o
         return ret;
     wiredtiger_session_guard session_guard(session);
 
-    /*
-     * Whether this crash keeps the checkpoint turns on connection logging, which the model reads
-     * from the database configuration. The connection configuration recorded in the workload and
-     * the caller's override are both appended after it, so either can contradict it; catch that
-     * here rather than let the two run out of step.
-     */
-    kv_database_config database_config = kv_database_config::from_string(_state->database_config);
-    bool logging = FLD_ISSET(S2C((WT_SESSION_IMPL *)session)->log_mgr.flags, WT_LOG_ENABLED);
-    if (logging != database_config.logging)
-        throw model_exception(
-          "Connection logging does not match the database configuration; set it there rather than "
-          "through the connection configuration");
-
     std::ostringstream config;
     config << "debug=(checkpoint_crash_trigger_point=" << operation::to_string(op.phase) << ")";
     std::string config_str = config.str();
@@ -730,6 +717,15 @@ kv_workload_runner_wt::wiredtiger_open_nolock()
     int ret = ::wiredtiger_open(_home.c_str(), nullptr, config_str.c_str(), &_connection);
     if (ret != 0)
         throw wiredtiger_exception("Cannot open WiredTiger", ret);
+
+    /*
+     * The database configuration is the only place the model records logging state. The connection
+     * configuration and any override can turn it on or off behind the model's back, so reconcile
+     * the resolved state with the model's belief at every open.
+     */
+    bool logging = FLD_ISSET(((WT_CONNECTION_IMPL *)_connection)->log_mgr.flags, WT_LOG_ENABLED);
+    if (logging != database_config.logging)
+        throw model_exception("Connection logging does not match the database configuration");
 
     /*
      * If we're using disaggregated storage, pick up the latest checkpoint, and step up, and set the

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -94,7 +94,8 @@ static void
 test_workload_basic(void)
 {
     model::kv_workload workload;
-    workload << model::operation::create_table(k_table1_id, "table1", "S", "S")
+    workload << model::operation::config("database", "logging=true")
+             << model::operation::create_table(k_table1_id, "table1", "S", "S")
              << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
              << model::operation::insert(k_table1_id, 1, key1, value1)
              << model::operation::insert(k_table1_id, 2, key2, value2)
@@ -132,7 +133,8 @@ static void
 test_workload_txn(void)
 {
     model::kv_workload workload;
-    workload << model::operation::create_table(k_table1_id, "table1", "S", "S")
+    workload << model::operation::config("database", "logging=true")
+             << model::operation::create_table(k_table1_id, "table1", "S", "S")
              << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
              << model::operation::insert(k_table1_id, 1, key1, value1)
              << model::operation::insert(k_table1_id, 2, key2, value2)
@@ -180,7 +182,8 @@ static void
 test_workload_prepared(void)
 {
     model::kv_workload workload;
-    workload << model::operation::create_table(k_table1_id, "table1", "S", "S")
+    workload << model::operation::config("database", "logging=true")
+             << model::operation::create_table(k_table1_id, "table1", "S", "S")
              << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
              << model::operation::insert(k_table1_id, 1, key1, value1)
              << model::operation::insert(k_table1_id, 2, key2, value2)
@@ -215,7 +218,8 @@ static void
 test_workload_restart(void)
 {
     model::kv_workload workload;
-    workload << model::operation::create_table(k_table1_id, "table1", "S", "S")
+    workload << model::operation::config("database", "logging=true")
+             << model::operation::create_table(k_table1_id, "table1", "S", "S")
              << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
              << model::operation::insert(k_table1_id, 1, key1, value1)
              << model::operation::insert(k_table1_id, 2, key2, value2)
@@ -255,7 +259,8 @@ static void
 test_workload_crash(void)
 {
     model::kv_workload workload;
-    workload << model::operation::create_table(k_table1_id, "table1", "S", "S")
+    workload << model::operation::config("database", "logging=true")
+             << model::operation::create_table(k_table1_id, "table1", "S", "S")
              << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
              << model::operation::insert(k_table1_id, 1, key1, value1)
              << model::operation::insert(k_table1_id, 2, key2, value2)
@@ -329,6 +334,36 @@ test_workload_checkpoint_crash_phase(void)
                   std::string(home) + DIR_DELIM_STR + "checkpoint_crash_" + std::to_string(run++);
                 verify_workload(workload, opts, test_home, nullptr);
             }
+}
+
+/*
+ * test_workload_logging_mismatch --
+ *     Check that a workload whose database configuration disagrees with the connection
+ *     configuration fails at open time rather than running a mismatched comparison.
+ */
+static void
+test_workload_logging_mismatch(void)
+{
+    model::kv_workload workload;
+    workload << model::operation::config("database", "logging=false")
+             << model::operation::create_table(k_table1_id, "table1", "S", "S")
+             << model::operation::begin_transaction(1)
+             << model::operation::insert(k_table1_id, 1, key1, value1)
+             << model::operation::commit_transaction(1);
+
+    /* Run the workload in the model. */
+    model::kv_database database;
+    workload.run(database);
+
+    /* The connection configuration enables logging, which contradicts the database config. */
+    bool caught = false;
+    try {
+        std::string test_home = std::string(home) + DIR_DELIM_STR + "logging_mismatch";
+        verify_workload(workload, opts, test_home, ENV_CONFIG);
+    } catch (model::model_exception &e) {
+        caught = true;
+    }
+    testutil_assert(caught);
 }
 
 /*
@@ -515,6 +550,7 @@ main(int argc, char *argv[])
         test_workload_restart();
         test_workload_crash();
         test_workload_checkpoint_crash_phase();
+        test_workload_logging_mismatch();
         test_workload_generator();
         test_workload_parse();
     } catch (std::exception &e) {


### PR DESCRIPTION
## Summary
- Move the logging-consistency check from `checkpoint_crash_trigger` to `wiredtiger_open_nolock`, so it runs on every connection open.
- Remove the now-redundant per-operation check.
- Declare `logging=true` in the five `model_workload` tests that open WiredTiger with `ENV_CONFIG`, matching the model's belief to the connection's actual state.
- Add a test that deliberately mismatches the database and connection logging configs and verifies the new exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)