### PR TITLE
WT-18598 Bound the multi-node sync point wait

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -501,6 +501,7 @@ WT_THREAD_RET timestamp(void *);
 
 uint32_t atou32(const char *, const char *, int);
 uint64_t checksum_database(WT_SESSION *);
+void abort_with_state_dump(WT_CONNECTION *, const char *) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 void config_clear(void);
 void config_compat(const char **);
 void config_error(void);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -27,6 +27,7 @@
  */
 
 #include "format.h"
+#include <poll.h>
 #include <sys/mman.h>
 
 /*
@@ -137,12 +138,16 @@ disagg_setup_multi_node(void)
 
 /*
  * disagg_multi_sync_point --
- *     Synchronization point in disagg multi-node setup for leader-follower.
+ *     Synchronization point in disagg multi-node setup for leader-follower. The wait is bounded: if
+ *     the other process never arrives (its workers are stalled), waiting forever would surface only
+ *     as a silent CI idle-timeout with no diagnostics, so dump state and abort instead.
  */
 static void
-disagg_multi_sync_point(void)
+disagg_multi_sync_point(WT_SESSION *session)
 {
+    struct pollfd pfd;
     char send = 'S'; /* S for sync */
+    int ret;
     char recv;
 
     /* Signal from leader or follower to synchronize. */
@@ -151,9 +156,23 @@ disagg_multi_sync_point(void)
 
     track("Reached sync point. Waiting for other process...", 0ULL);
 
-    /* Wait for synchronization signal from the other process. */
-    if (read(g.disagg_multi_sync_socket, &recv, 1) != 1)
-        testutil_die(errno, "disagg_multi_sync_point: read");
+    /* Wait for synchronization signal from the other process, with a 2-minute bound. */
+    pfd.fd = g.disagg_multi_sync_socket;
+    pfd.events = POLLIN;
+    do {
+        ret = poll(&pfd, 1, 120 * WT_THOUSAND);
+    } while (ret == -1 && errno == EINTR);
+
+    if (ret == 1) {
+        if (read(g.disagg_multi_sync_socket, &recv, 1) != 1)
+            testutil_die(errno, "disagg_multi_sync_point: wrong read content");
+        return;
+    }
+    if (ret == -1)
+        testutil_die(errno, "disagg_multi_sync_point: poll failure");
+
+    abort_with_state_dump(
+      session->connection, "multi-node sync point not reached within 2 minutes");
 }
 
 /*
@@ -176,7 +195,7 @@ disagg_sync_multi_node(WT_SESSION *session)
     }
 
     /* Initial synchronization between leader and follower processes. */
-    disagg_multi_sync_point();
+    disagg_multi_sync_point(session);
 
     if (GV(DISAGG_MULTI_VALIDATION)) {
         /*
@@ -190,7 +209,7 @@ disagg_sync_multi_node(WT_SESSION *session)
             testutil_disagg_preserve(session->connection, "preserve", g.stable_timestamp);
 
         /* Exit synchronization between leader and follower processes. */
-        disagg_multi_sync_point();
+        disagg_multi_sync_point(session);
 
         /* Assert after sync point to ensure both nodes have preserved the data. */
         testutil_assert(hash_match);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -156,11 +156,15 @@ disagg_multi_sync_point(WT_SESSION *session)
 
     track("Reached sync point. Waiting for other process...", 0ULL);
 
-    /* Wait for synchronization signal from the other process, with a 2-minute bound. */
+    /*
+     * Wait for synchronization signal from the other process, with a 10-minute bound. The bound
+     * must be generous: on sanitizer builds the follower's end-of-run validation walk legitimately
+     * lags the leader by minutes.
+     */
     pfd.fd = g.disagg_multi_sync_socket;
     pfd.events = POLLIN;
     do {
-        ret = poll(&pfd, 1, 120 * WT_THOUSAND);
+        ret = poll(&pfd, 1, 600 * WT_THOUSAND);
     } while (ret == -1 && errno == EINTR);
 
     if (ret == 1) {
@@ -172,7 +176,7 @@ disagg_multi_sync_point(WT_SESSION *session)
         testutil_die(errno, "disagg_multi_sync_point: poll failure");
 
     abort_with_state_dump(
-      session->connection, "multi-node sync point not reached within 2 minutes");
+      session->connection, "multi-node sync point not reached within 10 minutes");
 }
 
 /*

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -157,14 +157,15 @@ disagg_multi_sync_point(WT_SESSION *session)
     track("Reached sync point. Waiting for other process...", 0ULL);
 
     /*
-     * Wait for synchronization signal from the other process, with a 10-minute bound. The bound
-     * must be generous: on sanitizer builds the follower's end-of-run validation walk legitimately
-     * lags the leader by minutes.
+     * Wait for synchronization signal from the other process, with a 30-minute bound. The bound is
+     * deliberately far above the lag we expect: followers have been seen trailing the leader by
+     * more than ten minutes even in release builds (FIXME-WT-18605), and this guard exists to turn
+     * a permanent stall into a failure with diagnostics, not to police lag.
      */
     pfd.fd = g.disagg_multi_sync_socket;
     pfd.events = POLLIN;
     do {
-        ret = poll(&pfd, 1, 600 * WT_THOUSAND);
+        ret = poll(&pfd, 1, 30 * 60 * WT_THOUSAND);
     } while (ret == -1 && errno == EINTR);
 
     if (ret == 1) {
@@ -176,7 +177,7 @@ disagg_multi_sync_point(WT_SESSION *session)
         testutil_die(errno, "disagg_multi_sync_point: poll failure");
 
     abort_with_state_dump(
-      session->connection, "multi-node sync point not reached within 10 minutes");
+      session->connection, "multi-node sync point not reached within 30 minutes");
 }
 
 /*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -510,22 +510,8 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
             replay_end_timed_run();
         if (fourths != -1)
             --fourths;
-        if (quit_fourths != -1 && --quit_fourths == 0) {
-            fprintf(stderr, "%s\n", "format run more than 15 minutes past the maximum time");
-            fprintf(stderr, "%s\n",
-              "format run dumping cache and transaction state, then aborting the process");
-
-            /*
-             * If the library is deadlocked, we might just join the mess, set a two-minute timer to
-             * limit our exposure.
-             */
-            set_alarm(120);
-
-            (void)conn->debug_info(conn, "txn");
-            (void)conn->debug_info(conn, "cache");
-
-            __wt_abort(NULL);
-        }
+        if (quit_fourths != -1 && --quit_fourths == 0)
+            abort_with_state_dump(conn, "format run more than 15 minutes past the maximum time");
     }
 
     /* Wait for the special-purpose threads. */

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -72,6 +72,26 @@ signal_timer(int signo)
 }
 
 /*
+ * abort_with_state_dump --
+ *     Dump transaction and cache state, then abort the process. The two-minute alarm limits our
+ *     exposure: if the library is deadlocked, the dump might just join the mess.
+ */
+void
+abort_with_state_dump(WT_CONNECTION *conn, const char *reason)
+{
+    fprintf(stderr, "%s\n", reason);
+    fprintf(stderr, "%s\n", "dumping cache and transaction state, then aborting the process");
+
+    set_alarm(120);
+
+    (void)conn->debug_info(conn, "txn");
+    (void)conn->debug_info(conn, "cache");
+
+    __wt_abort(NULL);
+    /* NOTREACHED */
+}
+
+/*
  * set_alarm --
  *     Set a timer.
  */


### PR DESCRIPTION
### Problem

In disagg multi-node runs the leader/follower rendezvous (`disagg_multi_sync_point`) used a blocking `read()` with no timeout. When one process stalls before reaching the sync point, the other waits forever and the failure surfaces only as a silent 2-hour CI idle-timeout (`format-stress-test-disagg-multi-*`) with no diagnostics.

### Fix

Poll the sync socket with a 30-minute bound; on expiry dump txn and cache state via `debug_info` and abort, sharing a new `abort_with_state_dump` helper with the ops-loop abort guard. The bound is deliberately far above the lag seen in practice — followers have been observed trailing the leader by more than ten minutes even in release builds, tracked separately in WT-18605 — because this guard exists to turn a permanent stall into a failure with diagnostics, not to police lag.