### PR TITLE
WT-17625 Ignore slow tree walk warning on Windows in test_checkpoint20

### DIFF
--- a/test/suite/test_checkpoint20.py
+++ b/test/suite/test_checkpoint20.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import threading, time
+import os, threading, time
 import wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
@@ -143,3 +143,7 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         self.check(ds, self.first_checkpoint, nrows, value_a, 10)
         self.check(ds, self.first_checkpoint, nrows, value_a, 20)
         self.check(ds, self.first_checkpoint, nrows, value_a, None)
+
+        # The Windows CI builders can be slow.
+        if os.name == 'nt':
+            self.ignoreStdoutPatternIfExists('tree walk took more than')


### PR DESCRIPTION
## Summary
- Ignore the RTS tree walk >10s diagnostic warning on Windows in test_checkpoint20.
- The warning is informational and triggered by slow Windows CI builders, not a correctness issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)