### PR TITLE
WT-14375 Retry WT_ROLLBACK in wt8246_compact_rts_data_correctness check()

### DIFF
--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -296,22 +296,19 @@ check(WT_SESSION *session, const char *uri, char *value, int read_ts)
     testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
     for (i = 0; i < NUM_RECORDS; i++) {
-        retry_attempts = 0;
-        cursor->set_key(cursor, i + 1);
-
         /*
          * A long read transaction can race with eviction and be forced to roll back. Retry a
          * bounded number of times before giving up.
          */
-        while (((ret = cursor->search(cursor)) == WT_ROLLBACK) && retry_attempts < MAX_RETRIES) {
+        for (retry_attempts = 0; retry_attempts < MAX_RETRIES; retry_attempts++) {
+            cursor->set_key(cursor, i + 1);
+            ret = cursor->search(cursor);
+            if (ret != WT_ROLLBACK)
+                break;
             printf("Rollback search for key %d\n", i + 1);
             testutil_check(session->rollback_transaction(session, NULL));
             testutil_check(session->begin_transaction(session, tscfg));
-            ++retry_attempts;
-            cursor->set_key(cursor, i + 1);
         }
-        testutil_assertfmt(
-          ret != WT_ROLLBACK, "Cursor search returned WT_ROLLBACK for %d times", retry_attempts);
         testutil_check(ret);
 
         testutil_check(cursor->get_value(cursor, &val1, &val2, &val3, &str_val));

--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -280,9 +280,10 @@ static void
 check(WT_SESSION *session, const char *uri, char *value, int read_ts)
 {
     WT_CURSOR *cursor;
+    WT_DECL_RET;
     size_t val_1_size;
     uint64_t val1, val2, val3;
-    int i;
+    int i, retry_attempts;
     char *str_val;
     char tscfg[64];
 
@@ -295,8 +296,24 @@ check(WT_SESSION *session, const char *uri, char *value, int read_ts)
     testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
     for (i = 0; i < NUM_RECORDS; i++) {
+        retry_attempts = 0;
         cursor->set_key(cursor, i + 1);
-        testutil_check(cursor->search(cursor));
+
+        /*
+         * A long read transaction can race with eviction and be forced to roll back. Retry a
+         * bounded number of times before giving up.
+         */
+        while (((ret = cursor->search(cursor)) == WT_ROLLBACK) && retry_attempts < MAX_RETRIES) {
+            printf("Rollback search for key %d\n", i + 1);
+            testutil_check(session->rollback_transaction(session, NULL));
+            testutil_check(session->begin_transaction(session, tscfg));
+            ++retry_attempts;
+            cursor->set_key(cursor, i + 1);
+        }
+        testutil_assertfmt(
+          ret != WT_ROLLBACK, "Cursor search returned WT_ROLLBACK for %d times", retry_attempts);
+        testutil_check(ret);
+
         testutil_check(cursor->get_value(cursor, &val1, &val2, &val3, &str_val));
         testutil_assert(val_1_size == strlen(str_val));
         testutil_assert(memcmp(value, str_val, val_1_size) == 0);


### PR DESCRIPTION
## Summary
- Add a bounded retry loop around `cursor->search()` in the recovery verification path of `test_wt8246_compact_rts_data_correctness`.
- On `WT_ROLLBACK`, roll back and restart the read transaction with the same read timestamp, then re-search the current key.
- Matches the existing `WT_ROLLBACK` handling in `large_updates()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)