### PR TITLE
WT-18620 Turn off debug.slow_checkpoint under disagg.stepdown_async

### DIFF
--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1522,6 +1522,15 @@ config_disagg_storage(void)
             if (config_explicit(NULL, "ops.truncate"))
                 WARN("%s", "turning off ops.truncate to work with disagg.stepdown_async");
             config_off_all("ops.truncate");
+
+            /*
+             * The step-down checkpoint's duration counts against the same wall clock as the
+             * drain and pause timeouts above; slowing every dirty internal page it writes can run
+             * the total past the run's abort timer with no workload progress to show for it.
+             */
+            if (config_explicit(NULL, "debug.slow_checkpoint"))
+                WARN("%s", "turning off debug.slow_checkpoint to work with disagg.stepdown_async");
+            config_off(NULL, "debug.slow_checkpoint");
         }
     } else {
         g.disagg_leader = strcmp(mode, "leader") == 0;

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1524,9 +1524,9 @@ config_disagg_storage(void)
             config_off_all("ops.truncate");
 
             /*
-             * The step-down checkpoint's duration counts against the same wall clock as the
-             * drain and pause timeouts above; slowing every dirty internal page it writes can run
-             * the total past the run's abort timer with no workload progress to show for it.
+             * The step-down checkpoint's duration counts against the same wall clock as the drain
+             * and pause timeouts above; slowing every dirty internal page it writes can run the
+             * total past the run's abort timer with no workload progress to show for it.
              */
             if (config_explicit(NULL, "debug.slow_checkpoint"))
                 WARN("%s", "turning off debug.slow_checkpoint to work with disagg.stepdown_async");


### PR DESCRIPTION
The step-down checkpoint's duration counts against the same 15-minute run watchdog as the drain and write-pause timeouts. debug.slow_checkpoint adds a 10ms sleep per dirty internal page written during checkpoint sync, and with enough dirty internal pages in cache that alone can add several minutes to the step-down checkpoint, compounding with the protocol's own drain/pause budgets until the run aborts with no correctness issue involved.

This follows the existing precedent in config_disagg_storage() that already turns off ops.prepare/ops.truncate under disagg.stepdown_async, for the same reason: the step-down protocol's timing budget doesn't account for them.