### PR TITLE
WT-18602 Stop the checkpoint cleanup server when wiredtiger_open fails

### DIFF
--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -98,6 +98,7 @@ __wti_connection_close(WT_CONNECTION_IMPL *conn)
      */
     WT_TRET(__wt_live_restore_server_destroy(session));
     WT_TRET(__wti_background_compact_server_destroy(session));
+    WT_TRET(__wt_checkpoint_cleanup_destroy(session));
     WT_TRET(__wt_checkpoint_server_destroy(session));
     WT_TRET(__wti_disagg_deferred_pickup_server_destroy(session));
     WT_TRET(__wti_statlog_destroy(session, true));


### PR DESCRIPTION
Destroy checkpoint cleanup server in __wti_connection_close with the other servers.
The destroy is idempotent so the normal close path is unchanged.