### PR TITLE
WT-18172 Exclude checkpoint cursor btrees from block cache

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -151,6 +151,10 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
     if (S2BT(session)->storage_tier == WT_BTREE_STORAGE_TIER_COLD)
         F_SET(&get_args, WT_PAGE_LOG_COLD);
 
+    /* A checkpoint cursor reads historical page versions, so bypass any block cache. */
+    if (WT_DHANDLE_IS_CHECKPOINT(S2BT(session)->dhandle))
+        F_SET(&get_args, WT_PAGE_LOG_CACHE_BYPASS);
+
     __wt_verbose(session, WT_VERB_READ,
       "page_id %" PRIu64 ", table_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
       ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -88,6 +88,10 @@ __evict_page_victim_cache_eligible(WT_SESSION_IMPL *session, WT_REF *ref)
     if (!F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
         return (false);
 
+    /* A checkpoint cursor's btree is not eligible for the victim cache. */
+    if (WT_DHANDLE_IS_CHECKPOINT(S2BT(session)->dhandle))
+        return (false);
+
     WT_BM *bm = S2BT(session)->bm;
     if (bm == NULL)
         return (false);

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6014,6 +6014,8 @@ typedef enum {
 #define WT_PAGE_LOG_ENCRYPTED 0x4u
 /*! page is cold tier */
 #define WT_PAGE_LOG_COLD 0x8u
+/*! bypass any block cache when serving the read */
+#define WT_PAGE_LOG_CACHE_BYPASS 0x40u
 
 /*!
  * WT_PAGE_LOG::pl_complete_checkpoint interface.


### PR DESCRIPTION
The block cache shares reconstructed disk images across btrees keyed only on (file ID, address cookie). A btree opened by a checkpoint cursor is a separate dhandle over the same file, so it resolves the same address cookies and can share cache entries with the normal btree. This is not safe: the two reconstruct full disk images from deltas differently.
Currently we don't have ckpt cursor for disagg, the PR is to add this guard to prevent unexpected bugs if we re-enable that in the future.