### PR TITLE
WT-18596 WT tests fail to compile with clang v23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,11 @@ if(HAVE_UNITTEST)
     )
 
     FetchContent_MakeAvailable(Catch2)
+
+    # FIXME-WT-18597: Catch2 v2 uses std::nothrow without including <new>.
+    target_compile_options(Catch2
+        INTERFACE $<IF:$<BOOL:${MSVC_CXX_COMPILER}>,/FInew,-include new>
+    )
 endif()
 
 # Enable CTest. Subsequent targets may additionally define their own ctest definitions.

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -42,6 +42,7 @@
 #include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include "wiredtiger.h"
 #include "workgen.h"

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
- fix missing includes