### PR TITLE
WT-18607 Don't disable eviction to flush a handle that was never opened

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -1124,6 +1124,7 @@ __wt_session_lock_checkpoint(WT_SESSION_IMPL *session, const char *checkpoint)
 {
     WT_DATA_HANDLE *saved_dhandle;
     WT_DECL_RET;
+    bool evict_off;
 
     WT_ASSERT(session, WT_META_TRACKING(session));
     saved_dhandle = session->dhandle;
@@ -1144,10 +1145,21 @@ __wt_session_lock_checkpoint(WT_SESSION_IMPL *session, const char *checkpoint)
      * (we are about to re-write the checkpoint which will mean cached pages no longer have valid
      * contents). This is especially noticeable with memory mapped files, since changes to the
      * underlying file are visible to the in-memory pages.
+     *
+     * Nothing here opens the tree. The handle above is taken only to lock the checkpoint, so there
+     * is no root page and the flush below does nothing. Turning eviction off is expensive. It holds
+     * the connection-wide eviction walk lock, interrupts the eviction server, and scans every
+     * eviction queue. A checkpoint pays that for every handle it gathers. That slows the checkpoint
+     * and starves other threads that need eviction off. The sweep server needs the lock most often,
+     * so it waits most. Only turn eviction off when the handle is open. The flush asserts the same
+     * thing: only an open handle needs it.
      */
-    WT_ERR(__wt_evict_file_exclusive_on(session));
+    evict_off = F_ISSET(session->dhandle, WT_DHANDLE_OPEN);
+    if (evict_off)
+        WT_ERR(__wt_evict_file_exclusive_on(session));
     ret = __wt_evict_file(session, WT_SYNC_DISCARD);
-    __wt_evict_file_exclusive_off(session);
+    if (evict_off)
+        __wt_evict_file_exclusive_off(session);
     WT_ERR(ret);
 
     /*


### PR DESCRIPTION
Locking a checkpoint handle acquires it lock-only, which does not open it, so its root page is NULL and the flush that follows returns immediately. Turning eviction off around that flush is not free: it is a connection-wide handshake that interrupts the eviction server, takes the eviction pass and queue locks, and scans every eviction queue. Paying for it once per tree gathered, to bracket a call that does nothing, put the gather behind every other thread wanting that same gate -- including the sweep server, which takes it once per handle it discards.

Only turn eviction off when the handle is open, which is the condition the flush itself already asserts as sufficient.

Measured on the same reproducer, unsampled, 900s per arm: time in the per-handle stage of the gather fell from 157ms to 44ms per checkpoint, the share of checkpoints preparing longer than a second from 5.8% to 1.7%, and the longest prepare from 2859ms to 1623ms.
