### PR TITLE
WT-18593 Enable precise checkpoints in async step-down tests

### DIFF
--- a/test/suite/test_layered_async_stepdown01.py
+++ b/test/suite/test_layered_async_stepdown01.py
@@ -38,7 +38,8 @@ from wtscenario import make_scenarios
 @disagg_test_class
 class test_layered_async_stepdown01(LayeredStepdownMixin, wttest.WiredTigerTestCase):
     test_name = __qualname__
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -71,6 +72,7 @@ class test_layered_async_stepdown01(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), after)
         self.assertEqual(self.read_keys_at(self.stable_uri(self.uri), 40), before,
             'later writes must not reach the stable table')
+        self.complete_step_down(20)
 
     # Update, modify and remove of stable keys route to ingest, like insert.
     def test_update_modify_remove_routing_after_step_down_ts(self):
@@ -137,6 +139,7 @@ class test_layered_async_stepdown01(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertEqual(self.read_keys_at(self.stable_uri(uri2), 40), {'b'})
         self.assertEqual(self.read_kvs_at(uri1, 40), {'a': 'stable', 'c': 'ingest'})
         self.assertEqual(self.read_kvs_at(uri2, 40), {'b': 'stable', 'd': 'ingest'})
+        self.complete_step_down(20)
 
     # A non-overwrite insert of a stable key conflicts even though the write targets ingest.
     def test_duplicate_key_detection_while_step_down_ts_set(self):
@@ -158,6 +161,7 @@ class test_layered_async_stepdown01(LayeredStepdownMixin, wttest.WiredTigerTestC
         # The rejected insert left the stable value alone and nothing in ingest.
         self.assertEqual(self.read_kvs_at(self.uri, 40), {'dup': 'stable'})
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), set())
+        self.complete_step_down(20)
 
     # overwrite=false update and remove consult the merged view; the writes land in ingest.
     def test_overwrite_false_ops_while_step_down_ts_set(self):
@@ -230,3 +234,4 @@ class test_layered_async_stepdown01(LayeredStepdownMixin, wttest.WiredTigerTestC
         cursor.close()
         self.assertEqual(self.read_kvs_at(self.uri, 40), {'k1': 'stable'})
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), set())
+        self.complete_step_down(20)

--- a/test/suite/test_layered_async_stepdown02.py
+++ b/test/suite/test_layered_async_stepdown02.py
@@ -38,7 +38,8 @@ from wtscenario import make_scenarios
 @disagg_test_class
 class test_layered_async_stepdown02(LayeredStepdownMixin, wttest.WiredTigerTestCase):
     test_name = __qualname__
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -107,6 +108,7 @@ class test_layered_async_stepdown02(LayeredStepdownMixin, wttest.WiredTigerTestC
         expected[updated] = 'ingest-update'
         del expected[removed]
         self.assertEqual(self.read_kvs_at(uri, 70), expected)
+        self.complete_step_down(50)
 
     # Point/range lookups merge ingest over stable.
     def test_search_and_search_near_merged(self):
@@ -145,6 +147,7 @@ class test_layered_async_stepdown02(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertEqual(order, ['a', 'b', 'c', 'd', 'e', 'f'])
         self.session.rollback_transaction()
         cursor.close()
+        self.complete_step_down(20)
 
     # A write to ingest is visible to a later read in the same transaction.
     def test_read_your_own_writes_after_step_down_ts(self):
@@ -171,6 +174,7 @@ class test_layered_async_stepdown02(LayeredStepdownMixin, wttest.WiredTigerTestC
 
         # Ground truth: both writes landed in ingest; the stable version is untouched.
         self.assertEqual(self.read_kvs_at(self.stable_uri(uri), 40), {'old': 'stable'})
+        self.complete_step_down(20)
 
     # Reverse iteration and largest_key on either side of the step-down timestamp; largest_key is
     # non-transactional.
@@ -209,6 +213,7 @@ class test_layered_async_stepdown02(LayeredStepdownMixin, wttest.WiredTigerTestC
         # Reverse merged order across both constituents.
         self.assertEqual(reverse_keys(40), ['z', 'f', 'e', 'd', 'c', 'b', 'a'])
         self.assertEqual(largest(), 'z')
+        self.complete_step_down(20)
 
     # Read ops through straddling reader: snapshot pins stable; ingest invisible except largest_key.
     def test_read_ops_across_step_down_ts(self):
@@ -258,6 +263,7 @@ class test_layered_async_stepdown02(LayeredStepdownMixin, wttest.WiredTigerTestC
 
         self.session.rollback_transaction()
         rcur.close()
+        self.complete_step_down(20)
 
     # Check every read op against a per-timestamp oracle: tombstone/re-insert/straddler merges.
     def test_oracle_reads_merges(self):

--- a/test/suite/test_layered_async_stepdown03.py
+++ b/test/suite/test_layered_async_stepdown03.py
@@ -36,7 +36,8 @@ from wtscenario import make_scenarios
 #    back.
 @disagg_test_class
 class test_layered_async_stepdown03(LayeredStepdownMixin, wttest.WiredTigerTestCase):
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -93,6 +94,7 @@ class test_layered_async_stepdown03(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assert_step_down_rollback(lambda: cursor.remove())
         self.session.rollback_transaction()
         cursor.close()
+        self.complete_step_down(20)
 
     # A transaction that wrote beforehand rolls back at commit; the retry lands in ingest.
     def test_straddler_commit_rolls_back(self):
@@ -169,6 +171,7 @@ class test_layered_async_stepdown03(LayeredStepdownMixin, wttest.WiredTigerTestC
         # Committing a read-only transaction must succeed (no WT_ROLLBACK).
         self.session.commit_transaction()
         rcur.close()
+        self.complete_step_down(20)
 
     # Shared body: begin a stable write, set the cutoff, advance stable to it, checkpoint.
     def stable_writer_through_checkpoint(self):

--- a/test/suite/test_layered_async_stepdown04.py
+++ b/test/suite/test_layered_async_stepdown04.py
@@ -38,7 +38,7 @@ from wtscenario import make_scenarios
 class test_layered_async_stepdown04(LayeredStepdownMixin, wttest.WiredTigerTestCase):
     # No periodic statistics-logging thread: it would race with the cursor-cache reopen checks
     # below, which read a connection-wide stat over a narrow window.
-    conn_base_config = 'statistics=(all),'
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -97,6 +97,8 @@ class test_layered_async_stepdown04(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.write_at(self.uri, {'k1': 'v'}, 10)
 
         self.set_step_down_ts(20)
+        # Keep the cutoff armed while allowing the drop retry to checkpoint the stable content.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
         self.dropUntilSuccess(self.session, self.uri)
 
         self.assertRaisesException(wiredtiger.WiredTigerError,
@@ -130,6 +132,7 @@ class test_layered_async_stepdown04(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), {'k2'})
         self.assertEqual(self.read_keys_at(self.stable_uri(self.uri), 40), {'k1'})
         self.assertEqual(self.read_keys_at(self.uri, 40), {'k1', 'k2'})
+        self.complete_step_down(20)
 
     # A cursor closed before the demotion and reopened afterwards serves the surviving content.
     def test_cached_cursor_reuse_across_step_down(self):
@@ -313,6 +316,7 @@ class test_layered_async_stepdown04(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
         self.session.rollback_transaction()
         cursor.close()
+        self.complete_step_down(20)
 
     # The demotion happens with the table still holding an ingest/stable mix, so sampling afterwards
     # is bound by the same contract: only visible merged keys come back.

--- a/test/suite/test_layered_async_stepdown05.py
+++ b/test/suite/test_layered_async_stepdown05.py
@@ -35,7 +35,8 @@ from wtscenario import make_scenarios
 #    Validation of the step-down timestamp itself and the timestamp guards it imposes.
 @disagg_test_class
 class test_layered_async_stepdown05(LayeredStepdownMixin, wttest.WiredTigerTestCase):
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -72,6 +73,7 @@ class test_layered_async_stepdown05(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: self.set_step_down_ts(9),
             '/must not be older than the newest durable timestamp/')
         self.set_step_down_ts(10)
+        self.complete_step_down(10)
 
     # Stable may reach the cutoff exactly but never pass it.
     def test_stable_cannot_pass_cutoff(self):
@@ -192,3 +194,4 @@ class test_layered_async_stepdown05(LayeredStepdownMixin, wttest.WiredTigerTestC
         # A commit above the cutoff carries all_durable past it: drained.
         self.write_at(self.uri, {'k3': 'v'}, 25)
         self.assertEqual(self.all_durable(), 25)
+        self.complete_step_down(20)

--- a/test/suite/test_layered_async_stepdown06.py
+++ b/test/suite/test_layered_async_stepdown06.py
@@ -36,7 +36,8 @@ from wtscenario import make_scenarios
 #    demotion, and the step-up leg that proves the node is reusable.
 @disagg_test_class
 class test_layered_async_stepdown06(LayeredStepdownMixin, wttest.WiredTigerTestCase):
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -477,3 +478,7 @@ class test_layered_async_stepdown06(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.conn.reconfigure('disaggregated=(role="leader")')
         self.assertEqual(self.read_keys_at(self.stable_uri(self.uri), 80), {'a', 'b', 'c', 'd'})
         self.assertEqual(self.read_kvs_at(self.uri, 80), expected)
+
+        # Settle the final leader state after the behavior assertions so teardown can verify it.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(70))
+        self.session.checkpoint()

--- a/test/suite/test_layered_async_stepdown07.py
+++ b/test/suite/test_layered_async_stepdown07.py
@@ -37,7 +37,8 @@ from wtscenario import make_scenarios
 #    operation matrix and the write-conflict cases have their own classes at the end of the file.
 @disagg_test_class
 class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestCase):
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -134,6 +135,7 @@ class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestC
 
         self.session.rollback_transaction()
         c1.close()
+        self.complete_step_down(20)
 
     # Visibility flips at exactly the cutoff after the completed step-down.
     def test_boundary_reads_at_cutoff(self):
@@ -206,6 +208,7 @@ class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestC
         # Exactly one delete happened.
         self.assertEqual(self.read_kvs_at(self.uri, 25), {'victim': 'alive'})
         self.assertEqual(self.read_kvs_at(self.uri, 35), {})
+        self.complete_step_down(20)
 
     # The same conflict with a read timestamp stays caught.
     def test_remove_conflicts_with_read_timestamp(self):
@@ -217,6 +220,7 @@ class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestC
         straddler_session.rollback_transaction()
         straddler_cursor.close()
         straddler_session.close()
+        self.complete_step_down(20)
 
     # search_near on an exact match reports equality, whichever constituent holds the key, and a
     # read timestamp below the cutoff narrows it to the stable half.
@@ -247,6 +251,7 @@ class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestC
         self.assertIn(cursor.get_key(), ('b', 'd'))
         self.session.rollback_transaction()
         cursor.close()
+        self.complete_step_down(20)
 
     # search_near works when only one constituent has content: all of it in ingest over an empty
     # stable table, and nothing anywhere.
@@ -315,6 +320,7 @@ class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestC
         wcur.close()
         wsession.close()
         self.assertIn(largest(), ('d', 'zz'))
+        self.complete_step_down(20)
 
     # A reverse walk interrupted by the cutoff re-seats the same way a forward walk does.
     def test_reverse_iteration_across_step_down_ts(self):
@@ -362,6 +368,7 @@ class test_layered_async_stepdown07(LayeredStepdownMixin, wttest.WiredTigerTestC
             'the reverse walk must yield exactly the snapshot keys once, in order')
         self.assertIn((updated, 'v'), kvs, 'the invisible update must not reach this snapshot')
         self.assertIn((removed, 'v'), kvs, 'the invisible tombstone must not reach this snapshot')
+        self.complete_step_down(50)
 
     # A layered tree never opens by checkpoint, before or after the demotion. Reading the
     # step-down checkpoint means opening the stable constituent's checkpoint view, which holds
@@ -423,7 +430,8 @@ _straddler_ops = [
 # multiply the tests above.
 @disagg_test_class
 class test_layered_async_stepdown07_straddler_ops(LayeredStepdownMixin, wttest.WiredTigerTestCase):
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -452,13 +460,15 @@ class test_layered_async_stepdown07_straddler_ops(LayeredStepdownMixin, wttest.W
         self.assertEqual(self.read_kvs_at(self.uri, 40), {'k1': 'base'})
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), set())
         self.assertEqual(self.read_kvs_at(self.stable_uri(self.uri), 40), {'k1': 'base'})
+        self.complete_step_down(20)
 
 # Write-conflict detection around the cutoff and the demotion, plus a checkpoint taken while the
 # cutoff is set.
 @disagg_test_class
 class test_layered_async_stepdown07_write_conflicts(LayeredStepdownMixin,
                                                    wttest.WiredTigerTestCase):
-    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = \
+        'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
@@ -493,6 +503,7 @@ class test_layered_async_stepdown07_write_conflicts(LayeredStepdownMixin,
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
         cursor.close()
         self.assertEqual(self.read_kvs_at(self.uri, 40), {'k1': 'first'})
+        self.complete_step_down(20)
 
     # An uncommitted ingest write conflicts with another follower writer after demotion.
     def test_conflict_after_demotion(self):
@@ -551,6 +562,7 @@ class test_layered_async_stepdown07_write_conflicts(LayeredStepdownMixin,
         cursor.close()
         self.assertEqual(self.read_kvs_at(self.uri, 40), {'k1': 'newer', 'other': 'fine'})
         self.assertEqual(self.read_keys_at(self.ingest_uri(self.uri), 40), {'other'})
+        self.complete_step_down(20)
 
     # A checkpoint taken while the cutoff is set, before stable reaches it, changes nothing for
     # readers or for routing.

--- a/test/suite/test_layered_async_stepdown09.py
+++ b/test/suite/test_layered_async_stepdown09.py
@@ -40,7 +40,7 @@ from wtscenario import make_scenarios
 @disagg_test_class
 class test_layered_async_stepdown09(LayeredStepdownMixin, wttest.WiredTigerTestCase,
                                     suite_subprocess):
-    conn_config = 'disaggregated=(role="leader")'
+    conn_config = 'precise_checkpoint=true,disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
     checkpoints = [
@@ -75,6 +75,8 @@ class test_layered_async_stepdown09(LayeredStepdownMixin, wttest.WiredTigerTestC
         self._step_down_with_checkpoint_at(self.checkpoint_ts)
 
     def test_step_down_checkpoint_boundary(self):
+        # Precise checkpoint requires a stable timestamp when the parent connection closes.
+        self.set_global_ts(1, 1)
         rc, _ = self.run_subprocess_function(
             'SUBPROCESS',
             'test_layered_async_stepdown09.test_layered_async_stepdown09.subprocess_step_down',


### PR DESCRIPTION
## Summary
- enable `precise_checkpoint=true` in the remaining layered async step-down tests
- complete pending step-downs only after behavioral assertions so teardown can run normal layered verification
- preserve leader-specific test semantics with targeted stable/checkpoint cleanup

## Testing
- `python3 ../test/suite/run.py -j 8 layered_async_stepdown` (115 tests passed)
- `cd dist && ./s_fast`

https://jira.mongodb.org/browse/WT-18593