### PR TITLE
WT-18427 Defer cache discard to sweep for clean-tree drop

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -854,23 +854,69 @@ err:
 }
 
 /*
- * __conn_dhandle_close_one --
- *     Lock and, if necessary, close a data handle.
+ * __conn_dhandle_lock_one --
+ *     Lock a single data handle without closing it. If this is part of a schema-changing operation
+ *     (indicated by metadata tracking being enabled), register the lock so it is held for the
+ *     duration of the operation, exactly as a close would have registered it.
  */
 static int
-__conn_dhandle_close_one(WT_SESSION_IMPL *session, const char *uri, const char *checkpoint,
-  bool removed, bool mark_dead, bool check_visibility)
+__conn_dhandle_lock_one(WT_SESSION_IMPL *session, const char *uri, const char *checkpoint)
 {
-    WT_DECL_RET;
-
-    /*
-     * Lock the handle exclusively. If this is part of schema-changing operation (indicated by
-     * metadata tracking being enabled), hold the lock for the duration of the operation.
-     */
     WT_RET(__wt_session_get_dhandle(
       session, uri, checkpoint, NULL, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_LOCK_ONLY));
     if (WT_META_TRACKING(session))
         WT_RET(__wt_meta_track_handle_lock(session, false));
+
+    return (0);
+}
+
+/*
+ * __conn_dhandle_close_locked --
+ *     Close a single data handle the caller already holds exclusively locked.
+ */
+static int
+__conn_dhandle_close_locked(
+  WT_SESSION_IMPL *session, bool removed, bool mark_dead, bool check_visibility)
+{
+    WT_BTREE *btree;
+    WT_DATA_HANDLE *dhandle;
+    WT_DECL_RET;
+    bool evict_off;
+
+    dhandle = session->dhandle;
+    evict_off = false;
+
+    /*
+     * A clean tree is already durable, so there is nothing to lose by marking it dead and
+     * deferring its cache discard to sweep instead of walking and freeing every page here and now
+     * -- regardless of what the caller asked for. A dirty tree is untouched: it still goes through
+     * the checkpoint-or-EBUSY path below exactly as it does today, so a drop can never silently
+     * discard data that was never made durable.
+     *
+     * Only do this when the handle is actually being removed. The same close path also runs for a
+     * transient close-then-immediately-reopen (verify and alter close every handle for a URI to
+     * force a fresh exclusive open, then open it again in the same call): marking that handle dead
+     * would leave the reopen finding a handle that can never again satisfy a lookup by name, since
+     * nothing but sweep clears a dead handle and sweep may not even be running yet.
+     *
+     * A dirty reading needs no synchronization to trust: nothing makes a dirty tree clean again, so
+     * an unlocked dirty result can be acted on immediately, leaving mark_dead alone and falling
+     * through to the checkpoint-or-EBUSY path exactly as if this check didn't exist. A clean
+     * reading is not trustworthy on its own, though: a concurrent eviction pass (which can dirty
+     * pages itself, for example obsolete time-window cleanup) could flip it right after. Only pay
+     * to disable eviction -- and hold it disabled through the close below, rather than relying on
+     * the close call to do that -- to get an authoritative second read when the cheap first read
+     * looked clean.
+     */
+    if (removed && !mark_dead && WT_DHANDLE_BTREE(dhandle) && F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
+        btree = dhandle->handle;
+        if (!btree->modified) {
+            WT_RET(__wt_evict_file_exclusive_on(session));
+            evict_off = true;
+            if (!btree->modified)
+                mark_dead = true;
+        }
+    }
 
     /*
      * We have an exclusive lock, which means there are no cursors open at this point. Close the
@@ -890,6 +936,13 @@ __conn_dhandle_close_one(WT_SESSION_IMPL *session, const char *uri, const char *
     if (removed)
         F_SET(session->dhandle, WT_DHANDLE_DROPPED);
 
+    /*
+     * Turn eviction back on before releasing the dhandle: releasing can clear session->dhandle, and
+     * disabling eviction needs it to resolve the btree it was disabled for.
+     */
+    if (evict_off)
+        __wt_evict_file_exclusive_off(session);
+
     if (!WT_META_TRACKING(session))
         WT_TRET(__wt_session_release_dhandle(session));
 
@@ -905,20 +958,39 @@ __wt_conn_dhandle_close_all(
   WT_SESSION_IMPL *session, const char *uri, bool removed, bool mark_dead, bool check_visibility)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_DATA_HANDLE *dhandle;
+    WT_DATA_HANDLE *dhandle, **handles;
     WT_DECL_RET;
+    size_t handles_allocated;
     uint64_t bucket;
+    u_int i, nhandles;
+    bool tracked;
 
     conn = S2C(session);
+    handles = NULL;
+    handles_allocated = 0;
+    nhandles = 0;
+    i = 0;
+    tracked = WT_META_TRACKING(session);
 
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST_WRITE));
     WT_ASSERT(session, session->dhandle == NULL);
 
     /*
-     * Lock the live handle first. This ordering is important: we rely on locking the live handle to
-     * fail fast if the tree is busy (e.g., with cursors open or in a checkpoint).
+     * Lock every handle matching this URI -- the live handle first, then any checkpoint handles --
+     * before closing any of them. A close can mark a handle dead, and unlike an ordinary close,
+     * that can never be undone: a dead handle can never be reopened. Confirming the whole set can
+     * be locked before closing any of them means a handle that turns out to be busy fails the whole
+     * call before anything irreversible has happened to any handle in the set.
+     *
+     * Grow the array before taking each lock, never after. The error path releases the handles the
+     * array holds, so a handle locked while the array is still too short to record it would be left
+     * locked for good. Reserving the slot first cannot strand anything: a failure to grow happens
+     * before the lock is taken, and a failure to lock leaves the extra capacity unused.
      */
-    WT_ERR(__conn_dhandle_close_one(session, uri, NULL, removed, mark_dead, check_visibility));
+    WT_ERR(__wt_realloc_def(session, &handles_allocated, nhandles + 1, &handles));
+    WT_ERR(__conn_dhandle_lock_one(session, uri, NULL));
+    handles[nhandles++] = session->dhandle;
+    WT_DHANDLE_CLEAR(session);
 
     bucket = __wt_hash_city64(uri, strlen(uri)) & (conn->dh_hash_size - 1);
     TAILQ_FOREACH (dhandle, &conn->dhhash[bucket], hashq) {
@@ -926,11 +998,39 @@ __wt_conn_dhandle_close_all(
           F_ISSET(dhandle, WT_DHANDLE_DEAD))
             continue;
 
-        WT_ERR(__conn_dhandle_close_one(
-          session, dhandle->name, dhandle->checkpoint, removed, mark_dead, false));
+        WT_ERR(__wt_realloc_def(session, &handles_allocated, nhandles + 1, &handles));
+        WT_ERR(__conn_dhandle_lock_one(session, dhandle->name, dhandle->checkpoint));
+        handles[nhandles++] = session->dhandle;
+        WT_DHANDLE_CLEAR(session);
+    }
+
+    /*
+     * Every handle for this URI is confirmed available. Close the live handle first: of the set, it
+     * is the only one whose close can fail for content reasons (uncommitted or dirty data), and
+     * that failure happens before anything is touched, so the set ends up either closed in full or
+     * not at all.
+     */
+    for (; i < nhandles; i++) {
+        WT_WITH_DHANDLE(session, handles[i],
+          ret = __conn_dhandle_close_locked(
+            session, removed, mark_dead, i == 0 ? check_visibility : false));
+        if (ret != 0) {
+            ++i;
+            break;
+        }
     }
 
 err:
+    /*
+     * Release whatever we locked but never reached closing. A handle that itself failed to close
+     * already disposed of its own lock; only the handles after it are still outstanding. Under
+     * metadata tracking, every lock was registered as it was taken, so the surrounding operation's
+     * own unroll releases them instead.
+     */
+    if (ret != 0 && !tracked)
+        for (; i < nhandles; i++)
+            WT_WITH_DHANDLE(session, handles[i], WT_TRET(__wt_session_release_dhandle(session)));
+    __wt_free(session, handles);
     WT_DHANDLE_CLEAR(session);
     return (ret);
 }

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -911,7 +911,7 @@ __conn_dhandle_close_locked(
     if (removed && !mark_dead && WT_DHANDLE_BTREE(dhandle) && F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
         btree = dhandle->handle;
         if (!btree->modified) {
-            WT_RET(__wt_evict_file_exclusive_on(session));
+            WT_ERR(__wt_evict_file_exclusive_on(session));
             evict_off = true;
             if (!btree->modified)
                 mark_dead = true;
@@ -936,6 +936,7 @@ __conn_dhandle_close_locked(
     if (removed)
         F_SET(session->dhandle, WT_DHANDLE_DROPPED);
 
+err:
     /*
      * Turn eviction back on before releasing the dhandle: releasing can clear session->dhandle, and
      * disabling eviction needs it to resolve the btree it was disabled for.

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -950,6 +950,13 @@ __layered_queue_ingest_dhandles(WT_SESSION_IMPL *session)
 
         if (!WT_DHANDLE_BTREE(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN))
             continue;
+        /*
+         * A dead handle stays marked open until sweep's own close call clears it: its table (and
+         * the stable pair a drain would need) may already be gone, so skip it rather than queue a
+         * drain that can only fail to reopen it.
+         */
+        if (F_ISSET(dhandle, WT_DHANDLE_DEAD))
+            continue;
         if (!WT_URI_IS_INGEST(dhandle->name))
             continue;
 

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -972,13 +972,11 @@ __layered_queue_ingest_dhandles(WT_SESSION_IMPL *session)
 }
 
 /*
- * __layered_drain_ingest_tables_int --
- *     Moving all the data from the ingest tables to the stable tables. Called with the schema lock
- *     held, so a concurrent drop cannot remove a table between this queueing its ingest btree for
- *     drain and a worker thread processing it.
+ * __wti_layered_drain_ingest_tables --
+ *     Moving all the data from the ingest tables to the stable tables
  */
-static int
-__layered_drain_ingest_tables_int(WT_SESSION_IMPL *session)
+int
+__wti_layered_drain_ingest_tables(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
@@ -1042,19 +1040,6 @@ err:
     }
     /* Cleanup and release resources. */
     __layered_drain_clear_work_queue(session);
-    return (ret);
-}
-
-/*
- * __wti_layered_drain_ingest_tables --
- *     Moving all the data from the ingest tables to the stable tables.
- */
-int
-__wti_layered_drain_ingest_tables(WT_SESSION_IMPL *session)
-{
-    WT_DECL_RET;
-
-    WT_WITH_SCHEMA_LOCK(session, ret = __layered_drain_ingest_tables_int(session));
     return (ret);
 }
 

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -972,11 +972,13 @@ __layered_queue_ingest_dhandles(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wti_layered_drain_ingest_tables --
- *     Moving all the data from the ingest tables to the stable tables
+ * __layered_drain_ingest_tables_int --
+ *     Moving all the data from the ingest tables to the stable tables. Called with the schema lock
+ *     held, so a concurrent drop cannot remove a table between this queueing its ingest btree for
+ *     drain and a worker thread processing it.
  */
-int
-__wti_layered_drain_ingest_tables(WT_SESSION_IMPL *session)
+static int
+__layered_drain_ingest_tables_int(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
@@ -1040,6 +1042,19 @@ err:
     }
     /* Cleanup and release resources. */
     __layered_drain_clear_work_queue(session);
+    return (ret);
+}
+
+/*
+ * __wti_layered_drain_ingest_tables --
+ *     Moving all the data from the ingest tables to the stable tables.
+ */
+int
+__wti_layered_drain_ingest_tables(WT_SESSION_IMPL *session)
+{
+    WT_DECL_RET;
+
+    WT_WITH_SCHEMA_LOCK(session, ret = __layered_drain_ingest_tables_int(session));
     return (ret);
 }
 

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -950,6 +950,7 @@ __layered_queue_ingest_dhandles(WT_SESSION_IMPL *session)
 
         if (!WT_DHANDLE_BTREE(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN))
             continue;
+
         /*
          * A dead handle stays marked open until sweep's own close call clears it: its table (and
          * the stable pair a drain would need) may already be gone, so skip it rather than queue a
@@ -957,6 +958,7 @@ __layered_queue_ingest_dhandles(WT_SESSION_IMPL *session)
          */
         if (F_ISSET(dhandle, WT_DHANDLE_DEAD))
             continue;
+
         if (!WT_URI_IS_INGEST(dhandle->name))
             continue;
 

--- a/test/suite/helpers/eviction_util.py
+++ b/test/suite/helpers/eviction_util.py
@@ -26,11 +26,37 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import time
+
 import wttest
+from wiredtiger import stat
 
 # eviction_util.py
 # Shared base class used by eviction tests.
 class eviction_util(wttest.WiredTigerTestCase):
+
+    def scrub_images(self):
+        """The (pages, bytes) gauges of the images checkpoint scrub currently retains."""
+        return (self.get_stat(stat.conn.cache_scrub_image_pages),
+          self.get_stat(stat.conn.cache_scrub_image_bytes))
+
+    def wait_for_scrub_images_released(self, timeout=30):
+        """Wait until no retained scrub image is accounted for anywhere in the connection.
+
+        Freeing the pages that hold the images is not always finished by the time the call that
+        triggers it returns: dropping a clean tree marks its handle dead and leaves the discard to
+        the sweep server. Requiring both gauges to reach zero is also what checks that they drain
+        together rather than one outrunning the other. Callers wanting this to resolve promptly
+        rather than on the default scan interval should shorten file_manager.close_scan_interval."""
+        deadline = time.time() + timeout
+        while True:
+            pages, nbytes = self.scrub_images()
+            if (pages, nbytes) == (0, 0):
+                return
+            self.assertLess(time.time(), deadline,
+                'retained scrub images were not released within {}s: '
+                'pages={}, bytes={}'.format(timeout, pages, nbytes))
+            time.sleep(0.1)
 
     def evict_cursor_tw_cleanup(self, uri, nrows):
         # Configure debug behavior at the session level to evict the page when released.

--- a/test/suite/test_checkpoint_scrub_evict.py
+++ b/test/suite/test_checkpoint_scrub_evict.py
@@ -45,10 +45,11 @@
 #      and on activates it regardless of precise checkpoint.
 
 import wttest
+from eviction_util import eviction_util
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-class test_checkpoint_scrub_evict(wttest.WiredTigerTestCase):
+class test_checkpoint_scrub_evict(eviction_util):
     """
     Verify checkpoint based clean scrub-eviction behaviour.
 
@@ -322,10 +323,6 @@ class test_checkpoint_scrub_evict(wttest.WiredTigerTestCase):
         pages = self.get_stat(stat.conn.cache_scrub_image_pages)
         nbytes = self.get_stat(stat.conn.cache_scrub_image_bytes)
 
-        # The gauges are unsigned counts; underflow would surface as a huge value.
-        self.assertGreaterEqual(pages, 0, 'scrub image page gauge must not be negative')
-        self.assertGreaterEqual(nbytes, 0, 'scrub image byte gauge must not be negative')
-
         if self.precise:
             self.assertGreater(pages, 0,
                 msg='scrub image page gauge should rise after a precise checkpoint')
@@ -336,25 +333,23 @@ class test_checkpoint_scrub_evict(wttest.WiredTigerTestCase):
             self.assertGreaterEqual(nbytes, pages,
                 msg='retained bytes should be at least one per retained page')
 
-            # Dropping the table discards its pages through the image-discard
-            # path. The gauge is a live connection-wide count and a checkpoint
-            # retains fresh images, so its absolute value after the drop is not
-            # predictable; all we require is that the decrement runs cleanly and
-            # the two gauges stay consistent with each other.
-
             # Eviction restores the scrubbed pages as dirty in-memory images,
             # so the table can hold dirty data by the time we drop it.
             # Under precise_checkpoint the drop's close-checkpoint refuses dirty
             # data (WT_DIRTY_DATA). Checkpoint first so the drop closes cleanly.
             self.session.checkpoint()
+
+            # Dropping the table discards its pages through the image-discard path. This table is
+            # the only thing holding retained images, so the accounting must end up empty. Speed up
+            # the sweep scan so the wait resolves promptly instead of on the default interval.
+            #
+            # Nothing here needs to inspect the gauge for an underflow: the accounting clamps a
+            # decrement that would go negative back to zero and reports it, which aborts a
+            # diagnostic build and otherwise fails the test through the unexpected-stderr check.
+            self.conn.reconfigure('file_manager=(close_scan_interval=1)')
             self.session.drop(self.uri)
-            pages = self.get_stat(stat.conn.cache_scrub_image_pages)
-            nbytes = self.get_stat(stat.conn.cache_scrub_image_bytes)
-            self.assertGreaterEqual(pages, 0, 'scrub image page gauge underflowed')
-            self.assertGreaterEqual(nbytes, 0, 'scrub image byte gauge underflowed')
-            self.assertEqual(pages == 0, nbytes == 0,
-                msg='scrub image page and byte gauges must drain together: '
-                    'pages={}, bytes={}'.format(pages, nbytes))
+
+            self.wait_for_scrub_images_released()
         else:
             # Fuzzy checkpoint never retains a scrub image.
             self.assertEqual(pages, 0, 'fuzzy checkpoint must not retain scrub images')
@@ -577,11 +572,6 @@ class test_checkpoint_scrub_image_gauge(wttest.WiredTigerTestCase):
 
         pages = self.get_stat(stat.conn.cache_scrub_image_pages)
         nbytes = self.get_stat(stat.conn.cache_scrub_image_bytes)
-
-        # Whatever the mode, the gauge is an unsigned count; an underflow from an
-        # unbalanced decr would surface here as a huge value.
-        self.assertGreaterEqual(pages, 0, 'scrub image page gauge underflowed')
-        self.assertGreaterEqual(nbytes, 0, 'scrub image byte gauge underflowed')
 
         if self.expect_tracked:
             # Scrub ran, so at least one image is retained and its bytes tracked.

--- a/test/suite/test_checkpoint_scrub_evict02.py
+++ b/test/suite/test_checkpoint_scrub_evict02.py
@@ -38,12 +38,12 @@
 
 import threading
 
-import wttest
+from eviction_util import eviction_util
 from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtscenario import make_scenarios
 from wtthread import Thread
 
-class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
+class test_checkpoint_scrub_evict02(eviction_util):
     uri = 'table:scrub_evict02'
     nrows = 5000
 
@@ -62,16 +62,6 @@ class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
                 'checkpoint_threads=%d,'
                 'eviction_dirty_target=80,eviction_dirty_trigger=90,'
                 'eviction=(checkpoint_scrub_eviction=on)' % self.ckpt_threads)
-
-    def get_stat(self, statistic, uri=None):
-        cursor = self.session.open_cursor('statistics:' if uri is None else 'statistics:' + uri)
-        value = cursor[statistic][2]
-        cursor.close()
-        return value
-
-    def scrub_images(self):
-        return (self.get_stat(stat.conn.cache_scrub_image_pages),
-          self.get_stat(stat.conn.cache_scrub_image_bytes))
 
     def create(self, config=''):
         self.session.create(self.uri, 'key_format=i,value_format=S' + config)
@@ -136,14 +126,19 @@ class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
         self.check_values('y' * 100)
 
     def test_images_released_when_page_discarded(self):
-        """Dropping the table frees pages that still hold a retained image."""
+        """Dropping the table frees pages that still hold a retained image.
+
+        Speed up the sweep scan so the wait resolves quickly instead of waiting on the default
+        interval."""
         self.settle()
         self.write('y' * 100)
         self.session.checkpoint()
         self.assertGreater(self.scrub_images()[0], 0)
 
+        self.conn.reconfigure('file_manager=(close_scan_interval=1)')
         self.session.drop(self.uri)
-        self.assertEqual(self.scrub_images(), (0, 0))
+
+        self.wait_for_scrub_images_released()
 
     def test_images_released_by_later_reconciliation(self):
         """A page dirtied and reconciled again releases the image its last checkpoint retained.

--- a/test/suite/test_drop_cache_discard01.py
+++ b/test/suite/test_drop_cache_discard01.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+import wttest
+from wiredtiger import stat
+
+# A non-forced WT_SESSION::drop of an already-clean (checkpointed) table marks the dhandle dead
+# and defers the cache discard to the sweep server, rather than walking and freeing every page
+# resident in cache synchronously while holding the schema and dhandle-list write locks.
+#
+# A clean tree has nothing dirty to flush either way, so comparing the backing file's bytes before
+# and after the drop cannot tell the two behaviors apart: neither path writes to the file. The
+# property that does tell them apart is whether the discard happens through the sweep server at
+# all, not how soon: committing a drop wakes the sweep server so it can reclaim the handle
+# promptly, so the deferred discard usually runs within a moment of drop() returning rather than on
+# some later scan, and disabling the scan interval doesn't prevent that wake-up. So the statistic
+# that counts handles the sweep server closed is the property to poll for, not a stat read
+# immediately after drop() returns: with the fix, a clean-tree drop's handle is closed through that
+# path and the counter goes up; without it, the drop closes the handle itself before the sweep
+# server ever sees it, and the counter does not move.
+class test_drop_cache_discard01(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=1G,statistics=(all)'
+
+    value = 'a' * 200
+
+    def populate(self, uri, rows):
+        self.session.create(uri, 'key_format=Q,value_format=S')
+        cursor = self.session.open_cursor(uri, None, None)
+        for i in range(rows):
+            cursor[i] = self.value
+        cursor.close()
+
+    def get_stat(self, statistic):
+        cursor = self.session.open_cursor('statistics:', None, None)
+        value = cursor[statistic][2]
+        cursor.close()
+        return value
+
+    def test_clean_drop_defers_handle_close(self):
+        """
+        A non-forced drop of an already-clean table must not tear down its file/btree handle as
+        part of the drop call: that handle is marked dead and left for the sweep server to close.
+        """
+        uri = 'table:test_drop_cache_discard01_clean'
+        self.populate(uri, 10_000)
+
+        # The checkpoint leaves the tree clean without any wait here: the rows were written with
+        # auto-commit and no transaction is open, and a checkpoint advances the oldest id before it
+        # reconciles anything, so nothing it writes can be skipped as not yet globally visible and
+        # left dirtying the tree behind it.
+        self.session.checkpoint()
+
+        dead_close_before = self.get_stat(stat.conn.dh_sweep_dead_close)
+        self.session.drop(uri, None)
+
+        deadline = time.time() + 10
+        while self.get_stat(stat.conn.dh_sweep_dead_close) == dead_close_before:
+            self.assertLess(time.time(), deadline,
+                'the sweep server never closed the handle deferred by a clean-tree drop')
+            time.sleep(0.1)
+
+    def test_busy_checkpoint_handle_leaves_live_handle_usable(self):
+        """
+        Dropping a table locks the live handle before any checkpoint handles for the same URI,
+        then closes the whole set only once every handle in it is confirmed lockable. If a
+        checkpoint handle turns out to be busy, the live handle -- already locked by that point --
+        must not have been closed or marked dead: that step is irreversible, so committing it
+        before the rest of the set is confirmed available would strand a dead handle behind a drop
+        that reports failure. Check this directly: drop must fail EBUSY while a checkpoint cursor
+        is open, and the table must still be fully open and usable afterward.
+        """
+        uri = 'table:test_drop_cache_discard01_busy_checkpoint'
+        self.populate(uri, 100)
+        self.session.checkpoint('name=wt18427ckpt')
+
+        # Open a checkpoint cursor from a second session so it stays open across the drop attempt.
+        session2 = self.conn.open_session()
+        ckpt_cursor = session2.open_cursor(uri, None, 'checkpoint=wt18427ckpt')
+
+        self.assertTrue(self.raisesBusy(lambda: self.session.drop(uri, None)),
+            'expected drop to fail with EBUSY while a checkpoint cursor is open')
+
+        # Nothing was destroyed: the live table is still fully open and usable.
+        cursor = self.session.open_cursor(uri, None, None)
+        cursor.set_key(0)
+        self.assertEqual(cursor.search(), 0)
+        cursor.close()
+
+        ckpt_cursor.close()
+        session2.close()
+
+        # With the checkpoint handle free, the drop succeeds.
+        self.session.drop(uri, None)
+
+    def test_dirty_drop_still_fails(self):
+        """
+        A non-forced drop of a table with committed but uncheckpointed content must still fail
+        with EBUSY: the fix only changes what happens to an already-clean tree.
+        """
+        uri = 'table:test_drop_cache_discard01_dirty'
+        self.populate(uri, 1)
+
+        self.assertTrue(self.raisesBusy(lambda: self.session.drop(uri, None)),
+            'expected drop to fail with EBUSY on a dirty (uncheckpointed) table')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_sweep03.py
+++ b/test/suite/test_sweep03.py
@@ -157,8 +157,9 @@ class test_sweep03(sweep_util, suite_subprocess):
         close2 = stat_cursor[stat.conn.dh_sweep_dead_close][2]
         stat_cursor.close()
 
-        # The sweep server should not be involved in regular drop cleanup
-        self.assertEqual(close2, close1)
+        # A drop of a clean tree marks its handle dead and defers the close to sweep, the same as
+        # a forced drop of a clean tree already does.
+        self.assertEqual(close2, close1 + 1)
         # Ensure that any space was reclaimed from cache.
         self.assertLess(cache2, cache1)
 


### PR DESCRIPTION
Relands the change reverted in 92cb7e74a2 (#14709). Non-forced `WT_SESSION::drop` of an already-clean table now marks its dhandle dead and defers the cache discard to sweep, instead of walking and freeing every cached page synchronously while holding the schema and dhandle-list write locks.

The original landing was reverted because it exposed WT-18614: a non-forced drop of a clean tree marks the dhandle dead but deliberately leaves `WT_DHANDLE_OPEN` set -- the handle is finished off by a later call from sweep, run asynchronously on its own thread after being signalled. `__layered_queue_ingest_dhandles` checked only `WT_DHANDLE_OPEN`, not `WT_DHANDLE_DEAD`, so if the disagg drain's queueing walk ran before sweep got around to the handle, it could queue an ingest btree whose table had already been dropped. The drain worker then failed to open the derived stable table with ENOENT, and a drain worker treats any error as an unrecoverable panic.
