### PR TITLE
WT-14018 start_lsn isn't zero initialised in 464wt_print_debug_log

### DIFF
--- a/test/model/test/common/wiredtiger_util.cpp
+++ b/test/model/test/common/wiredtiger_util.cpp
@@ -454,7 +454,7 @@ wt_print_debug_log(WT_CONNECTION *conn, const char *file)
         throw model::wiredtiger_exception("Cannot open a session: ", ret);
     model::wiredtiger_session_guard session_guard(session);
 
-    WT_LSN start_lsn;
+    WT_LSN start_lsn{};
     WT_ASSIGN_LSN(&start_lsn, &((WT_CONNECTION_IMPL *)conn)->log_mgr.log->first_lsn);
     ret = __wt_txn_printlog(session, file, WT_TXN_PRINTLOG_UNREDACT, &start_lsn, nullptr);
     if (ret != 0)


### PR DESCRIPTION
Coverity flags `start_lsn` as uninitialized in `wt_print_debug_log()`. It's fully assigned by `WT_ASSIGN_LSN` on the next line, but changing the declaration to value-initialize (`WT_LSN start_lsn{};`) silences the false positive with no behavior change.