### PR TITLE
WT-18595 Skip disagg_stable_dhandle_delay stress under disagg multi-node

### DIFF
--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -150,6 +150,15 @@ config_random(TABLE *table, bool table_only)
             continue;
 
         /*
+         * The stable-dhandle delay stalls only the follower's stable checkpoint cursor opens; under
+         * multi-node the leader waits at a rendezvous for the follower to finish, so the delay can
+         * starve the follower past the task budget and hang the leader. Don't random-enable it
+         * there.
+         */
+        if (cp->off == V_GLOBAL_STRESS_DISAGG_STABLE_DHANDLE_DELAY && disagg_is_multi_node())
+            continue;
+
+        /*
          * Boolean flags are 0 or 1, where the variable's "min" value is the percent chance the flag
          * is "on" (so "on" if random rolled <= N, otherwise "off").
          */


### PR DESCRIPTION
### Problem

In `test/format` disaggregated multi-node, leader and follower run as two processes that rendezvous at a socket barrier (`disagg_multi_sync_point`, `format_disagg.c`). The barrier's `read()` has no timeout and runs after the operations loop, outside the 15-minutes-past-max abort guard.

The `disagg_stable_dhandle_delay` timing stress (WT-18532) sleeps 1 second on every stable-table dhandle open, and it fires only for stable URIs. Only the follower opens stable-checkpoint URIs (to validate/mirror), so the stress slows the follower by ~1s per cursor open while the leader runs at full speed. When format's RNG enables the knob (~2% of runs) under `disagg.multi=1`, the leader finishes its loop, blocks forever in the barrier `read()`, and the starved follower never reaches its side of the barrier. No output is produced, so Evergreen kills the task after the 2h idle timeout — the intermittent `task-timed-out` cluster duplicated to WT-18245.

### Fix

Disable the `disagg_stable_dhandle_delay` timing stress for disagg multi-node testing.