### PR TITLE
WT-13129 Add page size guard to avoid potential memory failure

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -274,6 +274,22 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
             WT_ERR(ret == 0 ? WT_ERROR : ret);
         }
 
+        /*
+         * The in-memory size in the page header hasn't been verified yet (salvage calls this
+         * function on speculative blocks before verify runs). Bound it before trusting it to size
+         * the decompression buffer and call: too small underflows the compress-skip subtraction
+         * below into a huge length, too large is an unreasonable allocation either way.
+         */
+        if (dsk->mem_size <= WT_BLOCK_COMPRESS_SKIP || dsk->mem_size > WT_BTREE_PAGE_SIZE_MAX) {
+            if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
+                __wt_errx(session,
+                  "%s: compressed block has an invalid in-memory size of %" PRIu32 "B",
+                  btree->dhandle->name, dsk->mem_size);
+            ret = __blkcache_read_corrupt(
+              session, WT_ERROR, addr, addr_size, "compressed block has an invalid in-memory size");
+            WT_ERR(ret == 0 ? WT_ERROR : ret);
+        }
+
         /* Size the buffer based on the in-memory bytes we're expecting from decompression. */
         WT_ERR(__wt_buf_initsize(session, buf, dsk->mem_size));
 

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -275,10 +275,8 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
         }
 
         /*
-         * The in-memory size in the page header hasn't been verified yet (salvage calls this
-         * function on speculative blocks before verify runs). Bound it before trusting it to size
-         * the decompression buffer and call: too small underflows the compress-skip subtraction
-         * below into a huge length, too large is an unreasonable allocation either way.
+         * Salvage reads unverified blocks, so bound the header's in-memory size before trusting it
+         * to size the decompression buffer: too small underflows the subtraction below.
          */
         if (dsk->mem_size <= WT_BLOCK_COMPRESS_SKIP || dsk->mem_size > WT_BTREE_PAGE_SIZE_MAX) {
             if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -280,7 +280,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
          */
         if (dsk->mem_size <= WT_BLOCK_COMPRESS_SKIP) {
             if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
-                __wt_errx_id(session, 1538002,
+                __wt_errx(session,
                   "%s: compressed block has an invalid in-memory size of %" PRIu32 "B",
                   btree->dhandle->name, dsk->mem_size);
             WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -278,14 +278,13 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
          * Salvage reads unverified blocks, so bound the header's in-memory size before trusting it
          * to size the decompression buffer: too small underflows the subtraction below.
          */
-        if (dsk->mem_size <= WT_BLOCK_COMPRESS_SKIP || dsk->mem_size > WT_BTREE_PAGE_SIZE_MAX) {
+        if (dsk->mem_size <= WT_BLOCK_COMPRESS_SKIP) {
             if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
-                __wt_errx(session,
+                __wt_errx_id(session, 1538002,
                   "%s: compressed block has an invalid in-memory size of %" PRIu32 "B",
                   btree->dhandle->name, dsk->mem_size);
-            ret = __blkcache_read_corrupt(
-              session, WT_ERROR, addr, addr_size, "compressed block has an invalid in-memory size");
-            WT_ERR(ret == 0 ? WT_ERROR : ret);
+            WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
+              "compressed block has an invalid in-memory size"));
         }
 
         /* Size the buffer based on the in-memory bytes we're expecting from decompression. */


### PR DESCRIPTION
Reject invalid compress size as `WT_BLOCK_COMPRESS_SKIP` is the uncompressed header. One step further, as we know the valid size range, so we can make a bound check to avoid the invalid size go into `__wt_buf_initsize` that lead to a real failure.