### PR TITLE
WT-18425 Free reference addresses during tree discard

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -292,7 +292,9 @@ __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len)
      */
     split_gen = __wt_gen(session, WT_GEN_SPLIT);
     WT_TRET(__wt_stash_add(session, WT_GEN_SPLIT, split_gen, p, len));
-    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+    /* Leave the generation unchanged until the discard completes. */
+    if (!session->split_stash_batch)
+        __wt_gen_next(session, WT_GEN_SPLIT, NULL);
 
     if (ret != 0)
         WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during ref address free"));

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -35,6 +35,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
     dhandle = session->dhandle;
     btree = dhandle->handle;
+    WT_ASSERT(session, !session->split_stash_batch);
 
     /*
      * We need exclusive access to the file, we're about to discard the root page. Assert eviction
@@ -59,6 +60,13 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT;
     if (!F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT))
         walk_flags |= WT_READ_VISIBLE_ALL;
+
+    /*
+     * Discard would otherwise stash, bump the split generation, and scan the session array once per
+     * address. Defer generation bumps and reclamation until the end.
+     */
+    if (syncop == WT_SYNC_DISCARD)
+        session->split_stash_batch = true;
 
     next_ref = NULL;
     WT_ERR(__wt_tree_walk(session, &next_ref, walk_flags));
@@ -135,6 +143,13 @@ err:
         /* On error, clear any left-over tree walk. */
         if (next_ref != NULL)
             WT_TRET(__wt_page_release(session, next_ref, walk_flags));
+    }
+
+    if (syncop == WT_SYNC_DISCARD) {
+        WT_ASSERT(session, session->split_stash_batch);
+        session->split_stash_batch = false;
+        __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+        __wt_stash_discard(session);
     }
 #ifdef HAVE_DIAGNOSTIC
     WT_CONN_CLOSE_ABORT(session, ret);

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -272,6 +272,7 @@ struct __wt_session_impl {
 
     /* Sync support. */
     bool syncing;
+    bool split_stash_batch; /* Batch split stashes during tree discard. */
 
     /* Sessions have an associated statistics bucket based on its ID. */
     u_int stat_conn_bucket;     /* Statistics connection bucket offset */

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -424,7 +424,7 @@ __wt_stash_discard(WT_SESSION_IMPL *session)
 
     for (which = 0; which < WT_GENERATIONS; ++which) {
         session_stash = &session->stash[which];
-        if (session_stash->cnt >= 1)
+        if (session_stash->cnt >= 1 && !(session->split_stash_batch && which == WT_GEN_SPLIT))
             __stash_discard(session, which);
     }
 }
@@ -460,8 +460,8 @@ __wt_stash_add(WT_SESSION_IMPL *session, int which, uint64_t generation, void *p
     (void)__wt_atomic_add_uint64(&conn->stashed_bytes, len);
     (void)__wt_atomic_add_uint64(&conn->stashed_objects, 1);
 
-    /* See if we can free any previous entries. */
-    if (session_stash->cnt > 1)
+    /* See if we can free any previous entries. A batched split stash reclaims once at the end. */
+    if (session_stash->cnt > 1 && !(session->split_stash_batch && which == WT_GEN_SPLIT))
         __stash_discard(session, which);
 
     return (0);

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
         misc_tests/test_layered_snapshot_stress.cpp
         misc_tests/test_semaphore.cpp
         misc_tests/test_session_config.cpp
+        misc_tests/test_stash_batch.cpp
         misc_tests/test_string_match.cpp
         misc_tests/test_tailq.cpp
         misc_tests/test_txn_config.cpp

--- a/test/catch2/misc_tests/test_stash_batch.cpp
+++ b/test/catch2/misc_tests/test_stash_batch.cpp
@@ -1,0 +1,171 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "../wrappers/mock_session.h"
+
+/*
+ * Address free either bumps the split generation per call, or defers the bump and reclamation while
+ * split_stash_batch is set.
+ */
+
+static void
+init_generations(WT_SESSION_IMPL *session, WT_SESSION_IMPL *slot)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    memset(slot, 0, sizeof(*slot));
+    conn->session_array.__array = slot;
+    conn->session_array.size = 1;
+    conn->session_array.cnt = 0;
+    __wt_gen_init(session);
+}
+
+static size_t
+stash_live(WT_SESSION_IMPL *session, int which)
+{
+    size_t i, n;
+
+    for (i = 0, n = 0; i < session->stash[which].cnt; ++i)
+        if (session->stash[which].list[i].p != NULL)
+            ++n;
+    return (n);
+}
+
+static void *
+alloc_buf(WT_SESSION_IMPL *session)
+{
+    void *p;
+
+    REQUIRE(__wt_calloc(session, 1, 16, &p) == 0);
+    return (p);
+}
+
+static void
+free_stash_list(WT_SESSION_IMPL *session, int which)
+{
+    __wt_free(session, session->stash[which].list);
+    session->stash[which].cnt = session->stash[which].alloc = 0;
+}
+
+TEST_CASE("Address free: batch defers generation advancement and reclamation", "[stash_batch]")
+{
+    std::shared_ptr<mock_session> mock = mock_session::build_test_mock_session();
+    WT_SESSION_IMPL *session = mock->get_wt_session_impl();
+    WT_SESSION_IMPL slot;
+    uint64_t start, batch_gen;
+
+    init_generations(session, &slot);
+    start = __wt_gen(session, WT_GEN_SPLIT);
+
+    session->split_stash_batch = true;
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+
+    REQUIRE(__wt_gen(session, WT_GEN_SPLIT) == start);
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 3);
+    batch_gen = session->stash[WT_GEN_SPLIT].list[0].gen;
+    REQUIRE(batch_gen == start);
+    REQUIRE(session->stash[WT_GEN_SPLIT].list[1].gen == batch_gen);
+    REQUIRE(session->stash[WT_GEN_SPLIT].list[2].gen == batch_gen);
+
+    /* A connection-wide generation advance must not trigger intermediate reclamation. */
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+    __wt_stash_discard(session);
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 3);
+
+    session->split_stash_batch = false;
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+    __wt_stash_discard(session);
+
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 0);
+    free_stash_list(session, WT_GEN_SPLIT);
+}
+
+TEST_CASE("Address free: without batch each address advances the generation", "[stash_batch]")
+{
+    std::shared_ptr<mock_session> mock = mock_session::build_test_mock_session();
+    WT_SESSION_IMPL *session = mock->get_wt_session_impl();
+    WT_SESSION_IMPL slot;
+    uint64_t start;
+
+    init_generations(session, &slot);
+    start = __wt_gen(session, WT_GEN_SPLIT);
+
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+    REQUIRE(__wt_gen(session, WT_GEN_SPLIT) == start + 1);
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 1);
+
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+    REQUIRE(__wt_gen(session, WT_GEN_SPLIT) == start + 2);
+    /* The older stash is reclaimed; the newest one still matches the previous generation. */
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 1);
+
+    __wt_stash_discard(session);
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 0);
+
+    free_stash_list(session, WT_GEN_SPLIT);
+}
+
+TEST_CASE("Address free: batched stash stays until the pinning generation drains", "[stash_batch]")
+{
+    std::shared_ptr<mock_session> mock = mock_session::build_test_mock_session();
+    WT_SESSION_IMPL *session = mock->get_wt_session_impl();
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    WT_SESSION_IMPL slot;
+    WT_HAZARD hazard;
+
+    memset(&hazard, 0, sizeof(hazard));
+    init_generations(session, &slot);
+
+    slot.active = 1;
+    slot.hazards.arr = &hazard;
+    slot.generations[WT_GEN_SPLIT] = __wt_gen(session, WT_GEN_SPLIT);
+    conn->session_array.cnt = 1;
+
+    session->split_stash_batch = true;
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+    __wti_ref_addr_safe_free(session, alloc_buf(session), 16);
+    session->split_stash_batch = false;
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+    __wt_stash_discard(session);
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 2);
+
+    slot.generations[WT_GEN_SPLIT] = 0;
+    __wt_stash_discard(session);
+    REQUIRE(stash_live(session, WT_GEN_SPLIT) == 0);
+
+    free_stash_list(session, WT_GEN_SPLIT);
+}
+
+TEST_CASE("Address free: split batch does not defer other stash types", "[stash_batch]")
+{
+    std::shared_ptr<mock_session> mock = mock_session::build_test_mock_session();
+    WT_SESSION_IMPL *session = mock->get_wt_session_impl();
+    WT_SESSION_IMPL slot;
+    uint64_t hazard_gen;
+
+    init_generations(session, &slot);
+    hazard_gen = __wt_gen(session, WT_GEN_HAZARD);
+    session->split_stash_batch = true;
+
+    REQUIRE(__wt_stash_add(session, WT_GEN_HAZARD, hazard_gen, alloc_buf(session), 16) == 0);
+    __wt_gen_next(session, WT_GEN_HAZARD, &hazard_gen);
+    REQUIRE(__wt_stash_add(session, WT_GEN_HAZARD, hazard_gen, alloc_buf(session), 16) == 0);
+    REQUIRE(stash_live(session, WT_GEN_HAZARD) == 1);
+
+    session->split_stash_batch = false;
+    __wt_gen_next(session, WT_GEN_HAZARD, NULL);
+    __wt_stash_discard(session);
+    REQUIRE(stash_live(session, WT_GEN_HAZARD) == 0);
+    free_stash_list(session, WT_GEN_HAZARD);
+}


### PR DESCRIPTION
Free off-page reference addresses immediately during WT_SYNC_DISCARD, where exclusive tree access guarantees no concurrent readers.

Preserve split-generation stashing for ordinary eviction, split, and compact paths.