### PR TITLE
WT-18272 Validate a pending DROP before panicking on skipped shared metadata creates

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1068,6 +1068,7 @@ env
 eof
 ep
 epochless
+epochp
 epp
 eq
 equalp

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -937,6 +937,96 @@ __disagg_remove_is_checkpoint_violation(WT_SESSION_IMPL *session, WT_CONNECTION_
 }
 
 /*
+ * __disagg_parked_create_drop_epoch --
+ *     Return the schema epoch of the DROP that blocks a parked CREATE, or WT_SCHEMA_EPOCH_NONE when
+ *     no such DROP exists.
+ */
+static wt_timestamp_t
+__disagg_parked_create_drop_epoch(
+  WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn, WT_DISAGG_METADATA_OP *parked)
+{
+    WT_DISAGG_METADATA_OP *entry;
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q)
+        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE &&
+          WT_STREQ(entry->stable_uri, parked->stable_uri))
+            return (entry->schema_epoch);
+
+    return (WT_SCHEMA_EPOCH_NONE);
+}
+
+/*
+ * __disagg_check_epoch_deferral --
+ *     Check that leaving an entry queued for a later checkpoint is legal, and count it.
+ */
+static int
+__disagg_check_epoch_deferral(WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn,
+  WT_DISAGG_METADATA_OP *entry, wt_timestamp_t cur_schema_epoch)
+{
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    if (__disagg_remove_is_checkpoint_violation(session, conn, entry, cur_schema_epoch)) {
+        __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "API violation: table \"%s\" was dropped at schema epoch %" PRIu64
+          " and recreated, above the checkpoint's schema epoch %" PRIu64
+          ": the checkpoint refers to the dropped generation",
+          entry->table_name, entry->schema_epoch, cur_schema_epoch);
+        WT_RET_PANIC(session, EINVAL,
+          "API violation: checkpoint schema epoch refers to a dropped and recreated table");
+    }
+
+    __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
+      "Defer metadata operation %s for table \"%s\" with schema epoch %" PRIu64,
+      __wti_disagg_shared_metadata_op_to_string(entry->metadata_op), entry->table_name,
+      entry->schema_epoch);
+    WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_unstable);
+
+    return (0);
+}
+
+/*
+ * __disagg_parked_creates_panic --
+ *     Panic on the creates this checkpoint parked, naming the DROP that blocks each one.
+ *
+ * The checkpoint's epoch is at or above the create's and below the drop's, so this checkpoint must
+ *     include the table in shared metadata. But the table was dropped and its stable constituent
+ *     was never created, so we have no data to write. Drop the table only once a checkpoint covers
+ *     its create, to avoid this window.
+ */
+static int
+__disagg_parked_creates_panic(WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn,
+  struct __wt_disagg_shared_metadata_qh *skipped_creates, wt_timestamp_t cur_schema_epoch)
+{
+    WT_DISAGG_METADATA_OP *skipped;
+    wt_timestamp_t drop_epoch;
+    char drop_desc[64];
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    TAILQ_FOREACH (skipped, skipped_creates, q) {
+        drop_epoch = __disagg_parked_create_drop_epoch(session, conn, skipped);
+        if (drop_epoch == WT_SCHEMA_EPOCH_NONE)
+            WT_IGNORE_RET(__wt_snprintf(drop_desc, sizeof(drop_desc), "no DROP is queued for it"));
+        else if (drop_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED)
+            WT_IGNORE_RET(
+              __wt_snprintf(drop_desc, sizeof(drop_desc), "its DROP was never published"));
+        else
+            WT_IGNORE_RET(__wt_snprintf(
+              drop_desc, sizeof(drop_desc), "its DROP is at epoch %" PRIu64, drop_epoch));
+        __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "API violation: Table \"%s\" was published with CREATE at epoch %" PRIu64
+          " and %s. This checkpoint must include the table in shared metadata, but the table was "
+          "dropped and we have no data to write.",
+          skipped->table_name, skipped->schema_epoch, drop_desc);
+    }
+
+    WT_RET_PANIC(session, EINVAL,
+      "API violation: See above for details. Current schema epoch: %" PRIu64 ".", cur_schema_epoch);
+}
+
+/*
  * __disagg_requeue_skipped_creates --
  *     Return parked create entries to the head of the shared metadata queue, restoring their
  *     original order, so a later checkpoint revisits them.
@@ -961,8 +1051,10 @@ __disagg_requeue_skipped_creates(
 
 /*
  * __wt_disagg_shared_metadata_queue_process --
- *     Process the update metadata list, returning the total checkpoint size of the shared rows the
- *     REMOVE entries deleted so the caller can reduce the database size accordingly.
+ *     Drain the shared metadata queue into the shared metadata table: apply every entry the
+ *     checkpoint's schema epoch covers, leave the rest queued for a later checkpoint, and resolve
+ *     the creates parked along the way. Returns the total checkpoint size of the shared rows the
+ *     REMOVE entries deleted, so the caller can reduce the database size accordingly.
  */
 int
 __wt_disagg_shared_metadata_queue_process(
@@ -971,7 +1063,7 @@ __wt_disagg_shared_metadata_queue_process(
     struct __wt_disagg_shared_metadata_qh skipped_creates;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
+    WT_DISAGG_METADATA_OP *entry, *tmp;
     uint64_t entry_drop_size;
 
     WT_ASSERT(session, drop_sizep != NULL);
@@ -1000,20 +1092,7 @@ __wt_disagg_shared_metadata_queue_process(
 
         /* Defer entries based on the schema epoch. */
         if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE && entry->schema_epoch > cur_schema_epoch) {
-            if (__disagg_remove_is_checkpoint_violation(session, conn, entry, cur_schema_epoch)) {
-                __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
-                  "API violation: table \"%s\" was dropped at schema epoch %" PRIu64
-                  " and recreated, above the checkpoint's schema epoch %" PRIu64
-                  ": the checkpoint refers to the dropped generation",
-                  entry->table_name, entry->schema_epoch, cur_schema_epoch);
-                WT_ERR_PANIC(session, EINVAL,
-                  "API violation: checkpoint schema epoch refers to a dropped and recreated table");
-            }
-            __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-              "Defer metadata operation %s for table \"%s\" with schema epoch %" PRIu64,
-              __wti_disagg_shared_metadata_op_to_string(entry->metadata_op), entry->table_name,
-              entry->schema_epoch);
-            WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_unstable);
+            WT_ERR(__disagg_check_epoch_deferral(session, conn, entry, cur_schema_epoch));
             continue;
         }
 
@@ -1036,35 +1115,18 @@ __wt_disagg_shared_metadata_queue_process(
         __disagg_shared_metadata_queue_free(session, &entry);
     }
 
+    /*
+     * A parked CREATE left while a step-down timestamp is set belongs to the era the pending
+     * step-down begins, so put it back for a later leader era to complete. A violation parked
+     * meanwhile is caught by the next era's drain. The schema lock held here serializes the
+     * timestamp, making the relaxed load safe. Anything else is an API violation.
+     */
     if (!TAILQ_EMPTY(&skipped_creates)) {
-        /*
-         * A parked CREATE left while a step-down timestamp is set belongs to the era the pending
-         * step-down begins, so put it back for a later leader era to complete. A violation parked
-         * meanwhile is caught by the next era's drain. The schema lock held here serializes the
-         * timestamp, making the relaxed load safe.
-         */
         if (__wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_timestamp) != WT_TS_NONE)
             __disagg_requeue_skipped_creates(session, &skipped_creates);
-        else {
-            /*
-             * Otherwise the stable epoch falls between the CREATE and DROP epochs, so this
-             * checkpoint must include the table in shared metadata. But the table was dropped and
-             * its stable constituent was never created, so we have no data to write. Publish CREATE
-             * and DROP at the same epoch to avoid this window.
-             *
-             * FIXME-WT-18272: Confirm a pending DROP for the same table really is queued behind the
-             * parked CREATE before panicking, and report the epoch of that DROP in the message.
-             */
-            TAILQ_FOREACH (skipped, &skipped_creates, q)
-                __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
-                  "API violation: Table \"%s\" was published with CREATE at epoch %" PRIu64
-                  " and DROP at a later epoch. This checkpoint must include the table in shared "
-                  "metadata, but the table was dropped and we have no data to write.",
-                  skipped->table_name, skipped->schema_epoch);
-            WT_ERR_PANIC(session, EINVAL,
-              "API violation: See above for details. Current schema epoch: %" PRIu64 ".",
-              cur_schema_epoch);
-        }
+        else
+            WT_ERR(
+              __disagg_parked_creates_panic(session, conn, &skipped_creates, cur_schema_epoch));
     }
 
 err:
@@ -1074,13 +1136,10 @@ err:
      */
     if (ret != 0)
         __disagg_requeue_skipped_creates(session, &skipped_creates);
+    /* By this point, the local list should no longer own any skipped creates. */
+    WT_ASSERT(session, TAILQ_EMPTY(&skipped_creates));
 
     __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
-    while (!TAILQ_EMPTY(&skipped_creates)) {
-        skipped = TAILQ_FIRST(&skipped_creates);
-        TAILQ_REMOVE(&skipped_creates, skipped, q);
-        __disagg_shared_metadata_queue_free(session, &skipped);
-    }
     return (ret);
 }
 
@@ -1887,8 +1946,8 @@ __disagg_step_down(WT_SESSION_IMPL *session)
     /*
      * The schema lock serializes two things against the step-down.
      *
-     * First, application schema operations: the step-down clears the shared metadata queue and
-     * changes layered-table state underneath them.
+     * First, application schema operations: the step-down changes layered-table state underneath
+     * them. The shared metadata queue survives it, for a later leader era to drain.
      *
      * Second, cursor opens: every btree open runs under the schema lock, so holding it here means
      * an open either completes before the step-down, and the walk below sees the handle and marks

--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -35,7 +35,7 @@ WT_TEST.foo/
 ├── switch_request                │ coordination protocol
 ├── switch_done.<k>               │
 ├── stop_run                      ┘
-└── ckpt_adopted                  latest follower checkpoint LSN
+└── ckpt_adopted                  latest follower checkpoint LSN and schema epoch
 WT_TEST.foo.SAVE/                 pre-verification copy of the home
 ```
 
@@ -61,7 +61,7 @@ stateDiagram-v2
     CREATED --> PUBLISHED : publish create
     CREATED --> NONE : cancel with drop
     PUBLISHED --> PUBLISHED : insert or linger
-    PUBLISHED --> DROPPED : drop
+    PUBLISHED --> DROPPED : drop, once the peer covers the create
     DROPPED --> DROPPED : linger
     DROPPED --> REMOVED : publish drop
     REMOVED --> REMOVED : await coverage

--- a/test/csuite/schema_disagg_abort/ckpt.c
+++ b/test/csuite/schema_disagg_abort/ckpt.c
@@ -266,6 +266,21 @@ ckpt_take_stepdown(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 }
 
 /*
+ * ckpt_update_adopted_epoch --
+ *     Track how far the peer's pick-ups have come: the generator gates its drops on it.
+ */
+static void
+ckpt_update_adopted_epoch(WORKLOAD_STATE *state)
+{
+    if (node_is_lone(state->cfg))
+        return; /* no one adopts checkpoints */
+
+    uint64_t peer_epoch;
+    (void)adopted_ckpt_read(&peer_epoch);
+    __wt_atomic_store_uint64(&state->adopted_ckpt_epoch, peer_epoch);
+}
+
+/*
  * leader_checkpoint --
  *     The leader's checkpoint duty: a step-down replaces the cadence with one final checkpoint, and
  *     nothing else is checkpointed until the transition completes.
@@ -273,6 +288,8 @@ ckpt_take_stepdown(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 void
 leader_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
 {
+    ckpt_update_adopted_epoch(state);
+
     if (__wt_atomic_load_uint64(&state->stepdown_ts) != 0)
         ckpt_take_stepdown(state, session, ckpt);
     else
@@ -309,8 +326,9 @@ follower_checkpoint(WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt)
           state->cfg->node_id, ckpt_args.checkpoint_timestamp, ckpt_args.checkpoint_lsn,
           frontier_ts);
 
-        /* Each pick-up is reported for a stepping-down peer. */
-        adopted_lsn_publish(state->cfg->node_id, state->adopted_ckpt_lsn);
+        /* Each pick-up is reported for the peer: a stepping-down leader and its generator. */
+        adopted_ckpt_publish(state->cfg->node_id, state->adopted_ckpt_lsn,
+          query_ts(state->conn, TS_LAST_SCHEMA_EPOCH));
 
         /* The first picked up checkpoint: follower is ready. */
         if (first_ckpt)

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -38,6 +38,26 @@ generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
 }
 
 /*
+ * generator_slot_droppable --
+ *     Whether this slot's table can be dropped now.
+ */
+static bool
+generator_slot_droppable(WORKLOAD_STATE *state, uint32_t t, uint32_t slot)
+{
+    if (state->workers[t].table[slot].uncovered_insert)
+        return (false);
+
+    /* Legacy mode has no epochs to cover, and a lone node or a dead peer has nobody to protect. */
+    if (state->cfg->epoch_less || node_is_lone(state->cfg) || !state->cfg->peer_alive)
+        return (true);
+
+    const uint64_t create_epoch =
+      __wt_atomic_load_uint64(&state->workers[t].table[slot].create_epoch);
+    return (create_epoch != WT_SCHEMA_EPOCH_NONE &&
+      __wt_atomic_load_uint64(&state->adopted_ckpt_epoch) >= create_epoch);
+}
+
+/*
  * generator_op --
  *     Advance one slot of the given worker thread through the table lifecycle, taking one of its
  *     state's valid moves at random. Reports whether an event was emitted; taking no move is valid,
@@ -51,6 +71,7 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
     WT_RAND_STATE *rnd = &state->workers[t].rnd;
     const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
     TABLE_STATE *slot_state = &state->workers[t].table[slot].state;
+    uint64_t *create_epoch = &state->workers[t].table[slot].create_epoch;
     uint64_t *drop_epoch = &state->workers[t].table[slot].drop_epoch;
     /* Set when no checkpoint of this phase can cover the insert; such a slot is not droppable. */
     bool *uncovered_insert = &state->workers[t].table[slot].uncovered_insert;
@@ -84,11 +105,14 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         /* Take (more) data, drop the table, or linger. */
         if (__wt_random(rnd) % GEN_INSERT_ODDS == 0) {
             ev.type = EVENT_INSERT;
+            /* No checkpoint of this phase can cover it, so the slot stops being droppable. */
             if (stepping_down || !state->leads)
                 *uncovered_insert = true;
-        } else if (__wt_random(rnd) % GEN_DROP_ODDS == 0 && !*uncovered_insert) {
-            /* Such a drop would wait on a checkpoint this phase cannot take. */
+        } else if (__wt_random(rnd) % GEN_DROP_ODDS == 0 &&
+          generator_slot_droppable(state, t, slot)) {
             ev.type = EVENT_DROP;
+            /* Consume the create's epoch: the next table in this slot publishes its own. */
+            __wt_atomic_store_uint64(create_epoch, WT_SCHEMA_EPOCH_NONE);
             *slot_state = state->cfg->epoch_less ? TABLE_NONE : TABLE_DROPPED;
         }
         break;
@@ -101,12 +125,13 @@ generator_op(WORKLOAD_STATE *state, uint32_t t, GENERATOR_PHASE phase)
         }
         break;
     case TABLE_REMOVED: {
-        /* Free the slot once the stable epoch passes the published drop; zero is not applied yet.
+        /*
+         * Free the slot once the stable epoch passes the published drop; zero is not applied yet.
          */
         const uint64_t published_drop = __wt_atomic_load_uint64(drop_epoch);
-        if (published_drop != 0 &&
+        if (published_drop != WT_SCHEMA_EPOCH_NONE &&
           __wt_atomic_load_uint64(&state->stable_epoch) >= published_drop) {
-            __wt_atomic_store_uint64(drop_epoch, 0);
+            __wt_atomic_store_uint64(drop_epoch, WT_SCHEMA_EPOCH_NONE);
             *slot_state = TABLE_NONE;
         }
         break;
@@ -194,9 +219,6 @@ generator_switch_requested(GENERATOR_PACING *pacing)
 /*
  * generator_publish_pending --
  *     Emit the pending publish for every slot in an unpublished state.
- *
- * FIXME-WT-18272 FIXME-WT-18284: Consider removing this function and GEN_PUBLISH_PENDING once these
- *     are fixed.
  */
 static void
 generator_publish_pending(WORKLOAD_STATE *state)
@@ -247,7 +269,7 @@ generator_stepdown_ended(WORKLOAD_STATE *state, GENERATOR_PACING *pacing)
     const uint64_t stepdown_events = state->emitted - pacing->stepdown_emitted;
     /* Lone node exhausted step-down events or peer adopted the checkpoint. */
     const bool ended = ckpt_lsn != 0 &&
-      (lone ? stepdown_events >= GEN_STEPDOWN_MIN_EVENTS : adopted_lsn_read() >= ckpt_lsn);
+      (lone ? stepdown_events >= GEN_STEPDOWN_MIN_EVENTS : adopted_ckpt_read(NULL) >= ckpt_lsn);
 
     if (ended)
         return (true);

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -104,38 +104,41 @@ set_ts(const TEST_CONFIG *cfg, WT_CONNECTION *conn, uint8_t mask, uint64_t ts)
 }
 
 /*
- * adopted_lsn_publish --
- *     Report the latest adopted checkpoint LSN for a stepping-down peer to wait on.
+ * adopted_ckpt_publish --
+ *     Report the latest adopted checkpoint's LSN and schema epoch for the peer to wait on.
  */
 void
-adopted_lsn_publish(uint32_t node_id, uint64_t lsn)
+adopted_ckpt_publish(uint32_t node_id, uint64_t lsn, uint64_t schema_epoch)
 {
     /* Write to a temporary file first, so a reader never sees a partial value */
     char tmp[64];
-    testutil_snprintf(tmp, sizeof(tmp), ADOPTED_LSN_FILE ".%" PRIu32, node_id);
+    testutil_snprintf(tmp, sizeof(tmp), ADOPTED_CKPT_FILE ".%" PRIu32, node_id);
 
     FILE *fp;
     testutil_assert_errno((fp = fopen(tmp, "w")) != NULL);
-    testutil_assert(fprintf(fp, "%" PRIu64 "\n", lsn) > 0);
+    testutil_assert(fprintf(fp, "%" PRIu64 " %" PRIu64 "\n", lsn, schema_epoch) > 0);
     testutil_check(fclose(fp));
-    /* Publish the LSN. */
-    testutil_assert_errno(rename(tmp, ADOPTED_LSN_FILE) == 0);
+    /* Publish the pair. */
+    testutil_assert_errno(rename(tmp, ADOPTED_CKPT_FILE) == 0);
 }
 
 /*
- * adopted_lsn_read --
- *     Return the peer's last reported adopted checkpoint LSN; zero when none yet.
+ * adopted_ckpt_read --
+ *     Return the peer's last reported adopted checkpoint LSN and its schema epoch.
  */
 uint64_t
-adopted_lsn_read(void)
+adopted_ckpt_read(uint64_t *schema_epochp)
 {
-    FILE *fp = fopen(ADOPTED_LSN_FILE, "r");
-    if (fp == NULL)
-        return (0);
+    uint64_t lsn = 0, schema_epoch = 0;
 
-    uint64_t lsn = 0;
-    testutil_ignore_ret(fscanf(fp, "%" SCNu64, &lsn));
-    testutil_check(fclose(fp));
+    FILE *fp = fopen(ADOPTED_CKPT_FILE, "r");
+    if (fp != NULL) {
+        testutil_ignore_ret(fscanf(fp, "%" SCNu64 " %" SCNu64, &lsn, &schema_epoch));
+        testutil_check(fclose(fp));
+    }
+
+    if (schema_epochp != NULL)
+        *schema_epochp = schema_epoch;
     return (lsn);
 }
 

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -86,8 +86,11 @@
 #define SWITCH_DONE_FMT "switch_done.%" PRIu32 /* the n-th switch completed */
 #define STOP_FILE "stop_run"                   /* parent directs a graceful stop */
 
-/* The follower's latest adopted checkpoint LSN; a stepping-down leader polls it. */
-#define ADOPTED_LSN_FILE "ckpt_adopted"
+/*
+ * The follower's latest adopted checkpoint, its LSN and its schema epoch: a stepping-down leader
+ * polls the LSN, and a leading generator the epoch.
+ */
+#define ADOPTED_CKPT_FILE "ckpt_adopted"
 
 /* Connection config. */
 #define ENV_CONFIG_DEF "create,statistics=(all),statistics_log=(json,on_close,wait=1)"
@@ -227,7 +230,9 @@ typedef struct {
     bool handover_received;    /* the term was handed over this phase; atomic access */
     uint32_t stop_stage;       /* how far the phase's shutdown has progressed; atomic access */
     uint64_t adopted_ckpt_lsn; /* skip re-adopting the same checkpoint; reset on role change */
-    uint32_t switch_gen;       /* how many role transitions this node has completed */
+    uint64_t adopted_ckpt_epoch; /* latest adopted checkpoint epoch (on follower); atomic access. */
+
+    uint32_t switch_gen; /* how many role transitions this node has completed */
 
     /* Step-down state, zero outside a transition; atomic access. */
     uint64_t stepdown_ts;       /* while set, the timestamp and checkpoint threads hold */
@@ -256,6 +261,8 @@ typedef struct {
             TABLE_STATE state;
             /* Advanced by every create under -q, so a slot's table name is never reused. */
             uint32_t gen;
+            /* Published create's epoch once its publish applies, else 0; atomic access. */
+            uint64_t create_epoch;
             /* Published drop's epoch once its publish applies, else 0; atomic access. */
             uint64_t drop_epoch;
             /* Inserted data is uncovered yet. Not droppable until a checkpoint. */
@@ -299,8 +306,8 @@ typedef struct {
 void println(const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 1, 2)));
 uint64_t query_ts(WT_CONNECTION *conn, uint8_t bit);
 void set_ts(const TEST_CONFIG *cfg, WT_CONNECTION *conn, uint8_t mask, uint64_t ts);
-void adopted_lsn_publish(uint32_t node_id, uint64_t lsn);
-uint64_t adopted_lsn_read(void);
+void adopted_ckpt_publish(uint32_t node_id, uint64_t lsn, uint64_t schema_epoch);
+uint64_t adopted_ckpt_read(uint64_t *schema_epochp);
 
 /* parent.c */
 void parent_main(TEST_CONFIG *cfg, const char *self_path);

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -304,10 +304,13 @@ apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, SCHEM
         testutil_assert(!state->cfg->epoch_less);
         ev->event_ts = worker_ts(state, ev);
         schema_op_publish(ctx->session, ev->uri, ev->event_ts);
-        if (state->generates && ev->type == EVENT_PUBLISH_DROP) {
+        if (state->generates) {
             testutil_assert(ev->slot < state->cfg->pool_size);
-            __wt_atomic_store_uint64(
-              &state->workers[thread_index].table[ev->slot].drop_epoch, ev->event_ts);
+            /* Preserve the epoch of this op, so generator can pace itself. */
+            __wt_atomic_store_uint64(ev->type == EVENT_PUBLISH_DROP ?
+                &state->workers[thread_index].table[ev->slot].drop_epoch :
+                &state->workers[thread_index].table[ev->slot].create_epoch,
+              ev->event_ts);
         }
         if (relay)
             (void)pipe_relay_event(state->cfg, ev);

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -665,7 +665,7 @@ variables:
             ${PREPARE_TEST_ENV}
             # The full mode matrix in short runs: single node, lone follower, role switches,
             # kills, and both two-node topologies. The two-node switch modes at the end are
-            # EXPECTED to fail until FIXME-WT-18068 and FIXME-WT-17746 land.
+            # EXPECTED to fail until FIXME-WT-17746 land.
             bash ./smoke.sh
 
   # Configure flags for builtins.

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -32,6 +32,7 @@
 # step-up, which uses the metadata operation queue populated while the node
 # was a follower.
 
+import os
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from suite_subprocess import suite_subprocess
@@ -75,6 +76,20 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         self.conn.reconfigure('disaggregated=(role="follower")')
         conn_follower.reconfigure('disaggregated=(role="leader")')
+
+    def assert_panicked(self, subdir, funcname, expected):
+        """
+        Run funcname in a subprocess and assert it panicked with the expected message.
+
+        Checking the message matters: an abort anywhere earlier in the body also exits non-zero,
+        so a return code alone cannot tell a reached panic from a mis-set up test.
+        """
+        [returncode, home] = self.run_subprocess_function(subdir,
+            f'{self.test_name}.{self.test_name}.{funcname}', silent=True)
+        self.assertNotEqual(returncode, 0)
+        with open(os.path.join(home, 'stderr.txt'), 'r') as f:
+            stderr = f.read()
+        self.assertIn(expected, stderr)
 
     def checkpoint_and_advance(self, epoch, stable_ts, conn_leader):
         """
@@ -278,7 +293,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """Subprocess body for the split-epochs panic test; expected to panic/abort."""
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 20, session_follow)
@@ -319,12 +334,104 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # Initialize self.conn so the test fixture can close it cleanly; the real test runs
         # in a subprocess so that the panic/abort does not kill the test runner.
         self.setup_leader_with_epoch()
-        subdir = 'SUBPROCESS_create_drop_split_epochs'
-        [returncode, _] = self.run_subprocess_function(subdir,
-            f'{self.test_name}.{self.test_name}.subprocess_create_drop_split_epochs',
-            silent=True)
-        self.assertNotEqual(returncode, 0)
+        self.assert_panicked('SUBPROCESS_create_drop_split_epochs',
+            'subprocess_create_drop_split_epochs',
+            f'Table "{self.test_name}" was published with CREATE at epoch 20 and its DROP is at '
+            'epoch 30')
 
+    def subprocess_create_unpublished_drop(self):
+        """Subprocess body for the unpublished-drop panic test; expected to panic/abort."""
+        self.setup_leader_with_epoch()
+
+        conn_follow, session_follow = self.open_follower_epoch()
+
+        session_follow.create(self.uri, self.table_config)
+        self.publish(self.uri, 20, session_follow)
+        # Drop without publishing: this is the state a peer inherits when the leader that would
+        # have published the drop is killed between relaying the drop and relaying its publish.
+        session_follow.drop(self.uri)
+        session_follow.close()
+
+        # Pre-swap state:
+        # Shared metadata: empty (no schema operations on the initial leader).
+        # Follower: uri was created then dropped; queue holds CREATE uri (epoch 20) followed
+        #   by REMOVE uri at the unpublished sentinel epoch.
+        self.swap_roles(conn_follow)
+
+        # After step-up: the REMOVE makes step-up skip the stable constituent whatever the
+        # REMOVE's epoch, so the CREATE keeps no stable value.
+        self.assertFalse(self.uri_stable_exists(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+
+        # Checkpoint at epoch=20: the CREATE is at the checkpoint's epoch, so the table must be
+        # visible in shared metadata. The REMOVE sits at the unpublished sentinel, above every
+        # finite epoch, so it is deferred and can never cancel the CREATE. The stable constituent
+        # was never created, so WiredTiger panics.
+        self.set_stable_epoch(20, conn_follow)
+        conn_follow.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(2) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        session_ck = conn_follow.open_session('')
+        session_ck.checkpoint()  # Expected to panic.
+
+    def subprocess_recreated_drop_split_epochs(self):
+        """Subprocess body for the recreated-table panic test; expected to panic/abort."""
+        self.setup_leader_with_epoch()
+
+        conn_follow, session_follow = self.open_follower_epoch()
+
+        # Two incarnations of the same name, so the queue holds CREATE, REMOVE, CREATE, REMOVE.
+        session_follow.create(self.uri, self.table_config)
+        self.publish(self.uri, 20, session_follow)
+        session_follow.drop(self.uri)
+        self.publish(self.uri, 30, session_follow)
+        session_follow.create(self.uri, self.table_config)
+        self.publish(self.uri, 40, session_follow)
+        session_follow.drop(self.uri)
+        self.publish(self.uri, 50, session_follow)
+        session_follow.close()
+
+        self.swap_roles(conn_follow)
+
+        # Checkpoint at epoch=25: only the first CREATE is at or below it, so only it is parked.
+        # The DROP blocking it is the first incarnation's, at epoch 30, not the second's at 50.
+        self.set_stable_epoch(25, conn_follow)
+        conn_follow.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(2) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        session_ck = conn_follow.open_session('')
+        session_ck.checkpoint()  # Expected to panic.
+
+    def test_recreated_drop_split_epochs(self):
+        """
+        The reported DROP is the one that blocks the parked CREATE, not the table's newest.
+
+        With two incarnations queued the table has two DROPs above the checkpoint's epoch. Only the
+        first incarnation's CREATE is parked, so only its own DROP explains the violation.
+        """
+        self.setup_leader_with_epoch()
+        self.assert_panicked('SUBPROCESS_recreated_drop_split_epochs',
+            'subprocess_recreated_drop_split_epochs',
+            f'Table "{self.test_name}" was published with CREATE at epoch 20 and its DROP is at '
+            'epoch 30')
+
+    def test_create_unpublished_drop(self):
+        """
+        A step-up that inherits an unpublished DROP panics its first covering checkpoint.
+
+        The CREATE is published at epoch 20 and the DROP is never published, so the checkpoint at
+        epoch 20 must include the table in shared metadata while the DROP, parked at the
+        unpublished sentinel, can never cancel it. Unlike the published-DROP case the application
+        has no epoch it could have published the DROP at to avoid the window: a node inheriting
+        the window from a killed peer cannot publish for the term that opened it.
+        """
+        # Initialize self.conn so the test fixture can close it cleanly; the real test runs
+        # in a subprocess so that the panic/abort does not kill the test runner.
+        self.setup_leader_with_epoch()
+        self.assert_panicked('SUBPROCESS_create_unpublished_drop',
+            'subprocess_create_unpublished_drop',
+            f'Table "{self.test_name}" was published with CREATE at epoch 20 and its DROP was '
+            'never published')
     def test_unpublished_create_not_flushed(self):
         """
         A table created on a follower but never published does not appear in shared metadata


### PR DESCRIPTION
- improve diagnostic message
- update `schema_disagg_abort` test
