### PR TITLE
WT-15917 Only set NOKEEP eviction at the trigger for disaggregated storage

### DIFF
--- a/src/evict/evict_thread.c
+++ b/src/evict/evict_thread.c
@@ -584,7 +584,8 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
             LF_SET(WT_EVICT_CACHE_SCRUB);
         }
 
-    } else
+    } else if (!__wt_conn_is_disagg(session) ||
+      bytes_inuse >= (uint64_t)(trigger * bytes_max) / 100)
         LF_SET(WT_EVICT_CACHE_NOKEEP);
 
     if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT)) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/BF-46261

WT-15917 Only set NOKEEP for disaggregated storage at the eviction trigger

Cache usage at or above the midpoint of the eviction target and trigger sets WT_EVICT_CACHE_NOKEEP, so pages read in are not retained. Under disaggregated storage that band is too aggressive: re-fetching a page costs far more than it does against local storage, so pages dropped between the midpoint and the trigger get read back, driving the ~12% ycsb_load and ~13% linkbench2 regressions seen in BF-46261.

Guard the flag so disagg stops keeping read pages only once usage reaches the trigger itself. Non-disagg behaviour is unchanged.

[BF-46261  
](https://spruce.corp.mongodb.com/version/6aa20080cf3056000752566f)
[PR 14702 (revert)](https://spruce.corp.mongodb.com/version/6aa1ec72483e920007a1d2ef)   https://github.com/wiredtiger/wiredtiger/pull/14702
[PR 14703  (no guard)](https://spruce.corp.mongodb.com/version/6aa23348b167ec00073d851b)  https://github.com/wiredtiger/wiredtiger/pull/14703