### PR TITLE
WT-18585 Reject untimestamped commits to layered tables while the step-down timestamp is set

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2438,6 +2438,8 @@ static WT_INLINE int __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, W
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_search_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_stepdown_commit_ts_check(WT_SESSION_IMPL *session, WT_TXN *txn,
+  WT_TXN_OP *op, wt_timestamp_t step_down_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_stepdown_straddler_check(WT_SESSION_IMPL *session, bool is_writer)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_timestamp_usage_check(WT_SESSION_IMPL *session, WT_BTREE *btree,

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2069,6 +2069,34 @@ __wt_txn_stepdown_straddler_check(WT_SESSION_IMPL *session, bool is_writer)
 }
 
 /*
+ * __wt_txn_stepdown_commit_ts_check --
+ *     Transactions committing layered content during step-down must carry a commit timestamp.
+ */
+static WT_INLINE int
+__wt_txn_stepdown_commit_ts_check(
+  WT_SESSION_IMPL *session, WT_TXN *txn, WT_TXN_OP *op, wt_timestamp_t step_down_ts)
+{
+    if (step_down_ts == WT_TS_NONE)
+        return (0);
+    if (op->type == WT_TXN_OP_NONE || op->btree == NULL)
+        return (0);
+
+    /*
+     * Only layered constituents are ordered against the boundary: ingest (WT_BTREE_GARBAGE_COLLECT)
+     * strictly above it, stable (WT_BTREE_DISAGGREGATED) at or below it. Metadata commits
+     * untimestamped in the window by design and its transactions cannot be rolled back.
+     */
+    if (!F_ISSET(op->btree, WT_BTREE_GARBAGE_COLLECT) &&
+      !(F_ISSET(op->btree, WT_BTREE_DISAGGREGATED) && !WT_IS_ANY_METADATA(op->btree->dhandle)))
+        return (0);
+    if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_COMMIT))
+        return (0);
+
+    WT_RET_MSG(
+      session, EINVAL, "commit timestamp is required while the step down timestamp is set");
+}
+
+/*
  * __wt_txn_config_clear --
  *     Discard a transaction's configuration. The cache-size exemption is the only setting stored
  *     outside the transaction, so it is dropped here, and only when the transaction claimed it

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1678,10 +1678,10 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_OP *op;
     WT_UPDATE *upd;
-    wt_timestamp_t candidate_durable_timestamp, prev_durable_timestamp, stable_timestamp;
+    wt_timestamp_t candidate_durable_timestamp, prev_durable_timestamp, stable_timestamp,
+      step_down_ts;
     uint64_t recno;
 #ifdef HAVE_DIAGNOSTIC
-    wt_timestamp_t step_down_ts;
     uint32_t prepare_count;
     bool wrote_ingest, wrote_stable;
 #endif
@@ -1694,9 +1694,9 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     key = NULL;
     txn = session->txn;
     txn_global = &conn->txn_global;
+    step_down_ts = __wt_atomic_load_uint64_relaxed(&txn_global->step_down_timestamp);
 #ifdef HAVE_DIAGNOSTIC
     prepare_count = 0;
-    step_down_ts = __wt_atomic_load_uint64_relaxed(&txn_global->step_down_timestamp);
     wrote_ingest = wrote_stable = false;
 #endif
     prepare = F_ISSET(txn, WT_TXN_PREPARE);
@@ -1754,25 +1754,28 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Process updates. */
     for (i = 0, op = txn->mod; i < txn->mod_count; i++, op++) {
+        /* A failure here rolls the whole transaction back. */
+        WT_ERR(__wt_txn_stepdown_commit_ts_check(session, txn, op, step_down_ts));
+
 #ifdef HAVE_DIAGNOSTIC
         /*
          * While the step-down timestamp is set, a committing transaction's layered content must sit
          * on one side of the boundary: ingest content strictly above the timestamp, stable content
-         * at or below it, and never both constituents from one transaction. Checked per operation
-         * here to fold the boundary check into the pass this loop already makes.
+         * at or below it, and never both constituents from one transaction. The commit timestamp is
+         * known to be present here: the check above rejects untimestamped layered commits on the
+         * same operation. Metadata tables commit untimestamped and are not layered content.
          */
         if (step_down_ts != WT_TS_NONE && !prepare && op->type != WT_TXN_OP_NONE &&
           op->btree != NULL) {
-            if (WT_URI_IS_INGEST(op->btree->dhandle->name)) {
+            if (F_ISSET(op->btree, WT_BTREE_GARBAGE_COLLECT)) {
                 wrote_ingest = true;
-                if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_COMMIT))
-                    WT_ASSERT_ALWAYS(session, txn->first_commit_timestamp > step_down_ts,
-                      "ingest content committing at or below the step-down timestamp");
-            } else if (WT_URI_IS_STABLE(op->btree->dhandle->name)) {
+                WT_ASSERT_ALWAYS(session, txn->first_commit_timestamp > step_down_ts,
+                  "ingest content committing at or below the step-down timestamp");
+            } else if (F_ISSET(op->btree, WT_BTREE_DISAGGREGATED) &&
+              !WT_IS_ANY_METADATA(op->btree->dhandle)) {
                 wrote_stable = true;
-                if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_COMMIT))
-                    WT_ASSERT_ALWAYS(session, txn->time_point.commit_timestamp <= step_down_ts,
-                      "stable content committing above the step-down timestamp");
+                WT_ASSERT_ALWAYS(session, txn->time_point.commit_timestamp <= step_down_ts,
+                  "stable content committing above the step-down timestamp");
             }
             WT_ASSERT_ALWAYS(session, !(wrote_ingest && wrote_stable),
               "transaction committing while the step-down timestamp is set wrote both layered "

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1761,9 +1761,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
         /*
          * While the step-down timestamp is set, a committing transaction's layered content must sit
          * on one side of the boundary: ingest content strictly above the timestamp, stable content
-         * at or below it, and never both constituents from one transaction. The commit timestamp is
-         * known to be present here: the check above rejects untimestamped layered commits on the
-         * same operation. Metadata tables commit untimestamped and are not layered content.
+         * at or below it, and never both constituents from one transaction.
          */
         if (step_down_ts != WT_TS_NONE && !prepare && op->type != WT_TXN_OP_NONE &&
           op->btree != NULL) {

--- a/test/suite/test_layered_async_stepdown05.py
+++ b/test/suite/test_layered_async_stepdown05.py
@@ -149,7 +149,7 @@ class test_layered_async_stepdown05(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 25), set())
         self.assertEqual(self.read_kvs_at(self.uri, 25), {})
 
-    # A commit with no timestamp succeeds and lands in ingest; this pins current behavior.
+    # A commit with no timestamp is rejected while the cutoff is set.
     def test_untimestamped_commit_while_step_down_ts_set(self):
         self.set_global_ts(1, 1)
         self.session.create(self.uri, 'key_format=S,value_format=S')
@@ -158,10 +158,14 @@ class test_layered_async_stepdown05(LayeredStepdownMixin, wttest.WiredTigerTestC
         cursor = self.session.open_cursor(self.uri, None, None)
         self.session.begin_transaction()
         cursor['k1'] = 'v'
-        self.session.commit_transaction()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(),
+            '/commit timestamp is required while the step down timestamp is set/')
         cursor.close()
 
-        self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 25), {'k1'})
+        # The rejected commit left nothing behind in either constituent.
+        self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 25), set())
+        self.assertEqual(self.read_kvs_at(self.uri, 25), {})
 
     # The cutoff does not change all_durable behavior: an in-flight txn still clamps it, and it
     # moves normally once that txn resolves and later commits land.


### PR DESCRIPTION
**Problem:** While `step_down_timestamp` is set, every commit to a layered table must carry a commit timestamp: ingest content is ordered strictly above the cutoff, stable content at or below it. A commit with no timestamp skipped validation entirely (`__txn_validate_commit_timestamp` only runs when a timestamp is supplied) and was routed to ingest unordered.

**Solution:** New `__wt_txn_stepdown_commit_ts_check` (txn_inline.h), called per operation in `__wt_txn_commit`'s update loop, rejects untimestamped commits to layered constituents with EINVAL; a failure rolls the whole transaction back. Metadata tables are excluded — they commit untimestamped inside the window by design and their transactions cannot be rolled back. The existing diagnostic per-op boundary check is simplified accordingly (flag-based constituent detection, timestamp-presence guards dropped).

**Test:** `test_untimestamped_commit_while_step_down_ts_set` now asserts the EINVAL refusal instead of pinning the old behavior.
