### PR TITLE
WT-18575 Fix test_disagg_fast_truncate03 flaky assertions, add race regression test

### DIFF
--- a/test/suite/test_disagg_fast_truncate03.py
+++ b/test/suite/test_disagg_fast_truncate03.py
@@ -313,17 +313,29 @@ class test_disagg_fast_truncate03(test_cc_base):
             cursor[self.nrows + 1] = self.value
 
         before = self.snapshot_stats()
-        self.assertEqual(self.scan_table(), surviving + 1)
-        after = self.snapshot_stats()
-        skipped_internal = after["internal_skip"] - before["internal_skip"]
-        self.assertEqual(
-            after["internal_read"], before["internal_read"],
-            "step 5: the evicted internal page was read back",
-        )
-        self.assertEqual(
-            after["evict_blocked"], before["evict_blocked"],
-            "step 5: the evicted internal page was re-dirtied",
-        )
+        # Rarely, an emptied page still resident in memory is evicted between the walk's
+        # skip check (which only evaluates on-disk pages) and the page swap, and the swap
+        # reads it back. The read-back is benign but leaves the page dirty; reconcile and
+        # re-evict it, then measure again.
+        deadline = time.time() + 30
+        while True:
+            self.assertEqual(self.scan_table(), surviving + 1)
+            after = self.snapshot_stats()
+            skipped_internal = after["internal_skip"] - before["internal_skip"]
+            if (after["internal_read"] == before["internal_read"] and
+                after["evict_blocked"] == before["evict_blocked"]):
+                break
+            self.assertLess(
+                time.time(), deadline,
+                "step 5: the evicted internal page keeps being read back",
+            )
+            self.session.checkpoint()
+            self.retry_for_stat_increase(
+                lambda: self.assertEqual(self.scan_table(), surviving + 1),
+                stat.dsrc.cache_eviction_internal, after["internal_evicted"],
+                "step 5: the read-back internal page was not re-evicted",
+            )
+            before = self.snapshot_stats()
         self.assertGreater(
             skipped_internal, 0,
             "step 5: no deleted internal page was skipped",
@@ -380,11 +392,22 @@ class test_disagg_fast_truncate03(test_cc_base):
         # its truncation is not yet globally visible.
         self.session.checkpoint()
         after = self.snapshot_stats()
-        # An emptied internal page still in cache reconciles to empty as well, so the
-        # count covers at least the pages the walk skipped.
-        self.assertGreaterEqual(
-            after["real_deleted"] - before["real_deleted"], skipped_internal,
-            "step 9: a skipped internal page did not reconcile to empty",
+        # The walk-skip statistic counts page examinations, not distinct pages, and can
+        # exceed the number of pages to reclaim. Drive reclamation to convergence instead:
+        # checkpoint until no more pages reconcile to empty.
+        prev = before["real_deleted"]
+        deadline = time.time() + 30
+        while after["real_deleted"] != prev:
+            prev = after["real_deleted"]
+            self.session.checkpoint()
+            after = self.snapshot_stats()
+            self.assertLess(
+                time.time(), deadline,
+                "step 9: reclamation did not converge",
+            )
+        self.assertGreater(
+            after["real_deleted"], before["real_deleted"],
+            "step 9: no skipped internal page reconciled to empty",
         )
         self.assertGreaterEqual(
             after["block_discard"] - before["block_discard"],
@@ -399,6 +422,14 @@ class test_disagg_fast_truncate03(test_cc_base):
         self.assertEqual(
             after["evict_blocked"], before["evict_blocked"],
             "exit: the loop should stop once checkpoint cleanup reclaims the subtree",
+        )
+        self.assertEqual(
+            after["internal_skip"], before["internal_skip"],
+            "exit: a deleted internal page was still present after reclamation",
+        )
+        self.assertEqual(
+            after["internal_read"], before["internal_read"],
+            "exit: a reclaimed internal page was read back",
         )
 
 if __name__ == "__main__":

--- a/test/suite/test_disagg_fast_truncate04.py
+++ b/test/suite/test_disagg_fast_truncate04.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading
+import time
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+
+@disagg_test_class
+class test_disagg_fast_truncate04(wttest.WiredTigerTestCase):
+    """
+    Stress the two race windows that made the scan-based statistics in
+    test_disagg_fast_truncate03 unreliable, and assert scan correctness throughout:
+
+      - a walk restarted by a concurrent split re-examines pages already skipped.
+      - an emptied internal page still resident in memory can be evicted between
+        the walk's skip check and the page swap, and read back.
+
+    Both races are benign, so no statistic is stable under them. What must hold is
+    the data: every scan returns exactly the records that survive the truncate.
+    Drive the races hard with concurrent splits and let cache pressure cycle the
+    emptied internal pages through eviction while scans run.
+    """
+
+    uri = "table:test_disagg_fast_truncate04"
+    nrows = 2000
+    ninserts = 400
+    nscans = 50
+    value = "a" * 50
+    trunc_start = 200
+    trunc_stop = 1800
+
+    truncate_ts = 20
+    read_ts = 25
+    insert_ts = 40
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def conn_config(self):
+        return ('cache_size=50MB,statistics=(all),precise_checkpoint=true,'
+                'checkpoint_cleanup=(wait=100000),disaggregated=(role="leader"),')
+
+    def read_stat(self, stat_key):
+        # Read with statistics=(fast): the default (all) does a full tree walk that
+        # reads every fast-deleted leaf back into cache, perturbing the very loop
+        # this test observes.
+        with wttest.open_cursor(
+            self.session, "statistics:" + self.uri, config="statistics=(fast)"
+        ) as stat_cursor:
+            return stat_cursor[stat_key][2]
+
+    def evict_keys(self, keys):
+        """Force-evict the pages holding the given keys."""
+        with (
+            wttest.open_cursor(
+                self.session, self.uri, config="debug=(release_evict)"
+            ) as evict_cursor,
+            self.transaction(rollback=True),
+        ):
+            for key in keys:
+                evict_cursor.set_key(key)
+                evict_cursor.search()
+                evict_cursor.reset()
+
+    def scan_keys(self):
+        """Return every key visible at read_ts, walked left to right."""
+        keys = []
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(self.read_ts))
+        with wttest.open_cursor(self.session, self.uri) as cursor:
+            while cursor.next() == 0:
+                keys.append(cursor.get_key())
+        self.session.rollback_transaction()
+        return keys
+
+    def insert_worker(self, errors):
+        """Append past the truncated range, splitting the tree the scans walk."""
+        session = self.conn.open_session()
+        try:
+            with wttest.open_cursor(session, self.uri) as cursor:
+                for i in range(self.ninserts):
+                    session.begin_transaction()
+                    cursor[self.nrows + 1 + i] = self.value
+                    session.commit_transaction(
+                        "commit_timestamp=" + self.timestamp_str(self.insert_ts + i))
+        except Exception as e:
+            errors.append(e)
+        finally:
+            session.close()
+
+    def test_scan_with_concurrent_splits(self):
+        # Cache pressure plus split stress can stall an eviction pass on loaded machines.
+        self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+        self.conn.set_timestamp("oldest_timestamp=" + self.timestamp_str(1))
+
+        # Small pages give a deep tree where the truncated range covers every child of
+        # several non-root internal pages.
+        self.session.create(
+            self.uri,
+            "key_format=i,value_format=S,block_manager=disagg,log=(enabled=false),"
+            "allocation_size=512,leaf_page_max=512,internal_page_max=512,"
+            "memory_page_max=4096",
+        )
+        with (
+            wttest.open_cursor(self.session, self.uri) as cursor,
+            self.transaction(commit_timestamp=10),
+        ):
+            for key in range(1, self.nrows + 1):
+                cursor[key] = self.value
+
+        self.conn.set_timestamp("stable_timestamp=" + self.timestamp_str(10))
+        self.session.checkpoint()
+        # On-disk leaves satisfy fast-delete eligibility.
+        self.evict_keys(range(1, self.nrows + 1))
+
+        # Fast-truncate the middle of the tree, then checkpoint so the emptied internal
+        # pages reconcile to proxy cells and become evictable.
+        with (
+            wttest.open_cursor(self.session, self.uri) as start_cursor,
+            wttest.open_cursor(self.session, self.uri) as stop_cursor,
+            self.transaction(commit_timestamp=self.truncate_ts),
+        ):
+            start_cursor.set_key(self.trunc_start)
+            stop_cursor.set_key(self.trunc_stop)
+            self.session.truncate(None, start_cursor, stop_cursor, None)
+
+        self.conn.set_timestamp("stable_timestamp=" + self.timestamp_str(self.truncate_ts))
+        self.session.checkpoint()
+
+        surviving = list(range(1, self.trunc_start)) + list(
+            range(self.trunc_stop + 1, self.nrows + 1))
+
+        # Widen the window where a split is visible to a walk mid-descent.
+        self.conn.reconfigure("timing_stress_for_test=[split_1,split_2,split_3,split_4]")
+
+        errors = []
+        inserter = threading.Thread(target=self.insert_worker, args=(errors,))
+        inserter.start()
+        try:
+            for _ in range(self.nscans):
+                self.assertEqual(self.scan_keys(), surviving)
+        finally:
+            inserter.join()
+        self.assertEqual(errors, [])
+
+        # The skip path engages once the emptied internal pages cycle through eviction;
+        # the eviction server owns that timing, so poll for it.
+        deadline = time.time() + 30
+        while self.read_stat(stat.dsrc.cursor_tree_walk_del_internal_page_skip) == 0:
+            self.assertEqual(self.scan_keys(), surviving)
+            self.assertLess(
+                time.time(), deadline, "no deleted internal page was skipped")
+
+        self.conn.set_timestamp(
+            "stable_timestamp=" + self.timestamp_str(self.insert_ts + self.ninserts))
+        self.session.checkpoint()
+        self.assertEqual(self.scan_keys(), surviving)

--- a/test/suite/test_disagg_fast_truncate04.py
+++ b/test/suite/test_disagg_fast_truncate04.py
@@ -35,22 +35,19 @@ from wtscenario import make_scenarios
 from wiredtiger import stat
 
 
+# Stress the two race windows that made the scan-based statistics in
+# test_disagg_fast_truncate03 unreliable, and assert scan correctness throughout:
+#
+#   - a walk restarted by a concurrent split re-examines pages already skipped.
+#   - an emptied internal page still resident in memory can be evicted between
+#     the walk's skip check and the page swap, and read back.
+#
+# Both races are benign, so no statistic is stable under them. What must hold is
+# the data: every scan returns exactly the records that survive the truncate.
+# Drive the races hard with concurrent splits and let cache pressure cycle the
+# emptied internal pages through eviction while scans run.
 @disagg_test_class
 class test_disagg_fast_truncate04(wttest.WiredTigerTestCase):
-    """
-    Stress the two race windows that made the scan-based statistics in
-    test_disagg_fast_truncate03 unreliable, and assert scan correctness throughout:
-
-      - a walk restarted by a concurrent split re-examines pages already skipped.
-      - an emptied internal page still resident in memory can be evicted between
-        the walk's skip check and the page swap, and read back.
-
-    Both races are benign, so no statistic is stable under them. What must hold is
-    the data: every scan returns exactly the records that survive the truncate.
-    Drive the races hard with concurrent splits and let cache pressure cycle the
-    emptied internal pages through eviction while scans run.
-    """
-
     uri = "table:test_disagg_fast_truncate04"
     nrows = 2000
     ninserts = 400
@@ -80,7 +77,7 @@ class test_disagg_fast_truncate04(wttest.WiredTigerTestCase):
             return stat_cursor[stat_key][2]
 
     def evict_keys(self, keys):
-        """Force-evict the pages holding the given keys."""
+        # Force-evict the pages holding the given keys.
         with (
             wttest.open_cursor(
                 self.session, self.uri, config="debug=(release_evict)"
@@ -93,7 +90,7 @@ class test_disagg_fast_truncate04(wttest.WiredTigerTestCase):
                 evict_cursor.reset()
 
     def scan_keys(self):
-        """Return every key visible at read_ts, walked left to right."""
+        # Return every key visible at read_ts, walked left to right.
         keys = []
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(self.read_ts))
         with wttest.open_cursor(self.session, self.uri) as cursor:
@@ -103,7 +100,7 @@ class test_disagg_fast_truncate04(wttest.WiredTigerTestCase):
         return keys
 
     def insert_worker(self, errors):
-        """Append past the truncated range, splitting the tree the scans walk."""
+        # Append past the truncated range, splitting the tree the scans walk.
         session = self.conn.open_session()
         try:
             with wttest.open_cursor(session, self.uri) as cursor:


### PR DESCRIPTION
`test_disagg_fast_truncate03` flaked in two windows where benign races make exact statistics unstable. Both root causes were pinned with ring-buffer instrumentation under amplified stress (spinlock build, oversubscribed containers, split/checkpoint-cleanup timing stress).

## Root causes

**Step 9 (`real_deleted < skipped_internal`)** — the walk-skip statistic counts page *examinations*, not distinct pages. A scan crossing the deleted region that hits a concurrent split restarts its walk and re-counts pages already skipped (instrumented proof: 58 distinct pages counted 107 times in one scan). Reclamation itself was always complete and correct.

**Step 5 (`the evicted internal page was read back`)** — an emptied internal page still resident in memory is descended by the scan (the skip check only evaluates on-disk pages), marked evict-soon, and can be evicted in the window between the skip check and the page swap; the swap then reads it back. The read is correct (the address aggregate is intact) but re-dirties the page via proxy cells, tripping both the read and the re-dirty assertions. Session-tagged instrumentation confirmed the read comes from the scan thread itself.

## Changes

- **test_disagg_fast_truncate03**: measure both steps to convergence — checkpoint until reclamation stops progressing; on a detected read-back, reconcile and re-evict the page, then re-measure. Added terminal assertions on exit: after reclamation, no deleted internal page is skipped or read back.
- **test_disagg_fast_truncate04** (new): drives both race paths with concurrent inserts (split timing stress armed) and repeated scans, asserting the exact surviving key set every scan — the race paths are now covered by data correctness rather than statistics. Instrumented runs show 100+ walk restarts per run exercised through these assertions.

## Validation

- Fixed test 03 under the original reproduction setup (Linux, adaptive spinlocks, 24-way oversubscription, split+cleanup stress): previously ~1.3% failure rate, now 0 failures across ~30k amplified runs; unfixed control group kept failing meanwhile.
- New test 04: 1440/1440 amplified runs green; 30/30 local.
- fast_truncate01/02 unaffected; sf/s_all clean.
