### PR TITLE
WT-18494 Honor operation timeout after transaction release

### DIFF
--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -199,15 +199,15 @@ __wt_op_timer_stop(WT_SESSION_IMPL *session)
 
 /*
  * __wt_op_timer_fired --
- *     Check the operations timers.
+ *     Check the operations timers. The timeout belongs to the current API call, so it still applies
+ *     after the transaction has been released.
  */
 static WT_INLINE bool
 __wt_op_timer_fired(WT_SESSION_IMPL *session)
 {
     uint64_t diff, now;
 
-    if (!F_ISSET(session->txn, WT_TXN_RUNNING) || session->operation_start_us == 0 ||
-      session->operation_timeout_us == 0)
+    if (session->operation_start_us == 0 || session->operation_timeout_us == 0)
         return (false);
 
     now = __wt_clock(session);

--- a/test/suite/test_eviction07.py
+++ b/test/suite/test_eviction07.py
@@ -31,12 +31,10 @@ import wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-# Test that a thread resolving a transaction is released from eviction assist at the remaining
-# operation timeout. The assist normally spins until the cache drops below its triggers, which never
-# happens when the dirty content cannot be reconciled away - here because another session is holding
-# it uncommitted. The resolving thread pins no transaction state, so nothing can roll it back to
-# relieve the pressure and it must be released on its own. The test configures a short operation
-# timeout rather than waiting out the default cap.
+# Test that a thread resolving a transaction is released from eviction assist when dirty content
+# cannot be reclaimed. With an operation timeout, the remaining timeout ends the assist. Without
+# one, the default bounded wait does. Another session holds the dirty content uncommitted, so
+# eviction cannot drain the cache and the resolving thread pins no transaction state.
 class test_eviction07(wttest.WiredTigerTestCase):
     uri = 'table:test_eviction07'
     cache_bytes = 50 * 1024 * 1024
@@ -66,30 +64,61 @@ class test_eviction07(wttest.WiredTigerTestCase):
             for i in range(rows_per_txn):
                 pin_cursor[base + i] = value
 
-    def _resolve_until_timeout(self, cursor):
-        # Resolve modified transactions while the pinned transaction prevents eviction from
-        # reducing the dirty cache pressure. A resolution that takes a material fraction of the
-        # operation timeout, but still returns well under the default assist cap, shows the
-        # caller's timeout was honored.
-        value = 'a' * 4096
-        min_elapsed = self.operation_timeout_ms / 1000.0 * 0.4
-        for i in range(100000, 100500):
-            self.session.begin_transaction(
-                'operation_timeout_ms=%d' % self.operation_timeout_ms)
-            cursor[i] = value
+    def _resolve_transaction(self, cursor, config=None):
+        if config is None:
+            self.session.begin_transaction()
+        else:
+            self.session.begin_transaction(config)
+        cursor[self._next_key] = 'a' * 4096
+        self._next_key += 1
+        start = time.monotonic()
+        if self.rollback:
+            self.session.rollback_transaction()
+        else:
+            self.session.commit_transaction()
+        return time.monotonic() - start
 
-            start = time.monotonic()
-            if self.rollback:
-                self.session.rollback_transaction()
-            else:
-                self.session.commit_transaction()
-            elapsed = time.monotonic() - start
-            if elapsed >= min_elapsed:
+    def _resolve_until_timeout(self, cursor, stat_session):
+        # A resolution that takes a material fraction of the operation timeout, but still returns
+        # well under the default assist cap, shows the caller's timeout was honored. The
+        # bounded-wait statistic must not increase across that resolution: that path is the
+        # fallback when no operation timeout is set.
+        #
+        # Both deadlines can expire in the same assist iteration, so a single increment is
+        # retried. If every slow resolution increments, the operation timeout is not what
+        # released the thread.
+        min_elapsed = self.operation_timeout_ms / 1000.0 * 0.4
+        slow_with_bounded_wait = 0
+        timeout_config = 'operation_timeout_ms=%d' % self.operation_timeout_ms
+        for _ in range(500):
+            bounded_waits = self.get_stat(
+                stat.conn.eviction_app_bounded_wait_exceeded, session=stat_session)
+            elapsed = self._resolve_transaction(cursor, timeout_config)
+            if elapsed < min_elapsed:
+                continue
+            if self.get_stat(stat.conn.eviction_app_bounded_wait_exceeded,
+                session=stat_session) == bounded_waits:
+                return elapsed
+            slow_with_bounded_wait += 1
+            if slow_with_bounded_wait >= 3:
+                return None
+        return None
+
+    def _resolve_until_bounded_wait(self, cursor, stat_session):
+        # No operation timeout, so the assist uses the default bounded wait. The statistic
+        # increasing across a resolution proves that path released the thread.
+        for _ in range(500):
+            bounded_waits = self.get_stat(
+                stat.conn.eviction_app_bounded_wait_exceeded, session=stat_session)
+            elapsed = self._resolve_transaction(cursor)
+            if self.get_stat(stat.conn.eviction_app_bounded_wait_exceeded,
+                session=stat_session) > bounded_waits:
                 return elapsed
         return None
 
-    def test_bounded_assist_at_transaction_resolution(self):
+    def _run_with_pinned_dirty(self, resolve):
         self.session.create(self.uri, 'key_format=i,value_format=S')
+        self._next_key = 100000
         stat_session = None
         pin_sessions_and_cursors = []
         cursor = None
@@ -97,11 +126,13 @@ class test_eviction07(wttest.WiredTigerTestCase):
 
         try:
             # Reading statistics is a cursor operation that can itself be pulled into an eviction
-            # assist, so read them from a session that ignores the cache size.
+            # assist, so read them from a session that ignores the cache size. Pin sessions ignore
+            # it too: they only hold uncommitted dirty, and rolling them back must not wait out
+            # the default bounded assist.
             stat_session = self.conn.open_session('ignore_cache_size=true')
 
             for _ in range(8):
-                pin_session = self.conn.open_session()
+                pin_session = self.conn.open_session('ignore_cache_size=true')
                 pin_sessions_and_cursors.append(
                     (pin_session, pin_session.open_cursor(self.uri)))
             self._pin_dirty_content(pin_sessions_and_cursors)
@@ -113,16 +144,14 @@ class test_eviction07(wttest.WiredTigerTestCase):
 
             cursor = self.session.open_cursor(self.uri)
             resolution_txn_active = True
-            resolution_time = self._resolve_until_timeout(cursor)
+            resolution_time = resolve(cursor, stat_session)
             resolution_txn_active = False
-
-            self.assertIsNotNone(resolution_time)
-            self.assertLess(resolution_time, 1.0)
 
             # The pressure must still be there, otherwise the assist stopped because the cache
             # drained.
             dirty = self.get_stat(stat.conn.cache_bytes_dirty, session=stat_session)
             self.assertGreater(dirty, dirty_trigger)
+            return resolution_time
         finally:
             if pin_txns_active:
                 for pin_session, _ in pin_sessions_and_cursors:
@@ -136,6 +165,17 @@ class test_eviction07(wttest.WiredTigerTestCase):
                 pin_session.close()
             if stat_session is not None:
                 stat_session.close()
+
+    def test_operation_timeout_at_transaction_resolution(self):
+        resolution_time = self._run_with_pinned_dirty(self._resolve_until_timeout)
+        self.assertIsNotNone(resolution_time)
+        self.assertLess(resolution_time, 1.0)
+
+    def test_bounded_assist_at_transaction_resolution(self):
+        resolution_time = self._run_with_pinned_dirty(self._resolve_until_bounded_wait)
+        self.assertIsNotNone(resolution_time)
+        self.assertGreater(resolution_time, 5.0)
+        self.assertLess(resolution_time, 90.0)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_eviction07.py
+++ b/test/suite/test_eviction07.py
@@ -31,12 +31,12 @@ import wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-# Test that a thread resolving a transaction is released from the eviction assist at its bounded
-# wait. The assist normally spins until the cache drops below its triggers, which never happens when
-# the dirty content cannot be reconciled away - here because another session is holding it
-# uncommitted. The resolving thread pins no transaction state, so nothing can roll it back to
-# relieve the pressure and it must be released on its own. The bound is what remains of the caller's
-# own operation timeout, so the test configures a short one rather than waiting out the default cap.
+# Test that a thread resolving a transaction is released from eviction assist at the remaining
+# operation timeout. The assist normally spins until the cache drops below its triggers, which never
+# happens when the dirty content cannot be reconciled away - here because another session is holding
+# it uncommitted. The resolving thread pins no transaction state, so nothing can roll it back to
+# relieve the pressure and it must be released on its own. The test configures a short operation
+# timeout rather than waiting out the default cap.
 class test_eviction07(wttest.WiredTigerTestCase):
     uri = 'table:test_eviction07'
     cache_bytes = 50 * 1024 * 1024
@@ -66,34 +66,27 @@ class test_eviction07(wttest.WiredTigerTestCase):
             for i in range(rows_per_txn):
                 pin_cursor[base + i] = value
 
-    def _resolve_until_bounded_wait(self, cursor, stat_session):
+    def _resolve_until_timeout(self, cursor):
         # Resolve modified transactions while the pinned transaction prevents eviction from
-        # reducing the dirty cache pressure. The bounded-wait statistic increasing across a
-        # resolution proves that the commit or rollback stopped assisting at its time limit.
+        # reducing the dirty cache pressure. A resolution that takes a material fraction of the
+        # operation timeout, but still returns well under the default assist cap, shows the
+        # caller's timeout was honored.
         value = 'a' * 4096
-        bounded_resolution_time = None
+        min_elapsed = self.operation_timeout_ms / 1000.0 * 0.4
         for i in range(100000, 100500):
-            # The assist bounds itself by what is left of the operation timeout, so give the
-            # resolution a short one instead of waiting out the much larger default cap.
             self.session.begin_transaction(
                 'operation_timeout_ms=%d' % self.operation_timeout_ms)
             cursor[i] = value
 
-            bounded_waits = self.get_stat(
-                stat.conn.eviction_app_bounded_wait_exceeded, session=stat_session)
             start = time.monotonic()
             if self.rollback:
                 self.session.rollback_transaction()
             else:
                 self.session.commit_transaction()
             elapsed = time.monotonic() - start
-
-            bounded_waits_after = self.get_stat(
-                stat.conn.eviction_app_bounded_wait_exceeded, session=stat_session)
-            if bounded_waits_after > bounded_waits:
-                bounded_resolution_time = elapsed
-                break
-        return bounded_resolution_time
+            if elapsed >= min_elapsed:
+                return elapsed
+        return None
 
     def test_bounded_assist_at_transaction_resolution(self):
         self.session.create(self.uri, 'key_format=i,value_format=S')
@@ -120,11 +113,11 @@ class test_eviction07(wttest.WiredTigerTestCase):
 
             cursor = self.session.open_cursor(self.uri)
             resolution_txn_active = True
-            bounded_resolution_time = self._resolve_until_bounded_wait(cursor, stat_session)
+            resolution_time = self._resolve_until_timeout(cursor)
             resolution_txn_active = False
 
-            self.assertIsNotNone(bounded_resolution_time)
-            self.assertLess(bounded_resolution_time, 1.0)
+            self.assertIsNotNone(resolution_time)
+            self.assertLess(resolution_time, 1.0)
 
             # The pressure must still be there, otherwise the assist stopped because the cache
             # drained.


### PR DESCRIPTION
The operation timeout belongs to the current API call, not to a running transaction. `__wt_op_timer_fired` previously required `WT_TXN_RUNNING`, so after `commit_transaction` / `rollback_transaction` released the transaction the generic timeout check always returned false. The session timer fields were still set; they were just ignored.

That left post-resolution eviction assist relying only on the separate bounded-wait path. With a caller timeout configured, the assist was still bounded, but the public timeout contract was not honored by the generic timer.

This change drops the `WT_TXN_RUNNING` check so the session timer still fires after release. Callers that did not set `operation_timeout_ms` are unchanged: the timer still returns false, and the default 60s assist cap still applies.

`test_eviction07` no longer asserts `eviction_app_bounded_wait_exceeded`. The timer now breaks the assist loop first, so that statistic usually does not increment. The test asserts that a resolution under pinned dirty pressure takes a material fraction of the 500ms timeout and still returns in under 1s, with dirty remaining above the trigger.
