### PR TITLE
WT-18616 Skip test_skip_write_wrapup_aggregated_flag when the failpoint does not fire

### DIFF
--- a/test/suite/test_disagg_checkpoint_size08.py
+++ b/test/suite/test_disagg_checkpoint_size08.py
@@ -331,13 +331,14 @@ class test_disagg_checkpoint_size08(DisaggSizeTestMixin, wttest.WiredTigerTestCa
             if self.get_stat(stat_key) > 0:
                 break
 
+        # The failpoint fires probabilistically (1% per reconcile). With a bounded
+        # workload it may not trigger on a given run; skip the size check below
+        # in that case rather than asserting on a probability.
+        if self.get_stat(stat_key) == 0:
+            self.skipTest('failpoint_rec_before_wrapup did not fire in this run')
+
         self.session.checkpoint()
         size_after_recovery = self.get_checkpoint_size()
-
-        # Verify the error path ran.
-        self.assertGreater(self.get_stat(stat_key), 0,
-            'rec_free_page_id_due_to_failed_replacement_reconciliation should be > 0 '
-            'after skip-write wrapup followed by failpoint eviction')
 
         # Verify size is not inflated.
         self.assertLess(size_after_recovery, size_with_delta + size_baseline,


### PR DESCRIPTION
test_skip_write_wrapup_aggregated_flag exercises failpoint_rec_before_wrapup, which fires with a flat 1% chance per reconciliation call. The test loop gives it up to 500 independent tries (~99.3% cumulative chance of firing at least once), but on the remaining tail it never fires within the bound, and the test asserted on the resulting stat instead of treating the miss as inconclusive.

test_supd_restore_wrapup_aggregated_flag, earlier in the same file, hits this identical failpoint in an identically shaped loop and already skips the test when the stat stays zero, with a comment explaining why. This applies the same guard to the sibling test.