### PR TITLE
WT-18606 Compare the durable timestamp against the step-down boundary

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1754,34 +1754,6 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Process updates. */
     for (i = 0, op = txn->mod; i < txn->mod_count; i++, op++) {
-#ifdef HAVE_DIAGNOSTIC
-        /*
-         * FIXME-WT-18606: Consider moving these assertions to the setting timestamp path.
-         *
-         * While the step-down timestamp is set, a committing transaction's layered content must sit
-         * on one side of the boundary: ingest content strictly above the timestamp, stable content
-         * at or below it, and never both constituents from one transaction. Checked per operation
-         * here to fold the boundary check into the pass this loop already makes.
-         */
-        if (step_down_ts != WT_TS_NONE && !prepare && op->type != WT_TXN_OP_NONE &&
-          op->btree != NULL) {
-            if (WT_URI_IS_INGEST(op->btree->dhandle->name)) {
-                wrote_ingest = true;
-                if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_COMMIT))
-                    WT_ASSERT_ALWAYS(session, txn->first_commit_timestamp > step_down_ts,
-                      "ingest content committing at or below the step-down timestamp");
-            } else if (WT_URI_IS_STABLE(op->btree->dhandle->name)) {
-                wrote_stable = true;
-                /* FIXME-WT-18606: Compare durable timestamp instead of commit for stable. */
-                if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_COMMIT))
-                    WT_ASSERT_ALWAYS(session, txn->time_point.commit_timestamp <= step_down_ts,
-                      "stable content committing above the step-down timestamp");
-            }
-            WT_ASSERT_ALWAYS(session, !(wrote_ingest && wrote_stable),
-              "transaction committing while the step-down timestamp is set wrote both layered "
-              "constituents");
-        }
-#endif
         switch (op->type) {
         case WT_TXN_OP_NONE:
             break;
@@ -1872,6 +1844,24 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
             __wti_mark_committed_truncate_table(session, op);
             break;
         }
+
+#ifdef HAVE_DIAGNOSTIC
+        /*
+         * While the step-down timestamp is set, a committing transaction's layered content must sit
+         * on one side of the boundary: ingest content strictly above the timestamp, stable content
+         * at or below it, and never both constituents from one transaction.
+         */
+        if (step_down_ts != WT_TS_NONE && op->type != WT_TXN_OP_NONE && op->btree != NULL) {
+            if (WT_URI_IS_INGEST(op->btree->dhandle->name)) {
+                wrote_ingest = true;
+                WT_ASSERT(session, txn->first_commit_timestamp > step_down_ts);
+            } else if (WT_URI_IS_STABLE(op->btree->dhandle->name)) {
+                wrote_stable = true;
+                WT_ASSERT(session, txn->time_point.durable_timestamp <= step_down_ts);
+            }
+            WT_ASSERT(session, !(wrote_ingest && wrote_stable));
+        }
+#endif
 
         /* If we used the cursor to resolve prepared updates, free and clear the key. */
         if (cursor != NULL)

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -905,7 +905,7 @@ static int
 __txn_validate_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts)
 {
     WT_TXN *txn;
-    wt_timestamp_t oldest_ts, stable_ts;
+    wt_timestamp_t oldest_ts, stable_ts, step_down_ts;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     txn = session->txn;
@@ -945,6 +945,17 @@ __txn_validate_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durabl
           "transaction",
           __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(txn->time_point.prepare_timestamp, ts_string[1]));
+
+    /*
+     * A transaction that began after the step-down timestamp was set commits to the ingest
+     * constituent, which lives strictly above that timestamp, so supplying a durable timestamp at
+     * or below it is a contradiction.
+     */
+    step_down_ts = __wt_atomic_load_uint64_relaxed(&S2C(session)->txn_global.step_down_timestamp);
+    if (txn->stepdown_ts_set && durable_ts <= step_down_ts)
+        WT_RET_MSG(session, EINVAL, "durable timestamp %s must be after the step down timestamp %s",
+          __wt_timestamp_to_string(durable_ts, ts_string[0]),
+          __wt_timestamp_to_string(step_down_ts, ts_string[1]));
 
     return (0);
 }


### PR DESCRIPTION
**Problem**

The step-down boundary assertions in `__wt_txn_commit` used the commit timestamp to
decide whether stable content sits at or below the step-down timestamp. Stable content
is ordered by its durable timestamp, which a prepared transaction can push above its
commit timestamp, so the check would accept content that is actually above the boundary.
Prepared transactions were excluded from the block entirely to work around this.

**Solution**

Compare the durable timestamp on the stable side. The ingest side keeps the first commit
timestamp, the earliest its content can be read at, so the two assertions bound the
transaction's timestamp range from both ends. The prepared-transaction exclusion existed
only because of the wrong comparison and is dropped.

Move the block from the top of the mod loop to after the switch, so per-operation
timestamp validation runs first. An untimestamped commit on a disaggregated table now
returns EINVAL from `__txn_disagg_commit_ts_check` before the assertions can read a
timestamp of zero, which removes the need to guard them on
`WT_TXN_TIME_POINT_HAS_TS_COMMIT`.

The ticket also asked whether these checks belong in `set_timestamp`. They do not: the
rule needs both the final timestamps and the set of constituents the transaction wrote,
and the write set is only complete at commit.

**Note**

Dropping the guard relies on the commit timestamp requirement being enforced. While
`debug_mode=(disagg_commit_ts_optional=true)` is still the default (WT-18608), an
untimestamped write inside the step-down window aborts a diagnostic build instead of
returning EINVAL.

**Tests**

Step-down, step-up and layered transaction suites: 258 tests, green. No new tests — the
durable/commit distinction only shows up for prepared transactions, which are separately
asserted unsupported while the step-down timestamp is set.