### PR TITLE
WT-18592 Add missing standard library includes to fix macOS build

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -42,6 +42,7 @@
 #include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include "wiredtiger.h"
 #include "workgen.h"

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
On macOS, libc++ does not provide transitive includes that libstdc++ does on Linux, so two source files fail to compile because they rely on symbols being pulled in indirectly:

- `test/model/src/include/model/kv_transaction_snapshot.h` uses `std::inserter` without including `<iterator>`.
- `bench/workgen/workgen.cpp` uses `std::lock_guard` without including `<mutex>` (it relied on `<shared_mutex>`, included via `workgen_int.h`, to provide it).

Add the missing `#include` directives to fix the macOS build.